### PR TITLE
Patch for cross-compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ MOD_LFLAGS += -L$(SYSROOT)/local/lib
 endif
 
 LIBS      += -lrem -lm
-
+LIBS      += -L$(SYSROOT)/lib
 
 -include $(APP_OBJS:.o=.d)
 

--- a/mk/mod.mk
+++ b/mk/mod.mk
@@ -28,7 +28,7 @@ ifeq ($(STATIC),)
 $(MOD)$(MOD_SUFFIX): $($(MOD)_OBJS)
 	@echo "  LD [M]  $@"
 	@$(LD) $(LFLAGS) $(SH_LFLAGS) $(MOD_LFLAGS) $($(basename $@)_OBJS) \
-		$($(basename $@)_LFLAGS) -L$(LIBRE_SO) -lre -o $@
+		$($(basename $@)_LFLAGS) -L$(LIBRE_SO) $(LIBS) -lre -o $@
 
 $(BUILD)/modules/$(MOD)/%.o: modules/$(MOD)/%.c $(BUILD) Makefile mk/mod.mk \
 				modules/$(MOD)/module.mk mk/modules.mk


### PR DESCRIPTION
For cross-compiling of baresip I used the next directory structure:
./re
./rem
./baresip

So, I cross-compiled with next commands in my custom Makefile:
Cross-compile "re"

. some-arm-env-setup; cd re; make SYSROOT=$(TARGET_FSROOT)/usr PREFIX=$(TARGET_FSROOT)/usr/local
Cross-compile "rem"

. some-arm-env-setup; cd rem; make SYSROOT=$(TARGET_FSROOT)/usr PREFIX=$(TARGET_FSROOT)/usr/local LIBRE_INC=../re/include
Cross-compile "baresip"

. some-arm-env-setup; cd baresip; make SYSROOT=$(TARGET_FSROOT)/usr DESTDIR=$(TARGET_FSROOT) PREFIX=/usr/local LIBRE_INC=../re/include

In short, I used SYSROOT, PREFIX, DESTDIR and LIBRE_INC... And this patch fixes using of SYSROOT for baresip.
