### PR TITLE
call/update_video() enhancements

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -360,10 +360,14 @@ static int update_audio(struct call *call)
 
 static int update_video(struct call *call)
 {
-	const struct sdp_format *sc;
+	const struct sdp_format *sc = NULL;
 	int err = 0;
 
-	sc = sdp_media_rformat(stream_sdpmedia(video_strm(call->video)), NULL);
+	struct sdp_media *m = stream_sdpmedia(video_strm(call->video));
+
+	if (!sdp_media_disabled(m))
+		sc = sdp_media_rformat(m, NULL);
+
 	if (sc) {
 		err = video_encoder_set(call->video, sc->data,
 					sc->pt, sc->params);
@@ -385,6 +389,7 @@ static int update_video(struct call *call)
 	else if (call->video) {
 		info("video stream is disabled..\n");
 		video_stop(call->video);
+		video_stop_display(call->video);
 	}
 
 	return err;


### PR DESCRIPTION
1) Before update, check that video stream has not been disabled, for example, by ua_event UA_EVENT_CALL_REMOTE_SDP.  Needs pull request https://github.com/creytiv/re/pull/248 to re.

2) If video stream has been disabled, stop also video display. 