### PR TITLE
Allow distribution specific CA trust bundle locations

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -422,7 +422,9 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 
 static const char *default_cafile(void)
 {
-#ifdef DARWIN
+#if defined (DEFAULT_CAFILE)
+	return DEFAULT_CAFILE;
+#elif defined (DARWIN)
 	return "/etc/ssl/cert.pem";
 #else
 	return "/etc/ssl/certs/ca-certificates.crt";


### PR DESCRIPTION
Proposal to address #993; adding `-DDEFAULT_CAFILE=\"/etc/pki/tls/certs/ca-bundle.crt\"` or similar to `$EXTRA_CFLAGS` should be suitable for Linux distributions needing this.