### PR TITLE
Allow distribution specific default audio device

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -432,7 +432,9 @@ static const char *default_cafile(void)
 
 static const char *default_audio_device(void)
 {
-#if defined (ANDROID)
+#if defined (DEFAULT_AUDIO_DEVICE)
+	return DEFAULT_AUDIO_DEVICE;
+#elif defined (ANDROID)
 	return "opensles,nil";
 #elif defined (DARWIN)
 	return "coreaudio,default";


### PR DESCRIPTION
Proposal to address #994; adding `-DDEFAULT_AUDIO_DEVICE=\"pulse\"` or similar to `$EXTRA_CFLAGS` should be suitable for Linux distributions needing this.