### PR TITLE
Derive default audio driver from default audio device

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -780,8 +780,14 @@ int config_write_template(const char *file, const struct config *cfg)
 #elif defined (WIN32)
 	(void)re_fprintf(f, "module\t\t\t" "winwave" MOD_EXT "\n");
 #else
-	(void)re_fprintf(f, "module\t\t\t" "alsa" MOD_EXT "\n");
-	(void)re_fprintf(f, "#module\t\t\t" "pulse" MOD_EXT "\n");
+	if (!strncmp(default_audio_device(), "pulse", 5)) {
+		(void)re_fprintf(f, "#module\t\t\t" "alsa" MOD_EXT "\n");
+		(void)re_fprintf(f, "module\t\t\t" "pulse" MOD_EXT "\n");
+	}
+	else {
+		(void)re_fprintf(f, "module\t\t\t" "alsa" MOD_EXT "\n");
+		(void)re_fprintf(f, "#module\t\t\t" "pulse" MOD_EXT "\n");
+	}
 #endif
 	(void)re_fprintf(f, "#module\t\t\t" "jack" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "portaudio" MOD_EXT "\n");


### PR DESCRIPTION
Modern Linux distributions often prefer PulseAudio over ALSA, thus their default audio driver should be "pulse" rather "alsa"; derive the default audio driver from the default audio device, which can already be changed by using e.g. `-DDEFAULT_AUDIO_DEVICE=\"pulse\"` in `$EXTRA_CFLAGS`.

It completes the approach taken by #994 and #1001 and avoids for downstreams the need to batch baresip just to change the default.