### PR TITLE
GTK notification buttons do not work on Systems

### DIFF
--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -71,25 +71,17 @@ static void reject_activated(GSimpleAction *, GVariant *, gpointer);
 static void denotify_incoming_call(struct gtk_mod *, struct call *);
 
 static GActionEntry app_entries[] = {
-	{"answer", answer_activated, "x", NULL, NULL, {0} },
-	{"reject", reject_activated, "x", NULL, NULL, {0} },
+	{"answer", answer_activated, "s", NULL, NULL, {0} },
+	{"reject", reject_activated, "s", NULL, NULL, {0} },
 };
 
 
 static struct call *get_call_from_gvariant(GVariant *param)
 {
-	gint64 call_ptr;
 	struct list *calls = ua_calls(uag_current());
-	struct le *le;
+	const gchar *call_ptr = g_variant_get_string(param, NULL);
 
-	call_ptr = g_variant_get_int64(param);
-
-	for (le = list_head(calls); le; le = le->next) {
-		if (GPOINTER_TO_INT(le->data) == call_ptr)
-			return le->data;
-
-	}
-	return NULL;
+	return call_find_id(calls, call_ptr);
 }
 
 
@@ -339,7 +331,7 @@ static void notify_incoming_call(struct gtk_mod *mod,
 	g_notification_set_urgent(notification, TRUE);
 #endif
 
-	target = g_variant_new_int64(GPOINTER_TO_INT(call));
+	target = g_variant_new_string(call_id(call));
 	g_notification_set_body(notification, msg);
 	g_notification_add_button_with_target_value(notification,
 			"Answer", "app.answer", target);

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -79,17 +79,16 @@ static GActionEntry app_entries[] = {
 static struct call *get_call_from_gvariant(GVariant *param)
 {
 	gint64 call_ptr;
-	struct call *call;
 	struct list *calls = ua_calls(uag_current());
 	struct le *le;
 
 	call_ptr = g_variant_get_int64(param);
-	call = GINT_TO_POINTER(call_ptr);
 
-	for (le = list_head(calls); le; le = le->next)
-		if (le->data == call)
-			return call;
+	for (le = list_head(calls); le; le = le->next) {
+		if (GPOINTER_TO_INT(le->data) == call_ptr)
+			return le->data;
 
+	}
 	return NULL;
 }
 


### PR DESCRIPTION
On my KDE System I see the notification, but the accept / reject buttons will not work.

While debugging I found, that the call is not found after the pointer to int conversation.
With this PR i could make the buttons work and should not break any other Systems.