### PR TITLE
Again, modifying info message on jack client creation

### DIFF
--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -108,10 +108,8 @@ static int start_jack(struct auplay_st *st)
 	if (status & JackServerStarted) {
 		info("jack: JACK server started\n");
 	}
-	if (status & JackNameNotUnique) {
-		client_name = jack_get_client_name(st->client);
-		info("jack: unique name `%s' assigned\n", client_name);
-	}
+	client_name = jack_get_client_name(st->client);
+	info("jack: source unique name `%s' assigned\n", client_name);
 
 	jack_set_process_callback(st->client, process_handler, st);
 

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -108,10 +108,8 @@ static int start_jack(struct ausrc_st *st)
 	if (status & JackServerStarted) {
 		info("jack: JACK server started\n");
 	}
-	if (status & JackNameNotUnique) {
-		client_name = jack_get_client_name(st->client);
-		info("jack: unique name `%s' assigned\n", client_name);
-	}
+	client_name = jack_get_client_name(st->client);
+	info("jack: destination unique name `%s' assigned\n", client_name);
 
 	jack_set_process_callback(st->client, process_handler, st);
 


### PR DESCRIPTION
Simpler version of my previous request to modify info message generation when a new jack client is created:
1. Always message the new client name, even if this is the first jack client created.
2. Specify in the message the audio flow direction as source (audio flow out of client) or destination (audio flow into client).

Unlike my previous pull request, this info change is only for the new client creation message and more closely conforms to the project info message format.