### PR TITLE
jack_play: connect all physical ports

### DIFF
--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -175,17 +175,17 @@ static int start_jack(struct auplay_st *st)
 		 * audio with 2 physical playback ports, connect the
 		 * single registered port to both physical port.
 		 */
-		unsigned channel_index = 0;
+		ch = 0;
 		for (unsigned i = 0; ports[i] != NULL; i++) {
 			if (jack_connect (st->client,
-					  jack_port_name (st->portv[channel_index]),
-					  ports[i])) {
+					jack_port_name (st->portv[ch]),
+						ports[i])) {
 				warning("jack: cannot connect output ports\n");
 			}
 
-			++channel_index;
-			if (channel_index >= st->prm.ch) {
-				channel_index = 0;
+			++ch;
+			if (ch >= st->prm.ch) {
+				ch = 0;
 			}
 		}
 

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -171,21 +171,21 @@ static int start_jack(struct auplay_st *st)
 			return ENODEV;
 		}
 
-		/* Connect all physical ports. In case of for example mono audio
-		 * with 2 physical playback ports, connect the single registered
-		 * port to both physical port.
+		/* Connect all physical ports. In case of for example mono
+		 * audio with 2 physical playback ports, connect the
+		 * single registered port to both physical port.
 		 */
-		unsigned channelIndex = 0;
+		unsigned channel_index = 0;
 		for (unsigned i = 0; ports[i] != NULL; i++) {
 			if (jack_connect (st->client,
-					  jack_port_name (st->portv[channelIndex]),
+					  jack_port_name (st->portv[channel_index]),
 					  ports[i])) {
 				warning("jack: cannot connect output ports\n");
 			}
 
-			channelIndex++;
-			if (channelIndex >= st->prm.ch) {
-				channelIndex = 0;
+			++channel_index;
+			if (channel_index >= st->prm.ch) {
+				channel_index = 0;
 			}
 		}
 

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -157,7 +157,7 @@ static int start_jack(struct ausrc_st *st)
 	if (jack_connect_ports) {
 		info("jack: connecting default output ports\n");
 		ports = jack_get_ports (st->client, NULL, NULL,
-					JackPortIsOutput);
+					JackPortIsOutput | JackPortIsPhysical);
 		if (ports == NULL) {
 			warning("jack: no physical playback ports\n");
 			return ENODEV;


### PR DESCRIPTION
* When for example making a call with mono audio with 2 physical jack playback ports the audio was only routed to the left channel. This fixes the problem by connecting all physical playback ports to at least one of the baresip registered ports.

* Also added JackPortIsPhysical flag when looking up jack ports.