### PR TITLE
Add snapshot_send and snapshot_recv commands

### DIFF
--- a/modules/snapshot/png_vf.c
+++ b/modules/snapshot/png_vf.c
@@ -7,7 +7,6 @@
 #define _DEFAULT_SOURCE 1
 #define _BSD_SOURCE 1
 #include <string.h>
-#include <time.h>
 #include <png.h>
 #include <re.h>
 #include <rem.h>
@@ -15,8 +14,6 @@
 #include "png_vf.h"
 
 
-static char *png_filename(const struct tm *tmx, const char *name,
-			  char *buf, unsigned int length);
 static void png_save_free(png_structp png_ptr, png_byte **png_row_pointers,
 			  int png_height);
 
@@ -34,14 +31,8 @@ int png_save_vidframe(const struct vidframe *vf, const char *path)
 	unsigned int width = vf->size.w & ~1;
 	unsigned int height = vf->size.h & ~1;
 	unsigned int bytes_per_pixel = 3; /* RGB format */
-	time_t tnow;
-	struct tm *tmx;
-	char filename_buf[64];
 	struct vidframe *f2 = NULL;
 	int err = 0;
-
-	tnow = time(NULL);
-	tmx = localtime(&tnow);
 
 	if (vf->fmt != VID_FMT_RGB32) {
 
@@ -118,8 +109,7 @@ int png_save_vidframe(const struct vidframe *vf, const char *path)
 	}
 
 	/* Write the image data. */
-	fp = fopen(png_filename(tmx, path,
-				filename_buf, sizeof(filename_buf)), "wb");
+	fp = fopen(path, "wb");
 	if (fp == NULL) {
 		err = errno;
 		goto out;
@@ -129,7 +119,7 @@ int png_save_vidframe(const struct vidframe *vf, const char *path)
 	png_set_rows(png_ptr, info_ptr, png_row_pointers);
 	png_write_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
 
-	info("png: wrote %s\n", filename_buf);
+	info("png: wrote %s\n", path);
 
  out:
 	/* Finish writing. */
@@ -159,31 +149,3 @@ static void png_save_free(png_structp png_ptr, png_byte **png_row_pointers,
 }
 
 
-static char *png_filename(const struct tm *tmx, const char *name,
-			  char *buf, unsigned int length)
-{
-	/*
-	 * -2013-03-03-15-22-56.png - 24 chars
-	 */
-	if (strlen(name) + 24 >= length) {
-		buf[0] = '\0';
-		return buf;
-	}
-
-	sprintf(buf, (tmx->tm_mon < 9 ? "%s-%d-0%d" : "%s-%d-%d"), name,
-		1900 + tmx->tm_year, tmx->tm_mon + 1);
-
-	sprintf(buf + strlen(buf), (tmx->tm_mday < 10 ? "-0%d" : "-%d"),
-		tmx->tm_mday);
-
-	sprintf(buf + strlen(buf), (tmx->tm_hour < 10 ? "-0%d" : "-%d"),
-		tmx->tm_hour);
-
-	sprintf(buf + strlen(buf), (tmx->tm_min < 10 ? "-0%d" : "-%d"),
-		tmx->tm_min);
-
-	sprintf(buf + strlen(buf), (tmx->tm_sec < 10 ? "-0%d.png" : "-%d.png"),
-		tmx->tm_sec);
-
-	return buf;
-}

--- a/modules/snapshot/snapshot.c
+++ b/modules/snapshot/snapshot.c
@@ -8,7 +8,7 @@
 #include <rem.h>
 #include <baresip.h>
 #include "png_vf.h"
-
+#include <time.h>
 
 /**
  * @defgroup snapshot snapshot
@@ -19,16 +19,21 @@
  * Commands:
  *
  \verbatim
- snapshot       Take video snapshot
+ snapshot           Take video snapshot of both video streams
+ snapshot_recv path Take snapshot of receiving video and save it to the path
+ snapshot_send path Take snapshot of sending video and save it to the path
  \endverbatim
  */
 
 
 static bool flag_enc, flag_dec;
+static char path_enc[100], path_dec[100];
 
+static char *png_filename(const struct tm *tmx, const char *name,
+			char *buf, unsigned int length);
 
 static int encode(struct vidfilt_enc_st *st, struct vidframe *frame,
-		  uint64_t *timestamp)
+			uint64_t *timestamp)
 {
 	(void)st;
 	(void)timestamp;
@@ -38,7 +43,7 @@ static int encode(struct vidfilt_enc_st *st, struct vidframe *frame,
 
 	if (flag_enc) {
 		flag_enc = false;
-		png_save_vidframe(frame, "snapshot-send");
+		png_save_vidframe(frame, path_enc);
 	}
 
 	return 0;
@@ -46,7 +51,7 @@ static int encode(struct vidfilt_enc_st *st, struct vidframe *frame,
 
 
 static int decode(struct vidfilt_dec_st *st, struct vidframe *frame,
-		  uint64_t *timestamp)
+			uint64_t *timestamp)
 {
 	(void)st;
 	(void)timestamp;
@@ -56,7 +61,7 @@ static int decode(struct vidfilt_dec_st *st, struct vidframe *frame,
 
 	if (flag_dec) {
 		flag_dec = false;
-		png_save_vidframe(frame, "snapshot-recv");
+		png_save_vidframe(frame, path_dec);
 	}
 
 	return 0;
@@ -65,15 +70,55 @@ static int decode(struct vidfilt_dec_st *st, struct vidframe *frame,
 
 static int do_snapshot(struct re_printf *pf, void *arg)
 {
+	time_t tnow;
+	struct tm *tmx;
+
 	(void)pf;
 	(void)arg;
 
+	if (flag_enc || flag_dec)
+		return 0;
+
+	tnow = time(NULL);
+	tmx = localtime(&tnow);
+
 	/* NOTE: not re-entrant */
+	png_filename(tmx, "snapshot-recv", path_dec, sizeof(path_dec));
+	png_filename(tmx, "snapshot-send", path_enc, sizeof(path_enc));
 	flag_enc = flag_dec = true;
 
 	return 0;
 }
 
+static int do_snapshot_recv(struct re_printf *pf, void *arg)
+{
+	(void)pf;
+	const struct cmd_arg *carg = arg;
+
+	if (flag_dec)
+		return 0;
+
+	/* NOTE: not re-entrant */
+	str_ncpy(path_dec, carg->prm, sizeof(path_dec));
+	flag_dec = true;
+
+	return 0;
+}
+
+static int do_snapshot_send(struct re_printf *pf, void *arg)
+{
+	(void)pf;
+	const struct cmd_arg *carg = arg;
+
+	if (flag_enc)
+		return 0;
+
+	/* NOTE: not re-entrant */
+	str_ncpy(path_enc, carg->prm, sizeof(path_enc));
+	flag_enc = true;
+
+	return 0;
+}
 
 static struct vidfilt snapshot = {
 	.name = "snapshot",
@@ -84,6 +129,12 @@ static struct vidfilt snapshot = {
 
 static const struct cmd cmdv[] = {
 	{"snapshot", 0, 0, "Take video snapshot", do_snapshot },
+	{"snapshot_recv", 0, CMD_PRM,
+   "Take receiving video snapshot and save to path",
+   do_snapshot_recv},
+	{"snapshot_send", 0, CMD_PRM,
+   "Take sending video snapshot and save to path",
+   do_snapshot_send}
 };
 
 
@@ -99,6 +150,36 @@ static int module_close(void)
 	vidfilt_unregister(&snapshot);
 	cmd_unregister(baresip_commands(), cmdv);
 	return 0;
+}
+
+
+static char *png_filename(const struct tm *tmx, const char *name,
+			char *buf, unsigned int length)
+{
+	/*
+	 * -2013-03-03-15-22-56.png - 24 chars
+	 */
+	if (strlen(name) + 24 >= length) {
+		buf[0] = '\0';
+		return buf;
+	}
+
+	sprintf(buf, (tmx->tm_mon < 9 ? "%s-%d-0%d" : "%s-%d-%d"), name,
+					1900 + tmx->tm_year, tmx->tm_mon + 1);
+
+	sprintf(buf + strlen(buf), (tmx->tm_mday < 10 ? "-0%d" : "-%d"),
+					tmx->tm_mday);
+
+	sprintf(buf + strlen(buf), (tmx->tm_hour < 10 ? "-0%d" : "-%d"),
+					tmx->tm_hour);
+
+	sprintf(buf + strlen(buf), (tmx->tm_min < 10 ? "-0%d" : "-%d"),
+					tmx->tm_min);
+
+	sprintf(buf + strlen(buf), (tmx->tm_sec < 10 ? "-0%d.png" : "-%d.png"),
+					tmx->tm_sec);
+
+	return buf;
 }
 
 


### PR DESCRIPTION
Hi,

Here is a simple extension to snapshot module. It adds two additional commands `snapshot_recv path` and `snapshot_send path`. 
They create snapshot only from receiving video stream or sending video stream and save it to provided file path.
The old "snapshot" command works as it was, creating two png files in working directory.

Just need more control over snapshots for one of my projects.