### PR TITLE
Do not try to install modules if build is static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,8 +263,10 @@ $(BUILD): Makefile
 install: $(BIN) $(MOD_BINS)
 	@mkdir -p $(DESTDIR)$(BINDIR)
 	$(INSTALL) -m 0755 $(BIN) $(DESTDIR)$(BINDIR)
+ifeq ($(STATIC),)
 	@mkdir -p $(DESTDIR)$(MOD_PATH)
 	$(INSTALL) -m 0644 $(MOD_BINS) $(DESTDIR)$(MOD_PATH)
+endif
 	@mkdir -p $(DESTDIR)$(SHARE_PATH)
 	$(INSTALL) -m 0644 share/* $(DESTDIR)$(SHARE_PATH)
 


### PR DESCRIPTION
With this change, debian package build works also when STATIC=yes.  There exists separate `make install-static`, but I would prefer `make install` to work also when the build is static.  If others don't think so, this pull request can be deleted.