### PR TITLE
Add avfilter module/command

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -264,7 +264,6 @@ endif
 # ------------------------------------------------------------------------- #
 
 MODULES   += $(EXTRA_MODULES)
-
 ifneq ($(BASIC_MODULES),no)
 MODULES   += account
 MODULES   += auloop

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -264,6 +264,7 @@ endif
 # ------------------------------------------------------------------------- #
 
 MODULES   += $(EXTRA_MODULES)
+
 ifneq ($(BASIC_MODULES),no)
 MODULES   += account
 MODULES   += auloop
@@ -319,6 +320,9 @@ MODULES   += avcodec
 ifneq ($(USE_AVFORMAT),)
 MODULES   += avformat
 endif
+endif
+ifneq ($(USE_AVFILTER),)
+MODULES   += avfilter
 endif
 ifneq ($(USE_CAIRO),)
 MODULES   += cairo

--- a/modules/avfilter/avfilter.c
+++ b/modules/avfilter/avfilter.c
@@ -41,7 +41,7 @@
  *
  */
 
-static struct lock *lock = (void*)0;
+static struct lock *lock;
 static char filter_descr[MAX_DESCR] = "";
 static bool filter_updated = false;
 
@@ -142,7 +142,7 @@ static int module_init(void)
 	int err;
 	err = lock_alloc(&lock);
 	if (err)
-		return ENOMEM;
+		return err;
 
 	vidfilt_register(baresip_vidfiltl(), &avfilter);
 	return cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
@@ -151,7 +151,7 @@ static int module_init(void)
 
 static int module_close(void)
 {
-	mem_deref(lock);
+	lock = mem_deref(lock);
 	vidfilt_unregister(&avfilter);
 	cmd_unregister(baresip_commands(), cmdv);
 	return 0;

--- a/modules/avfilter/avfilter.c
+++ b/modules/avfilter/avfilter.c
@@ -125,6 +125,7 @@ static int avfilter_command(struct re_printf *pf, void *arg)
 	return 0;
 }
 
+
 static struct vidfilt avfilter = {
 	.name    = "avfilter",
 	.ench    = encode,

--- a/modules/avfilter/avfilter.c
+++ b/modules/avfilter/avfilter.c
@@ -17,14 +17,16 @@
 /**
  * @defgroup avfilter avfilter
  *
- * Apply FFmpeg filter graph to outcoming stream
+ * Video filters using libavfilter
  *
+ * This module allows to dynamically apply complex video filter graphs
+ * to outcoming stream using libavfilter from FFmpeg project.
  *
  * Commands:
  *
  \verbatim
- avfilter [filter_string] Apply avfilter to outcoming stream
- avfilter [Empty filter_string] Stop avfilter
+ avfilter <FILTER> - Enable avfilter for outcoming stream
+ avfilter          - Disable avfilter
  \endverbatim
  *
  * Example:
@@ -32,6 +34,11 @@
  \verbatim
  avfilter movie=watermark.png[pic];[in][pic]overlay=10:10[out]
  \endverbatim
+ *
+ * References:
+ *
+ *     https://ffmpeg.org/ffmpeg-filters.html
+ *
  */
 
 static struct lock *lock = (void*)0;
@@ -49,8 +56,8 @@ static void st_destructor(void *arg)
 
 
 static int update(struct vidfilt_enc_st **stp, void **ctx,
-	const struct vidfilt *vf, struct vidfilt_prm *prm,
-	const struct video *vid)
+		  const struct vidfilt *vf, struct vidfilt_prm *prm,
+		  const struct video *vid)
 {
 	struct avfilter_st *st;
 	(void)vid;
@@ -73,7 +80,7 @@ static int update(struct vidfilt_enc_st **stp, void **ctx,
 
 
 static int encode(struct vidfilt_enc_st *enc_st, struct vidframe *frame,
-	uint64_t *timestamp)
+		  uint64_t *timestamp)
 {
 	struct avfilter_st *st = (struct avfilter_st *)enc_st;
 	int err=0;
@@ -106,8 +113,8 @@ static int avfilter_command(struct re_printf *pf, void *arg)
 	if (str_isset(carg->prm)) {
 		str_ncpy(filter_descr, carg->prm, sizeof(filter_descr));
 		info("avfilter: enabled for %s\n", filter_descr);
-  }
-  else {
+	}
+	else {
 		str_ncpy(filter_descr, "", sizeof(filter_descr));
 		info("avfilter: disabled\n");
 	}
@@ -119,8 +126,8 @@ static int avfilter_command(struct re_printf *pf, void *arg)
 }
 
 static struct vidfilt avfilter = {
-	.name = "avfilter",
-	.ench = encode,
+	.name    = "avfilter",
+	.ench    = encode,
 	.encupdh = update
 };
 

--- a/modules/avfilter/avfilter.c
+++ b/modules/avfilter/avfilter.c
@@ -1,0 +1,159 @@
+/**
+ * @file avfilter.c	 Video filter using libavfilter
+ *
+ * Copyright (C) 2020 Mikhail Kurkov
+ */
+
+#include <string.h>
+#include <libavformat/avformat.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavutil/opt.h>
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include "avfilter.h"
+
+/**
+ * @defgroup avfilter avfilter
+ *
+ * Apply FFmpeg filter graph to outcoming stream
+ *
+ *
+ * Commands:
+ *
+ \verbatim
+ avfilter [filter_string] Apply avfilter to outcoming stream
+ avfilter [Empty filter_string] Stop avfilter
+ \endverbatim
+ *
+ * Example:
+ *
+ \verbatim
+ avfilter movie=watermark.png[pic];[in][pic]overlay=10:10[out]
+ \endverbatim
+ */
+
+static struct lock *lock = (void*)0;
+static char filter_descr[MAX_DESCR] = "";
+static bool filter_updated = false;
+
+
+static void st_destructor(void *arg)
+{
+	struct avfilter_st *st = arg;
+
+	list_unlink(&st->vf.le);
+	filter_reset(st);
+}
+
+
+static int update(struct vidfilt_enc_st **stp, void **ctx,
+	const struct vidfilt *vf, struct vidfilt_prm *prm,
+	const struct video *vid)
+{
+	struct avfilter_st *st;
+	(void)vid;
+
+	if (!stp || !ctx || !vf || !prm)
+		return EINVAL;
+
+	if (*stp)
+		return 0;
+
+	st = mem_zalloc(sizeof(*st), st_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->enabled = false;
+
+	*stp = (struct vidfilt_enc_st *)st;
+	return 0;
+}
+
+
+static int encode(struct vidfilt_enc_st *enc_st, struct vidframe *frame,
+	uint64_t *timestamp)
+{
+	struct avfilter_st *st = (struct avfilter_st *)enc_st;
+	int err=0;
+	(void)timestamp;
+
+	if (!frame)
+		return 0;
+
+	lock_write_get(lock);
+	if (filter_updated || !filter_valid(st, frame)) {
+		filter_reset(st);
+		filter_init(st, filter_descr, frame);
+	}
+	filter_updated = false;
+	lock_rel(lock);
+
+	err = filter_encode(st, frame, timestamp);
+
+	return err;
+}
+
+
+static int avfilter_command(struct re_printf *pf, void *arg)
+{
+	(void)pf;
+	const struct cmd_arg *carg = arg;
+
+	lock_write_get(lock);
+
+	if (str_isset(carg->prm)) {
+		str_ncpy(filter_descr, carg->prm, sizeof(filter_descr));
+		info("avfilter: enabled for %s\n", filter_descr);
+  }
+  else {
+		str_ncpy(filter_descr, "", sizeof(filter_descr));
+		info("avfilter: disabled\n");
+	}
+
+	filter_updated = true;
+
+	lock_rel(lock);
+	return 0;
+}
+
+static struct vidfilt avfilter = {
+	.name = "avfilter",
+	.ench = encode,
+	.encupdh = update
+};
+
+
+static const struct cmd cmdv[] = {
+	{"avfilter", 0, CMD_PRM, "Start avfilter", avfilter_command}
+};
+
+
+static int module_init(void)
+{
+	int err;
+	err = lock_alloc(&lock);
+	if (err)
+		return ENOMEM;
+
+	vidfilt_register(baresip_vidfiltl(), &avfilter);
+	return cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
+}
+
+
+static int module_close(void)
+{
+	mem_deref(lock);
+	vidfilt_unregister(&avfilter);
+	cmd_unregister(baresip_commands(), cmdv);
+	return 0;
+}
+
+
+EXPORT_SYM const struct mod_export DECL_EXPORTS(avfilter) = {
+	"avfilter",
+	"vidfilt",
+	module_init,
+	module_close
+};

--- a/modules/avfilter/avfilter.h
+++ b/modules/avfilter/avfilter.h
@@ -33,7 +33,7 @@ int filter_init(struct avfilter_st *st, char* filter_descr,
 
 void filter_reset(struct avfilter_st *st);
 
-bool filter_valid(struct avfilter_st *st, struct vidframe *frame);
+bool filter_valid(const struct avfilter_st *st, const struct vidframe *frame);
 
 int filter_encode(struct avfilter_st *st, struct vidframe *frame,
 		  uint64_t *timestamp);

--- a/modules/avfilter/avfilter.h
+++ b/modules/avfilter/avfilter.h
@@ -1,0 +1,39 @@
+/**
+ * @file avfilter.h  Video filter using libavfilter -- internal API
+ *
+ * Copyright (C) 2020 Mikhail Kurkov
+ */
+
+/* Maximum filter length */
+#define MAX_DESCR          512
+
+
+/* Filter state */
+struct avfilter_st {
+	struct vidfilt_enc_st vf;   /* base class */
+
+	struct vidsz size;
+	enum vidfmt format;
+  bool enabled;
+
+	AVFilterContext *buffersink_ctx;
+	AVFilterContext *buffersrc_ctx;
+	AVFilterGraph *filter_graph;
+	AVFrame *vframe_in;
+	AVFrame *vframe_out;
+};
+
+
+/*
+ * Filter API
+ */
+
+int filter_init(struct avfilter_st *st, char* filter_descr,
+		 struct vidframe *frame);
+
+int filter_reset(struct avfilter_st *st);
+
+bool filter_valid(struct avfilter_st *st, struct vidframe *frame);
+
+int filter_encode(struct avfilter_st *st, struct vidframe *frame,
+     uint64_t *timestamp);

--- a/modules/avfilter/avfilter.h
+++ b/modules/avfilter/avfilter.h
@@ -31,7 +31,7 @@ struct avfilter_st {
 int filter_init(struct avfilter_st *st, char* filter_descr,
 		struct vidframe *frame);
 
-int filter_reset(struct avfilter_st *st);
+void filter_reset(struct avfilter_st *st);
 
 bool filter_valid(struct avfilter_st *st, struct vidframe *frame);
 

--- a/modules/avfilter/avfilter.h
+++ b/modules/avfilter/avfilter.h
@@ -5,7 +5,7 @@
  */
 
 /* Maximum filter length */
-#define MAX_DESCR          512
+#define MAX_DESCR 512
 
 
 /* Filter state */
@@ -14,7 +14,7 @@ struct avfilter_st {
 
 	struct vidsz size;
 	enum vidfmt format;
-  bool enabled;
+	bool enabled;
 
 	AVFilterContext *buffersink_ctx;
 	AVFilterContext *buffersrc_ctx;
@@ -29,11 +29,11 @@ struct avfilter_st {
  */
 
 int filter_init(struct avfilter_st *st, char* filter_descr,
-		 struct vidframe *frame);
+		struct vidframe *frame);
 
 int filter_reset(struct avfilter_st *st);
 
 bool filter_valid(struct avfilter_st *st, struct vidframe *frame);
 
 int filter_encode(struct avfilter_st *st, struct vidframe *frame,
-     uint64_t *timestamp);
+		  uint64_t *timestamp);

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -116,7 +116,7 @@ int filter_init(struct avfilter_st *st, char* filter_descr,
 void filter_reset(struct avfilter_st* st)
 {
 	if (!st->enabled)
-		return 0;
+		return;
 	if (st->filter_graph)
 		avfilter_graph_free(&st->filter_graph);
 	if (st->vframe_in)

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -128,7 +128,7 @@ void filter_reset(struct avfilter_st* st)
 }
 
 
-bool filter_valid(struct avfilter_st* st, struct vidframe *frame)
+bool filter_valid(const struct avfilter_st* st, const struct vidframe *frame)
 {
 	bool res = !st->enabled ||
 		((st->size.h == frame->size.h) &&

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -48,7 +48,7 @@ int filter_init(struct avfilter_st *st, char* filter_descr,
 	snprintf(args, sizeof(args),
 		 "video_size=%dx%d:pix_fmt=%d:"
 		 "time_base=%d/%d:pixel_aspect=1/1",
-		 frame->size.w, frame->size.h, src_format, 1, 25);
+		 frame->size.w, frame->size.h, src_format, 1, VIDEO_TIMEBASE);
 
 	err = avfilter_graph_create_filter(
 		&st->buffersrc_ctx, buffersrc, "in", args, NULL,

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -1,0 +1,187 @@
+/**
+ * @file avfilter/filter.c	Video filter using libavfilter -- filtering
+ *
+ * Copyright (C) 2020 Mikhail Kurkov
+ */
+
+#include <string.h>
+#include <libavformat/avformat.h>
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
+#include <libavutil/opt.h>
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include "avfilter.h"
+#include "util.h"
+
+
+int filter_init(struct avfilter_st *st, char* filter_descr,
+		 struct vidframe *frame)
+{
+	char args[512];
+	int err = 0;
+
+	if (!str_isset(filter_descr)) {
+		st->enabled = false;
+		return 0;
+	}
+
+	const AVFilter *buffersrc	 = avfilter_get_by_name("buffer");
+	const AVFilter *buffersink = avfilter_get_by_name("buffersink");
+	AVFilterInOut *outputs = avfilter_inout_alloc();
+	AVFilterInOut *inputs	 = avfilter_inout_alloc();
+
+	enum AVPixelFormat src_format = vidfmt_to_avpixfmt(frame->fmt);
+	enum AVPixelFormat pix_fmts[] = { src_format, AV_PIX_FMT_NONE };
+
+	st->filter_graph = avfilter_graph_alloc();
+	st->vframe_in = av_frame_alloc();
+	st->vframe_out = av_frame_alloc();
+	if (!outputs || !inputs || !st->filter_graph ||
+      !st->vframe_in || !st->vframe_out) {
+		err = AVERROR(ENOMEM);
+		goto end;
+	}
+
+	/* buffer video source */
+	snprintf(args, sizeof(args),
+		"video_size=%dx%d:pix_fmt=%d:time_base=%d/%d:pixel_aspect=1/1",
+		frame->size.w, frame->size.h, src_format, 1, 25);
+
+	err = avfilter_graph_create_filter(
+          &st->buffersrc_ctx, buffersrc, "in",
+				  args, NULL, st->filter_graph);
+	if (err < 0) {
+		warning("avfilter: cannot create buffer source\n");
+		goto end;
+	}
+
+	/* buffer video sink: to terminate the filter chain. */
+	err = avfilter_graph_create_filter(
+          &st->buffersink_ctx, buffersink, "out",
+					NULL, NULL, st->filter_graph);
+	if (err < 0) {
+		warning("avfilter: cannot create buffer sink\n");
+		goto end;
+	}
+
+	err = av_opt_set_int_list(
+     st->buffersink_ctx, "pix_fmts", pix_fmts,
+		 AV_PIX_FMT_NONE, AV_OPT_SEARCH_CHILDREN);
+	if (err < 0) {
+		warning("avfilter: Cannot set output pixel format\n");
+		goto end;
+	}
+
+	outputs->name				= av_strdup("in");
+	outputs->filter_ctx = st->buffersrc_ctx;
+	outputs->pad_idx		= 0;
+	outputs->next				= NULL;
+
+	inputs->name			 = av_strdup("out");
+	inputs->filter_ctx = st->buffersink_ctx;
+	inputs->pad_idx		 = 0;
+	inputs->next			 = NULL;
+
+	if ((err = avfilter_graph_parse_ptr(
+          st->filter_graph, filter_descr,
+					&inputs, &outputs, NULL)) < 0)
+		goto end;
+
+	if ((err = avfilter_graph_config(st->filter_graph, NULL)) < 0)
+		goto end;
+
+	st->size = frame->size;
+	st->format = frame->fmt;
+	st->enabled = true;
+
+	info("avfilter: filter graph initialized for %s\n", filter_descr);
+
+ end:
+	avfilter_inout_free(&inputs);
+	avfilter_inout_free(&outputs);
+
+	return err;
+}
+
+int filter_reset(struct avfilter_st* st) {
+	if (!st->enabled)
+		return 0;
+	if (st->filter_graph)
+		avfilter_graph_free(&st->filter_graph);
+	if (st->vframe_in)
+		av_frame_free(&st->vframe_in);
+	if (st->vframe_out)
+		av_frame_free(&st->vframe_out);
+	st->enabled = false;
+	info("avfilter: filter graph reset\n");
+	return 0;
+}
+
+bool filter_valid(struct avfilter_st* st, struct vidframe *frame) {
+	return (
+		!st->enabled ||
+		((st->size.h == frame->size.h) &&
+		 (st->size.w == frame->size.w) &&
+		 (st->format == frame->fmt)));
+}
+
+int filter_encode(struct avfilter_st* st, struct vidframe *frame,
+		  uint64_t *timestamp)
+{
+	unsigned i;
+	int err;
+
+	if (!frame)
+		return 0;
+
+	if (!st->enabled) {
+		return 0;
+	}
+
+	/* fill the source frame */
+	st->vframe_in->format = vidfmt_to_avpixfmt(frame->fmt);
+	st->vframe_in->width = frame->size.w;
+	st->vframe_in->height = frame->size.h;
+	st->vframe_in->pts = *timestamp;
+
+	for (i=0; i<4; i++) {
+		st->vframe_in->data[i] = frame->data[i];
+		st->vframe_in->linesize[i] = frame->linesize[i];
+	}
+
+	/* push source frame into the filter graph */
+	err = av_buffersrc_add_frame_flags(st->buffersrc_ctx,
+			st->vframe_in, AV_BUFFERSRC_FLAG_KEEP_REF);
+	if (err < 0) {
+		warning("avfilter: error while feeding the filtergraph\n");
+		goto out;
+	}
+
+	/* pull filtered frames from the filtergraph */
+	av_frame_unref(st->vframe_out);
+	err = av_buffersink_get_frame(st->buffersink_ctx, st->vframe_out);
+	if (err == AVERROR(EAGAIN) || err == AVERROR_EOF)
+		goto out;
+	if (err < 0) {
+		warning("avfilter: error while getting"
+      " filtered frame from the filtergraph\n");
+		goto out;
+	}
+
+	avframe_ensure_topdown(st->vframe_out);
+
+	/* Copy filtered frame back to the input frame */
+	for (i=0; i<4; i++) {
+		frame->data[i]		 = st->vframe_out->data[i];
+		frame->linesize[i] = st->vframe_out->linesize[i];
+	}
+	frame->size.h = st->vframe_out->height;
+	frame->size.w = st->vframe_out->width;
+	frame->fmt = avpixfmt_to_vidfmt(st->vframe_out->format);
+
+ out:
+	return err;
+}
+

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -15,6 +15,7 @@
 #include "avfilter.h"
 #include "util.h"
 
+
 int filter_init(struct avfilter_st *st, char* filter_descr,
 		struct vidframe *frame)
 {
@@ -111,6 +112,7 @@ int filter_init(struct avfilter_st *st, char* filter_descr,
 	return err;
 }
 
+
 int filter_reset(struct avfilter_st* st)
 {
 	if (!st->enabled)
@@ -126,6 +128,7 @@ int filter_reset(struct avfilter_st* st)
 	return 0;
 }
 
+
 bool filter_valid(struct avfilter_st* st, struct vidframe *frame)
 {
 	bool res = !st->enabled ||
@@ -134,6 +137,7 @@ bool filter_valid(struct avfilter_st* st, struct vidframe *frame)
 		 (st->format == frame->fmt));
 	return res;
 }
+
 
 int filter_encode(struct avfilter_st* st, struct vidframe *frame,
 		  uint64_t *timestamp)
@@ -192,4 +196,3 @@ int filter_encode(struct avfilter_st* st, struct vidframe *frame,
  out:
 	return err;
 }
-

--- a/modules/avfilter/filter.c
+++ b/modules/avfilter/filter.c
@@ -113,7 +113,7 @@ int filter_init(struct avfilter_st *st, char* filter_descr,
 }
 
 
-int filter_reset(struct avfilter_st* st)
+void filter_reset(struct avfilter_st* st)
 {
 	if (!st->enabled)
 		return 0;
@@ -125,7 +125,6 @@ int filter_reset(struct avfilter_st* st)
 		av_frame_free(&st->vframe_out);
 	st->enabled = false;
 	info("avfilter: filter graph reset\n");
-	return 0;
 }
 
 

--- a/modules/avfilter/module.mk
+++ b/modules/avfilter/module.mk
@@ -1,0 +1,13 @@
+#
+# module.mk
+#
+# Copyright (C) 2020 Mikhail Kurkov
+#
+
+MOD		:= avfilter
+$(MOD)_SRCS	+= avfilter.c
+$(MOD)_SRCS	+= filter.c
+$(MOD)_SRCS	+= util.c
+$(MOD)_LFLAGS	+= -lavfilter -lavutil
+
+include mk/mod.mk

--- a/modules/avfilter/util.c
+++ b/modules/avfilter/util.c
@@ -22,15 +22,15 @@ static int swap_lines(uint8_t *a, uint8_t *b, size_t size) {
 static int reverse_lines(uint8_t *data, int linesize, int count) {
 	for (int i = 0; i < count/2; i++)
 		swap_lines(data + linesize * i,
-       data + linesize * (count - i - 1),
-       abs(linesize));
+			   data + linesize * (count - i - 1),
+			   abs(linesize));
 	return 0;
 }
 
 /*
- *	Sometimes AVFrame contains planes with lines in bottom-up order.
- *	Then linesize is negative and data points to the last row in buffer.
- *	Baresip uses unsigned linesizes, lets reorder lines to fix it.
+ * Sometimes AVFrame contains planes with lines in bottom-up order.
+ * Then linesize is negative and data points to the last row in buffer.
+ * Baresip uses unsigned linesizes, lets reorder lines to fix it.
  */
 int avframe_ensure_topdown(AVFrame *frame)
 {
@@ -42,7 +42,7 @@ int avframe_ensure_topdown(AVFrame *frame)
 			if (ls >= 0) continue;
 			int h = i == 0 ? frame->height : frame->height/2;
 			reverse_lines(frame->data[i], ls, h);
-			frame->data[i] = frame->data[i] + ls * (h - 1);
+			frame->data[i]     = frame->data[i] + ls * (h - 1);
 			frame->linesize[i] = abs(ls);
 		}
 		break;
@@ -50,10 +50,13 @@ int avframe_ensure_topdown(AVFrame *frame)
 	default:
 		/* TODO support more formats */
 		for (int i=0; i<4; i++) {
+
 			if (frame->linesize[0] <0) {
+
 				warning("avfilter: unsupported frame"
-          " format with negative linesize: %d",
-          frame->format);
+					" format with negative linesize: %d",
+					frame->format);
+
 				return EPROTO;
 			}
 		}
@@ -79,11 +82,11 @@ enum vidfmt avpixfmt_to_vidfmt(const enum AVPixelFormat pix_fmt)
 {
 	switch (pix_fmt) {
 
-	case AV_PIX_FMT_YUV420P:	return VID_FMT_YUV420P;
+	case AV_PIX_FMT_YUV420P:  return VID_FMT_YUV420P;
 	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
-	case AV_PIX_FMT_YUV444P:	return VID_FMT_YUV444P;
-	case AV_PIX_FMT_NV12:			return VID_FMT_NV12;
-	case AV_PIX_FMT_NV21:			return VID_FMT_NV21;
+	case AV_PIX_FMT_YUV444P:  return VID_FMT_YUV444P;
+	case AV_PIX_FMT_NV12:     return VID_FMT_NV12;
+	case AV_PIX_FMT_NV21:     return VID_FMT_NV21;
 	default:                  return (enum vidfmt)-1;
 	}
 }

--- a/modules/avfilter/util.c
+++ b/modules/avfilter/util.c
@@ -11,7 +11,9 @@
 #include <libavutil/frame.h>
 #include "util.h"
 
-static int swap_lines(uint8_t *a, uint8_t *b, size_t size) {
+
+static int swap_lines(uint8_t *a, uint8_t *b, size_t size)
+{
 	uint8_t tmp[size];
 	memcpy(tmp, a, size);
 	memcpy(a, b, size);
@@ -19,13 +21,16 @@ static int swap_lines(uint8_t *a, uint8_t *b, size_t size) {
 	return 0;
 }
 
-static int reverse_lines(uint8_t *data, int linesize, int count) {
+
+static int reverse_lines(uint8_t *data, int linesize, int count)
+{
 	for (int i = 0; i < count/2; i++)
 		swap_lines(data + linesize * i,
 			   data + linesize * (count - i - 1),
 			   abs(linesize));
 	return 0;
 }
+
 
 /*
  * Sometimes AVFrame contains planes with lines in bottom-up order.
@@ -65,6 +70,7 @@ int avframe_ensure_topdown(AVFrame *frame)
 	return 0;
 }
 
+
 enum AVPixelFormat vidfmt_to_avpixfmt(const enum vidfmt fmt)
 {
 
@@ -77,6 +83,7 @@ enum AVPixelFormat vidfmt_to_avpixfmt(const enum vidfmt fmt)
 	default:              return AV_PIX_FMT_NONE;
 	}
 }
+
 
 enum vidfmt avpixfmt_to_vidfmt(const enum AVPixelFormat pix_fmt)
 {

--- a/modules/avfilter/util.c
+++ b/modules/avfilter/util.c
@@ -79,7 +79,7 @@ int avframe_ensure_topdown(AVFrame *frame)
 }
 
 
-enum AVPixelFormat vidfmt_to_avpixfmt(const enum vidfmt fmt)
+enum AVPixelFormat vidfmt_to_avpixfmt(enum vidfmt fmt)
 {
 
 	switch (fmt) {
@@ -93,7 +93,7 @@ enum AVPixelFormat vidfmt_to_avpixfmt(const enum vidfmt fmt)
 }
 
 
-enum vidfmt avpixfmt_to_vidfmt(const enum AVPixelFormat pix_fmt)
+enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt)
 {
 	switch (pix_fmt) {
 

--- a/modules/avfilter/util.c
+++ b/modules/avfilter/util.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2020 Mikhail Kurkov
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <re.h>
 #include <rem.h>
@@ -12,9 +13,8 @@
 #include "util.h"
 
 
-static int swap_lines(uint8_t *a, uint8_t *b, size_t size)
+static int swap_lines(uint8_t *a, uint8_t *b, uint8_t *tmp, size_t size)
 {
-	uint8_t tmp[size];
 	memcpy(tmp, a, size);
 	memcpy(a, b, size);
 	memcpy(b, tmp, size);
@@ -24,10 +24,18 @@ static int swap_lines(uint8_t *a, uint8_t *b, size_t size)
 
 static int reverse_lines(uint8_t *data, int linesize, int count)
 {
+	size_t size = abs(linesize) * sizeof(uint8_t);
+	uint8_t *tmp = malloc(size);
+	if (!tmp)
+		return ENOMEM;
+
 	for (int i = 0; i < count/2; i++)
 		swap_lines(data + linesize * i,
 			   data + linesize * (count - i - 1),
-			   abs(linesize));
+			   tmp,
+			   size);
+
+	free(tmp);
 	return 0;
 }
 

--- a/modules/avfilter/util.c
+++ b/modules/avfilter/util.c
@@ -1,0 +1,89 @@
+/**
+ * @file util.c	 Video filter using libavfilter -- utility functions
+ *
+ * Copyright (C) 2020 Mikhail Kurkov
+ */
+
+#include <string.h>
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <libavutil/frame.h>
+#include "util.h"
+
+static int swap_lines(uint8_t *a, uint8_t *b, size_t size) {
+	uint8_t tmp[size];
+	memcpy(tmp, a, size);
+	memcpy(a, b, size);
+	memcpy(b, tmp, size);
+	return 0;
+}
+
+static int reverse_lines(uint8_t *data, int linesize, int count) {
+	for (int i = 0; i < count/2; i++)
+		swap_lines(data + linesize * i,
+       data + linesize * (count - i - 1),
+       abs(linesize));
+	return 0;
+}
+
+/*
+ *	Sometimes AVFrame contains planes with lines in bottom-up order.
+ *	Then linesize is negative and data points to the last row in buffer.
+ *	Baresip uses unsigned linesizes, lets reorder lines to fix it.
+ */
+int avframe_ensure_topdown(AVFrame *frame)
+{
+	switch (frame->format) {
+
+	case AV_PIX_FMT_YUV420P:
+		for (int i=0; i<4; i++) {
+			int ls = frame->linesize[i];
+			if (ls >= 0) continue;
+			int h = i == 0 ? frame->height : frame->height/2;
+			reverse_lines(frame->data[i], ls, h);
+			frame->data[i] = frame->data[i] + ls * (h - 1);
+			frame->linesize[i] = abs(ls);
+		}
+		break;
+
+	default:
+		/* TODO support more formats */
+		for (int i=0; i<4; i++) {
+			if (frame->linesize[0] <0) {
+				warning("avfilter: unsupported frame"
+          " format with negative linesize: %d",
+          frame->format);
+				return EPROTO;
+			}
+		}
+	}
+
+	return 0;
+}
+
+enum AVPixelFormat vidfmt_to_avpixfmt(const enum vidfmt fmt)
+{
+
+	switch (fmt) {
+
+	case VID_FMT_YUV420P: return AV_PIX_FMT_YUV420P;
+	case VID_FMT_YUV444P: return AV_PIX_FMT_YUV444P;
+	case VID_FMT_NV12:    return AV_PIX_FMT_NV12;
+	case VID_FMT_NV21:    return AV_PIX_FMT_NV21;
+	default:              return AV_PIX_FMT_NONE;
+	}
+}
+
+enum vidfmt avpixfmt_to_vidfmt(const enum AVPixelFormat pix_fmt)
+{
+	switch (pix_fmt) {
+
+	case AV_PIX_FMT_YUV420P:	return VID_FMT_YUV420P;
+	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
+	case AV_PIX_FMT_YUV444P:	return VID_FMT_YUV444P;
+	case AV_PIX_FMT_NV12:			return VID_FMT_NV12;
+	case AV_PIX_FMT_NV21:			return VID_FMT_NV21;
+	default:                  return (enum vidfmt)-1;
+	}
+}

--- a/modules/avfilter/util.h
+++ b/modules/avfilter/util.h
@@ -1,0 +1,10 @@
+/**
+ * @file util.h  Video filter using libavfilter -- utility functions
+ *
+ * Copyright (C) 2020 Mikhail Kurkov
+ */
+
+
+int avframe_ensure_topdown(AVFrame *frame);
+enum AVPixelFormat vidfmt_to_avpixfmt(enum vidfmt fmt);
+enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt);

--- a/src/config.c
+++ b/src/config.c
@@ -806,6 +806,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module\t\t\t" "snapshot" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "swscale" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "vidinfo" MOD_EXT "\n");
+  (void)re_fprintf(f, "#module\t\t\t" "avfilter" MOD_EXT "\n");
 
 	(void)re_fprintf(f, "\n# Video source modules\n");
 #if defined (DARWIN)

--- a/src/config.c
+++ b/src/config.c
@@ -806,7 +806,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module\t\t\t" "snapshot" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "swscale" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "vidinfo" MOD_EXT "\n");
-  (void)re_fprintf(f, "#module\t\t\t" "avfilter" MOD_EXT "\n");
+	(void)re_fprintf(f, "#module\t\t\t" "avfilter" MOD_EXT "\n");
 
 	(void)re_fprintf(f, "\n# Video source modules\n");
 #if defined (DARWIN)


### PR DESCRIPTION
Hi,

Here is my attempt to add FFmpeg filter graphs integration to baresip.

Idea is to allow dynamically set video filter graph for current video stream. And then remove it when needed.
It's implemented as baresip filter module and command `/avfilter`. For example to enable `vflip` simple filter graph just call `/avfilter vflip` at any time and see how video is flipped. To disable filter graph just send `/avfilter` command without any filter string.
As more complex example you can apply some png overlay on top of current video stream with
`/avfilter movie=/path/to/some/image.png[pic];[in][pic]overlay=(W-w)/2:H-h-20` command.
Full syntax and list of filters are available on FFmpeg Filtegraph's page: https://ffmpeg.org/ffmpeg-filters.html#Filtergraph-description

I run into several issues during development:

### 1. Bottom-up FFmpeg frames.

It seems that FFmpeg frame structure could keep both top-down and bottom-up plane lines orders. In the last case
linesizes are negative and data pointers point to the last rows in the buffer. Baresip uses unsigned linesizes, so as I understand
it doesn't support bottom-up order. As workaround I had to rearrange plane lines in top-down order for such frames and
update linesizes/data pointers. So my question is how Baresip works with bottom-up frames and is my approach valid.

### 2. Moving data between AVFrame/vidframe structures

I wonder how properly work with FFmpeg AVFrame structure. Currently as I get new AVFrame from filter graph pipeline, I just
update incoming filter frame, setting data pointers and linesizes to AVframe data. It seems to work well and without any additional copying. Main question is when I supposed to unref AVFrame structure. Normally it should be done in the end of encoding pipeline, but filter module sits in the middle of pipeline and doesn't control it. Now I unref previous AVFrame before processing new one, assuming that previous encoding cycle is finished and it's safe to clean memory. Am I right or there is a more proper way to do it?

I don't have much experience with baresip modules and video processing, so any suggestions are greatly appreciated.

Thanks,
Mikhail