### PR TITLE
Update the re project to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Distributed under BSD license
 baresip is using GNU makefiles, and the following packages must be
 installed before building:
 
-* [libre](https://github.com/creytiv/re)
+* [libre](https://github.com/baresip/re)
 * [librem](https://github.com/creytiv/rem)
 * [openssl](https://www.openssl.org/)
 
@@ -437,6 +437,7 @@ zrtp          ZRTP media encryption module
 ## Related projects
 
 * [libre](https://github.com/creytiv/re)
+* [libre - baresip fork](https://github.com/baresip/re)
 * [librem](https://github.com/creytiv/rem)
 * [retest](https://github.com/creytiv/retest)
 * [restund](http://creytiv.com/restund.html)


### PR DESCRIPTION
When testing out the build system I'm updating I found a build error.
After a bit of searching I found I had the upstream libre, not the
forked version that's now required to build, yet I had followed the
README instructions.  This should hopefully stop others falling into the
same trap.