### PR TITLE
fixes #1044: correctly link against ffmpeg libraries

### DIFF
--- a/modules/avcodec/module.mk
+++ b/modules/avcodec/module.mk
@@ -11,7 +11,7 @@ $(MOD)_SRCS	+= encode.c
 $(MOD)_SRCS	+= h263.c
 $(MOD)_SRCS	+= h265.c
 $(MOD)_SRCS	+= sdp.c
-$(MOD)_CFLAGS	+= -isystem /usr/local/include
+$(MOD)_CFLAGS	+= -isystem /usr/local/include -static -fPIC
 $(MOD)_LFLAGS	+= `pkg-config --libs libavcodec libavutil`
 
 include mk/mod.mk

--- a/modules/avfilter/module.mk
+++ b/modules/avfilter/module.mk
@@ -8,6 +8,7 @@ MOD		:= avfilter
 $(MOD)_SRCS	+= avfilter.c
 $(MOD)_SRCS	+= filter.c
 $(MOD)_SRCS	+= util.c
+$(MOD)_CFLAGS	+= -static -fPIC
 $(MOD)_LFLAGS	+= -lavfilter -lavutil
 
 include mk/mod.mk

--- a/modules/avformat/module.mk
+++ b/modules/avformat/module.mk
@@ -8,6 +8,7 @@ MOD		:= avformat
 $(MOD)_SRCS	+= avformat.c
 $(MOD)_SRCS	+= audio.c
 $(MOD)_SRCS	+= video.c
+$(MOD)_CFLAGS	+= -static -fPIC
 $(MOD)_LFLAGS	+= \
 	`pkg-config --libs libavformat libavcodec libswresample \
 		libavutil libavdevice libavfilter libswscale libpostproc`


### PR DESCRIPTION
Compile avformat, avcodec and avfilter modules so that they
are correctly linked to the ffmpeg libraries.