### PR TITLE
menu: fix segfault in ua_event_handler (#1059)

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -1273,7 +1273,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_CALL_TRANSFER_FAILED:
 		info("menu: transfer failure: %s\n", prm);
-		mem_deref(call);
 		break;
 
 	case UA_EVENT_REGISTER_OK:
@@ -1290,7 +1289,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_AUDIO_ERROR:
 		info("menu: audio error (%s)\n", prm);
-		mem_deref(call);
 		break;
 
 	default:

--- a/src/call.c
+++ b/src/call.c
@@ -495,6 +495,8 @@ static void audio_error_handler(int err, const char *str, void *arg)
 	}
 
 	ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s", err, str);
+	call_stream_stop(call);
+	call_event_handler(call, CALL_EVENT_CLOSED, str);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -431,6 +431,7 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 	case CALL_EVENT_TRANSFER_FAILED:
 		ua_event(ua, UA_EVENT_CALL_TRANSFER_FAILED, call, str);
+		mem_deref(call);
 		break;
 
 	case CALL_EVENT_MENC:


### PR DESCRIPTION
A segfault occurs in modules loaded after menu and have an ua_event_handler
that use call object (to collect information about the call). The call object
may not be de-referenced in any ua_event_handler.