### PR TITLE
reg: view proxy expiry value in reg_status

### DIFF
--- a/src/reg.c
+++ b/src/reg.c
@@ -301,7 +301,8 @@ int reg_status(struct re_printf *pf, const struct reg *reg)
 	if (!reg)
 		return 0;
 
-	return re_hprintf(pf, " %s %s", print_scode(reg->scode), reg->srv);
+	return re_hprintf(pf, " %s %s Expires %us", print_scode(reg->scode),
+			reg->srv, sipreg_proxy_expires(reg->sipreg));
 }
 
 


### PR DESCRIPTION
This PR adds the proxies expiry value to the output of module menus command reginfo. It is based on the libre PR
https://github.com/baresip/re/pull/12.