### PR TITLE
account: add parameter rwait for re-register interval

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -19,6 +19,7 @@
 #    ;outbound2=sip:secondary.example.com
 #    ;ptime={10,20,30,40,...}
 #    ;regint=3600
+#    ;rwait=90
 #    ;pubint=0 (publishing off)
 #    ;regq=0.5
 #    ;sipnat={outbound}

--- a/src/account.c
+++ b/src/account.c
@@ -316,6 +316,12 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 
 	acc->regint = REG_INTERVAL + (rand_u32()&0xff);
 	err |= param_u32(&acc->regint, &aor->params, "regint");
+	err |= param_u32(&acc->rwait, &aor->params, "rwait");
+	if (acc->rwait > 95)
+		acc->rwait = 95;
+
+	if (acc->rwait && acc->rwait < 5)
+		acc->rwait = 5;
 
 	acc->pubint = 0;
 	err |= param_u32(&acc->pubint, &aor->params, "pubint");

--- a/src/core.h
+++ b/src/core.h
@@ -65,6 +65,7 @@ struct account {
 	char *outboundv[2];          /**< Optional SIP outbound proxies      */
 	uint32_t ptime;              /**< Configured packet time in [ms]     */
 	uint32_t regint;             /**< Registration interval in [seconds] */
+	uint32_t rwait;              /**< R. Int. in [%] from proxy expiry   */
 	uint32_t pubint;             /**< Publication interval in [seconds]  */
 	char *regq;                  /**< Registration Q-value               */
 	char *sipnat;                /**< SIP Nat mechanism                  */

--- a/src/reg.c
+++ b/src/reg.c
@@ -209,7 +209,10 @@ int reg_register(struct reg *reg, const char *reg_uri, const char *params,
 	if (err)
 		return err;
 
-	return 0;
+	if (acc->rwait)
+		err = sipreg_set_rwait(reg->sipreg, acc->rwait);
+
+	return err;
 }
 
 


### PR DESCRIPTION
Adds a parameter rwait to the account that set the re-register interval
relative to the proxy expiry time reported from the SIP proxy. This value was
hard-coded in libre to 90%.

This PR is based on libre PR https://github.com/baresip/re/pull/13.