### PR TITLE
call, stream, menu: add cmd to set the direction of video stream

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -183,6 +183,7 @@ int  call_progress(struct call *call);
 void call_hangup(struct call *call, uint16_t scode, const char *reason);
 int  call_modify(struct call *call);
 int  call_hold(struct call *call, bool hold);
+int  call_set_video_dir(struct call *call, enum sdp_dir dir);
 int  call_send_digit(struct call *call, char key);
 bool call_has_audio(const struct call *call);
 bool call_has_video(const struct call *call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -838,6 +838,34 @@ static int call_video_debug(struct re_printf *pf, void *unused)
 }
 
 
+static int set_video_dir(struct re_printf *pf, void *arg)
+{
+	const struct cmd_arg *carg = arg;
+	int err = 0;
+
+	if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_INACTIVE))) {
+		err = call_set_video_dir(ua_call(uag_current()), SDP_INACTIVE);
+	}
+	else if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_SENDONLY))) {
+		err = call_set_video_dir(ua_call(uag_current()), SDP_SENDONLY);
+	}
+	else if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_RECVONLY))) {
+		err = call_set_video_dir(ua_call(uag_current()), SDP_RECVONLY);
+	}
+	else if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_SENDRECV))) {
+		err = call_set_video_dir(ua_call(uag_current()), SDP_SENDRECV);
+	}
+	else {
+		(void)re_hprintf(pf, "Invalid video direction %s"
+			" (inactive, sendonly, recvonly, sendrecv)\n",
+			carg->prm);
+		return EINVAL;
+	}
+
+	return err;
+}
+
+
 static int digit_handler(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
@@ -969,6 +997,7 @@ static const struct cmd callcmdv[] = {
 {"statmode",    'S',       0, "Statusmode toggle",    toggle_statmode      },
 {"transfer",    't', CMD_PRM, "Transfer call",        call_xfer            },
 {"video_debug", 'V',       0, "Video stream",         call_video_debug     },
+{"video_dir",     0, CMD_PRM, "Set video direction",  set_video_dir        },
 
 /* Numeric keypad for DTMF events: */
 {NULL, '#',         0, NULL,                  digit_handler         },

--- a/src/call.c
+++ b/src/call.c
@@ -1172,6 +1172,24 @@ int call_hold(struct call *call, bool hold)
 }
 
 
+/**
+ * Sets the video direction of the given call
+ *
+ * @param call  Call object
+ * @param dir   SDP media direction
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int call_set_video_dir(struct call *call, enum sdp_dir dir)
+{
+	if (!call)
+		return EINVAL;
+
+	stream_set_ldir(video_strm(call_video(call)), dir);
+	return call_modify(call);
+}
+
+
 int call_sdp_get(const struct call *call, struct mbuf **descp, bool offer)
 {
 	if (!call)

--- a/src/core.h
+++ b/src/core.h
@@ -348,6 +348,7 @@ int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 void stream_update_encoder(struct stream *s, int pt_enc);
 int  stream_jbuf_stat(struct re_printf *pf, const struct stream *s);
 void stream_hold(struct stream *s, bool hold);
+void stream_set_ldir(struct stream *s, enum sdp_dir dir);
 void stream_set_srate(struct stream *s, uint32_t srate_tx, uint32_t srate_rx);
 void stream_send_fir(struct stream *s, bool pli);
 void stream_reset(struct stream *s);

--- a/src/stream.c
+++ b/src/stream.c
@@ -737,6 +737,23 @@ void stream_hold(struct stream *s, bool hold)
 }
 
 
+void stream_set_ldir(struct stream *s, enum sdp_dir dir)
+{
+	if (!s)
+		return;
+
+	if (dir == SDP_INACTIVE) {
+		sdp_media_set_disabled(s->sdp, true);
+	}
+	else {
+		sdp_media_set_disabled(s->sdp, false);
+		sdp_media_set_ldir(s->sdp, dir);
+	}
+
+	stream_reset(s);
+}
+
+
 void stream_set_srate(struct stream *s, uint32_t srate_tx, uint32_t srate_rx)
 {
 	if (!s)


### PR DESCRIPTION
This commit adds a command for the user to specify the video stream direction.
Possible directions:

    none: disable the video at all
    send: the client does not accept a video stream but will send a video steam
    receive: the client will receive and display a video stream but will NOT send a video stream
    duplex: normal bidirectional video call
