### PR TITLE
ua, menue: new command to print certificate issuer and subject

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -812,6 +812,7 @@ const char  *uag_event_str(enum ua_event ev);
 struct list *uag_list(void);
 void         uag_current_set(struct ua *ua);
 struct ua   *uag_current(void);
+struct tls  *uag_tls(void);
 struct sipsess_sock  *uag_sipsess_sock(void);
 struct sipevent_sock *uag_sipevent_sock(void);
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -471,6 +471,54 @@ static int cmd_ua_delete(struct re_printf *pf, void *arg)
 }
 
 
+#ifdef USE_TLS
+static int cmd_tls_issuer(struct re_printf *pf, void *unused)
+{
+	int err = 0;
+	struct mbuf *mb;
+
+	mb = mbuf_alloc(20);
+	if (!mb)
+		return ENOMEM;
+
+	err = tls_get_issuer(uag_tls(), mb);
+	if (err){
+		warning("menu: Unable to get certificate issuer (%m)\n", err);
+		goto out;
+	}
+
+	(void)re_hprintf(pf, "TLS Cert Issuer: %b\n", mb->buf, mb->pos);
+
+ out:
+	mem_deref(mb);
+	return err;
+}
+
+
+static int cmd_tls_subject(struct re_printf *pf, void *unused)
+{
+	int err = 0;
+	struct mbuf *mb;
+
+	mb = mbuf_alloc(20);
+	if (!mb)
+		return ENOMEM;
+
+	err = tls_get_subject(uag_tls(), mb);
+	if (err) {
+		warning("menu: Unable to get certificate subject (%m)\n", err);
+		goto out;
+	}
+
+	(void)re_hprintf(pf, "TLS Cert Subject: %b\n", mb->buf, mb->pos);
+
+ out:
+	mem_deref(mb);
+	return err;
+}
+#endif
+
+
 static int print_commands(struct re_printf *pf, void *unused)
 {
 	(void)unused;
@@ -527,6 +575,10 @@ static const struct cmd cmdv[] = {
 {"uanew",     0,    CMD_PRM, "Create User-Agent",       create_ua            },
 {"uadel",     0,    CMD_PRM, "Delete User-Agent",       cmd_ua_delete        },
 {"uafind",    0,    CMD_PRM, "Find User-Agent <aor>",   cmd_ua_find          },
+#ifdef USE_TLS
+{"tlsissuer", 0,          0, "TLS certificate issuer",  cmd_tls_issuer    },
+{"tlssubject",0,          0, "TLS certificate subject", cmd_tls_subject   },
+#endif
 {"ausrc",     0,    CMD_PRM, "Switch audio source",     switch_audio_source  },
 {"auplay",    0,    CMD_PRM, "Switch audio player",     switch_audio_player  },
 {"about",     0,          0, "About box",               about_box            },

--- a/src/ua.c
+++ b/src/ua.c
@@ -2238,6 +2238,21 @@ struct ua *uag_current(void)
 
 
 /**
+ * Get UAG-TLS Context
+ *
+ * @return TLS Context if used, NULL otherwise
+ */
+struct tls *uag_tls(void)
+{
+#ifdef USE_TLS
+	return uag.tls ? uag.tls : NULL;
+#else
+	return NULL;
+#endif
+}
+
+
+/**
  * Set the preferred address family for media
  *
  * @param ua       User-Agent


### PR DESCRIPTION
With these two commands a user can print the issuers and subjects of the certificate chain stored in SIP_certificate