### PR TITLE
ua: use configurable TCP idle timeout

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -55,6 +55,7 @@ rtp_stats		no
 #dns_server		1.1.1.1:53
 #dns_server		1.0.0.1:53
 #net_interface		wlan1
+#tcp_timeout		180
 
 #------------------------------------------------------------------------------
 # Modules

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -277,6 +277,7 @@ struct config_sip {
 	char local[64];         /**< Local SIP Address              */
 	char cert[256];         /**< SIP Certificate                */
 	char cafile[256];       /**< SIP CA-file                    */
+	uint16_t tcp_timeout;   /**< TCP idle timeout               */
 };
 
 /** Call config */

--- a/modules/dtls_srtp/dtls_srtp.c
+++ b/modules/dtls_srtp/dtls_srtp.c
@@ -473,10 +473,12 @@ static struct menc dtls_srtp = {
 
 static int module_init(void)
 {
+	struct config *cfg = conf_config();
 	struct list *mencl = baresip_mencl();
 	int err;
 
-	err = tls_alloc(&tls, TLS_METHOD_DTLSV1, NULL, NULL);
+	err = tls_alloc(&tls, TLS_METHOD_DTLSV1, cfg->sip.tcp_timeout,
+			NULL, NULL);
 	if (err) {
 		warning("dtls_srtp: failed to create DTLS context (%m)\n",
 			err);

--- a/src/config.c
+++ b/src/config.c
@@ -247,6 +247,9 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   sizeof(cfg->sip.cert));
 	(void)conf_get_str(conf, "sip_cafile", cfg->sip.cafile,
 			   sizeof(cfg->sip.cafile));
+	cfg->sip.tcp_timeout = TCP_IDLE_TIMEOUT;
+	if (!conf_get_u32(conf, "tcp_timeout", &v))
+		cfg->sip.tcp_timeout = v;
 
 	/* Call */
 	(void)conf_get_u32(conf, "call_local_timeout",

--- a/src/ua.c
+++ b/src/ua.c
@@ -1337,7 +1337,8 @@ static int add_transp_af(const struct sa *laddr)
 	if (uag.use_udp)
 		err |= sip_transp_add(uag.sip, SIP_TRANSP_UDP, &local);
 	if (uag.use_tcp)
-		err |= sip_transp_add(uag.sip, SIP_TRANSP_TCP, &local);
+		err |= sip_transp_add(uag.sip, SIP_TRANSP_TCP, &local,
+					uag.cfg->tcp_timeout);
 	if (err) {
 		warning("ua: SIP Transport failed: %m\n", err);
 		return err;
@@ -1355,7 +1356,7 @@ static int add_transp_af(const struct sa *laddr)
 			}
 
 			err = tls_alloc(&uag.tls, TLS_METHOD_SSLV23,
-					cert, NULL);
+					uag.cfg->tcp_timeout, cert, NULL);
 			if (err) {
 				warning("ua: tls_alloc() failed: %m\n", err);
 				return err;


### PR DESCRIPTION
The idle timeout of the TCP connection can be changed
by the user if needed.