### PR TITLE
Add a HTTP request module with authorization

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -152,6 +152,7 @@ module_app		menu.so
 module_app		vidloop.so
 # module_app		ctrl_dbus.so
 # ctrl_dbus_use		system       # system, session
+# module_app		httpreq.so
 
 
 #------------------------------------------------------------------------------
@@ -220,3 +221,4 @@ video_selfview		window # {window,pip}
 
 # EBU ACIP
 #ebuacip_jb_type     	fixed   # auto,fixed
+

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -222,3 +222,11 @@ video_selfview		window # {window,pip}
 # EBU ACIP
 #ebuacip_jb_type     	fixed   # auto,fixed
 
+# HTTP request module
+# httpreq_ca		trusted1.pem
+# httpreq_ca		trusted2.pem
+# httpreq_dns		1.1.1.1
+# httpreq_dns		8.8.8.8
+# httpreq_hostname	myserver
+# httpreq_cert		cert.pem
+# httpreq_key		key.pem

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -28,6 +28,7 @@
 #   USE_GST           Gstreamer audio module
 #   USE_GST_VIDEO     Gstreamer video module
 #   USE_GTK           GTK+ user interface
+#   USE_HTTPREQ       HTTP request module
 #   USE_ILBC          iLBC audio codec
 #   USE_ISAC          iSAC audio codec
 #   USE_JACK          JACK Audio Connection Kit audio driver
@@ -65,6 +66,7 @@ USE_CONS  := 1
 USE_G711  := 1
 USE_L16   := 1
 USE_DBUS  := 1
+USE_HTTPREQ  := 1
 
 ifneq ($(OS),win32)
 
@@ -383,6 +385,9 @@ MODULES   += gst_video
 endif
 ifneq ($(USE_GTK),)
 MODULES   += gtk
+endif
+ifneq ($(USE_HTTPREQ),)
+MODULES   += httpreq
 endif
 ifneq ($(USE_ILBC),)
 MODULES   += ilbc

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -18,11 +18,13 @@
  * Combines libre structs http_cli and http_reqcon to provide HTTP requests.
  * Supports:
  *   - GET, POST requests
- *   - basic, digest authentication
+ *   - basic, digest and bearer authentication
  *
  * Commands:
  * http_setauth     - Sets user and password. If no parameter is specified then
  *                    user and password is cleared.
+ * http_setbearer   - Sets bearer token. If no parameter is specified then the
+ *                    bearer is cleared.
  * http_setbody     - Sets HTTP body (for POST, PUT requests). If no parameter
  *                    is specified then the body is cleared.
  * http_settimeout  - Sets timeout (currently) only for DNS requests.
@@ -216,6 +218,18 @@ static int cmd_setauth(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_setbearer(struct re_printf *pf, void *arg)
+{
+	struct pl pl;
+	struct pl *plp = &pl;
+	int err = pl_opt_arg(&plp, arg);
+	if (err)
+		return err;
+
+	return http_reqconn_set_bearer(d->conn, plp);
+}
+
+
 static int cmd_setbody(struct re_printf *pf, void *arg)
 {
 	struct pl pl;
@@ -290,6 +304,7 @@ static const struct cmd cmdv[] = {
 {"http_get",  0, CMD_PRM, "httpreq: send HTTP GET request",  cmd_httpget  },
 {"http_post", 0, CMD_PRM, "httpreq: send HTTP POST request", cmd_httppost },
 {"http_setauth", 0, CMD_PRM, "httpreq: set user and password", cmd_setauth },
+{"http_setbearer", 0, CMD_PRM, "httpreq: set bearer token", cmd_setbearer },
 {"http_setbody", 0, CMD_PRM, "httpreq: set body", cmd_setbody },
 {"http_settimeout", 0, CMD_PRM, "httpreq: set timeout in ms", cmd_settimeout },
 {"http_setctype", 0, CMD_PRM, "httpreq: set content-type", cmd_setctype },

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -26,6 +26,8 @@
  * http_setbody     - Sets HTTP body (for POST, PUT requests). If no parameter
  *                    is specified then the body is cleared.
  * http_settimeout  - Sets timeout (currently) only for DNS requests.
+ * http_setctype    - Sets content type for HTTP header. If no parameter is
+ *                    specified then the content type is cleared.
  * http_clear       - Clears all internal data.
  * http_get         - Sends an HTTP GET request and performs authentication if
  *                    requested by the HTTP server and http_setauth was invoked
@@ -224,6 +226,18 @@ static int cmd_setbody(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_setctype(struct re_printf *pf, void *arg)
+{
+	struct pl pl;
+	struct pl *plp = &pl;
+	int err = pl_opt_arg(&plp, arg);
+	if (err)
+		return err;
+
+	return http_reqconn_set_ctype(d->conn, plp);
+}
+
+
 static int cmd_clear(struct re_printf *pf, void *arg)
 {
 	(void) arg;
@@ -255,6 +269,7 @@ static const struct cmd cmdv[] = {
 {"http_setauth", 0, CMD_PRM, "httpreq: set user and password", cmd_setauth },
 {"http_setbody", 0, CMD_PRM, "httpreq: set body", cmd_setbody },
 {"http_settimeout", 0, CMD_PRM, "httpreq: set timeout in ms", cmd_settimeout },
+{"http_setctype", 0, CMD_PRM, "httpreq: set content-type", cmd_setctype },
 {"http_clear", 0, CMD_PRM, "httpreq: clear all internal data", cmd_clear },
 
 };

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -28,6 +28,8 @@
  * http_settimeout  - Sets timeout (currently) only for DNS requests.
  * http_setctype    - Sets content type for HTTP header. If no parameter is
  *                    specified then the content type is cleared.
+ * http_addheader   - Adds a custom header (without newline).
+ * http_clrheaders  - Clears all custom headers.
  * http_clear       - Clears all internal data.
  * http_get         - Sends an HTTP GET request and performs authentication if
  *                    requested by the HTTP server and http_setauth was invoked
@@ -238,6 +240,27 @@ static int cmd_setctype(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_addheader(struct re_printf *pf, void *arg)
+{
+	struct pl pl = PL_INIT;
+	int err = pl_set_arg(&pl, arg);
+	if (err) {
+		re_hprintf(pf, "Usage:\nhttp_addheader <header>\n");
+		return err;
+	}
+
+	return http_reqconn_add_header(d->conn, &pl);
+}
+
+
+static int cmd_clrheader(struct re_printf *pf, void *arg)
+{
+	(void) arg;
+	(void) http_reqconn_clr_header(d->conn);
+	return 0;
+}
+
+
 static int cmd_clear(struct re_printf *pf, void *arg)
 {
 	(void) arg;
@@ -270,6 +293,10 @@ static const struct cmd cmdv[] = {
 {"http_setbody", 0, CMD_PRM, "httpreq: set body", cmd_setbody },
 {"http_settimeout", 0, CMD_PRM, "httpreq: set timeout in ms", cmd_settimeout },
 {"http_setctype", 0, CMD_PRM, "httpreq: set content-type", cmd_setctype },
+{"http_addheader", 0, CMD_PRM, "httpreq: add a custom header "
+	"(without newline)", cmd_addheader },
+{"http_clrheaders", 0, CMD_PRM, "httpreq: clear custom headers",
+	cmd_clrheader },
 {"http_clear", 0, CMD_PRM, "httpreq: clear all internal data", cmd_clear },
 
 };

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -25,6 +25,7 @@
  *                    user and password is cleared.
  * http_setbody     - Sets HTTP body (for POST, PUT requests). If no parameter
  *                    is specified then the body is cleared.
+ * http_settimeout  - Sets timeout (currently) only for DNS requests.
  * http_clear       - Clears all internal data.
  * http_get         - Sends an HTTP GET request and performs authentication if
  *                    requested by the HTTP server and http_setauth was invoked
@@ -232,12 +233,28 @@ static int cmd_clear(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_settimeout(struct re_printf *pf, void *arg)
+{
+	const struct cmd_arg *carg = arg;
+	uint32_t v;
+	int err = ensure_carg_alloc(carg);
+	if (err) {
+		re_hprintf(pf, "Usage:\nhttp_settimeout <ms>\n");
+		return err;
+	}
+
+	v = (uint32_t) atoi(carg->prm);
+	return http_client_set_timeout(d->client, v);
+}
+
+
 static const struct cmd cmdv[] = {
 
 {"http_get",  0, CMD_PRM, "httpreq: send HTTP GET request",  cmd_httpget  },
 {"http_post", 0, CMD_PRM, "httpreq: send HTTP POST request", cmd_httppost },
 {"http_setauth", 0, CMD_PRM, "httpreq: set user and password", cmd_setauth },
 {"http_setbody", 0, CMD_PRM, "httpreq: set body", cmd_setbody },
+{"http_settimeout", 0, CMD_PRM, "httpreq: set timeout in ms", cmd_settimeout },
 {"http_clear", 0, CMD_PRM, "httpreq: clear all internal data", cmd_clear },
 
 };

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -1,0 +1,203 @@
+/**
+ * @file httpreq.c HTTP request module
+ *
+ * Copyright (C) 2020 Commend.com - c.spielberger@commend.com
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <re.h>
+#include <baresip.h>
+
+
+/**
+ * @defgroup httpreq httpreq
+ *
+ * HTTP request client connection
+ *
+ * Combines libre structs http_cli and http_reqcon to provide HTTP requests.
+ * Supports:
+ *   - GET requests
+ *
+ * Commands:
+ * http_clear       - Clears all internal data.
+ * http_get         - Sends an HTTP GET request.
+ */
+
+struct httpreq_data {
+	const struct config_net *cfg;
+	struct http_cli *client;
+	struct http_reqconn *conn;
+};
+
+
+static void destructor(void *arg)
+{
+	struct httpreq_data *d = arg;
+	mem_deref(d->client);
+	mem_deref(d->conn);
+}
+
+
+static struct httpreq_data *d = NULL;
+
+
+static void http_resph(int err, const struct http_msg *msg, void *arg)
+{
+	(void) arg;
+	struct pl pl;
+	const struct pl *v;
+	const struct http_hdr *hdr;
+
+	if (err) {
+		warning("httpreq: HTTP response error (%m)\n", err);
+	}
+	else if (!msg) {
+		warning("httpreq: HTTP empty response\n");
+	}
+	else {
+		hdr = http_msg_hdr(msg, HTTP_HDR_CONTENT_TYPE);
+		v = &hdr->val;
+		info("httpreq: HTTP response:\n");
+		re_fprintf(stdout, "%H\n", http_msg_print,  msg);
+		if (msg->mb && !re_regex(v->p, v->l, "text/")) {
+			pl_set_mbuf(&pl, msg->mb);
+			re_fprintf(stdout, "\n%r\n", &pl);
+		}
+	}
+}
+
+
+static int ensure_alloc(void)
+{
+	int err = 0;
+	struct network *net = baresip_network();
+
+	if (!net) {
+		warning("httpreq: no baresip network\n");
+		return err;
+	}
+
+	if (!d->client)
+		err = http_client_alloc(&d->client, net_dnsc(net));
+
+	if (err) {
+		warning("httpreq: could not alloc http client\n");
+		return err;
+	}
+
+	if (!d->conn)
+		err = http_reqconn_alloc(&d->conn, d->client, http_resph, NULL,
+				NULL);
+
+	if (err)
+		warning("httpreq: could not alloc http request connection\n");
+
+	return err;
+}
+
+
+static int ensure_carg_alloc(const struct cmd_arg *carg)
+{
+	if (!carg || !str_isset(carg->prm))
+		return EINVAL;
+
+	return ensure_alloc();
+}
+
+
+static int pl_set_arg(struct pl *pl, const struct cmd_arg *carg)
+{
+	int err = ensure_carg_alloc(carg);
+	if (err)
+		return err;
+
+	pl->p = carg->prm;
+	pl->l = strlen(carg->prm);
+	return 0;
+}
+
+
+static int send_request(struct re_printf *pf, void *arg, const struct pl *met)
+{
+	struct pl uri;
+	int err = pl_set_arg(&uri, arg);
+	if (err)
+		return err;
+
+	err = http_reqconn_set_method(d->conn, met);
+	if (err)
+		return err;
+
+	err = http_reqconn_send(d->conn, &uri);
+	return err;
+}
+
+
+static int cmd_httpget(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	struct pl pl = PL("GET");
+
+	err = send_request(pf, arg, &pl);
+	if (err)
+		re_hprintf(pf, "Usage:\nhttp_get <uri>\n");
+
+	return err;
+}
+
+
+static int cmd_clear(struct re_printf *pf, void *arg)
+{
+	(void) arg;
+	d->conn = mem_deref(d->conn);
+	d->client = mem_deref(d->client);
+	return 0;
+}
+
+
+static const struct cmd cmdv[] = {
+
+{"http_get",  0, CMD_PRM, "httpreq: send HTTP GET request",  cmd_httpget  },
+{"http_clear", 0, CMD_PRM, "httpreq: clear all internal data", cmd_clear },
+
+};
+
+
+static int module_init(void)
+{
+	int err = 0;
+
+	info("httpreq: module init\n");
+	d = mem_zalloc(sizeof(*d), destructor);
+	if (!d)
+		return ENOMEM;
+
+	d->cfg = &conf_config()->net;
+	err = cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
+	if (err) {
+		d->client = mem_deref(d->client);
+		d->conn = mem_deref(d->conn);
+	}
+
+	return err;
+}
+
+
+static int module_close(void)
+{
+	info("httpreq: module closed\n");
+
+	cmd_unregister(baresip_commands(), cmdv);
+	d = mem_deref(d);
+
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(httpreq) = {
+	"httpreq",
+	"application",
+	module_init,
+	module_close
+};

--- a/modules/httpreq/module.mk
+++ b/modules/httpreq/module.mk
@@ -1,0 +1,10 @@
+#
+# module.mk
+#
+# Copyright (C) 2020 Commend.com - Christian Spielberger
+#
+
+MOD		:= httpreq
+$(MOD)_SRCS	+= httpreq.c
+
+include mk/mod.mk

--- a/src/config.c
+++ b/src/config.c
@@ -884,6 +884,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module_app\t\t" "mqtt" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module_app\t\t" "ctrl_tcp" MOD_EXT "\n");
 	(void)re_fprintf(f, "module_app\t\t" "vidloop"MOD_EXT"\n");
+	(void)re_fprintf(f, "#module_app\t\t" "httpreq"MOD_EXT"\n");
 	(void)re_fprintf(f, "\n");
 
 	(void)re_fprintf(f, "\n#------------------------------------"

--- a/src/config.c
+++ b/src/config.c
@@ -975,6 +975,17 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "\n# EBU ACIP\n"
 			 "#ebuacip_jb_type\tfixed\t# auto,fixed\n");
 
+	(void)re_fprintf(f,
+			 "\n# HTTP request module\n"
+			 "# httpreq_ca\t\ttrusted1.pem\n"
+			 "# httpreq_ca\t\ttrusted2.pem\n"
+			 "# httpreq_dns\t\t1.1.1.1\n"
+			 "# httpreq_dns\t\t8.8.8.8\n"
+			 "# httpreq_hostname\tmyserver\n"
+			 "# httpreq_cert\t\tcert.pem\n"
+			 "# httpreq_key\t\tkey.pem\n"
+			 );
+
 	if (f)
 		(void)fclose(f);
 


### PR DESCRIPTION
Provides the HTTP request feature of https://github.com/baresip/re/pull/33 in form of a new baresip module "httpreq".
- Makes use of struct network which also was moved to libre.
- GET, POST requests
- TLS
- basic, digest and bearer authentication

PR https://github.com/baresip/re/pull/34 adds struct network to libre.

Travis will be happy if https://github.com/baresip/re/pull/33 and https://github.com/baresip/re/pull/34 are merged.