### PR TITLE
Menu: corrections for ring tones and call status by means of a global call counter

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -816,6 +816,7 @@ struct ua   *uag_find_param(const char *name, const char *val);
 struct sip  *uag_sip(void);
 const char  *uag_event_str(enum ua_event ev);
 struct list *uag_list(void);
+uint32_t     uag_call_count(void);
 void         uag_current_set(struct ua *ua);
 struct ua   *uag_current(void);
 struct tls  *uag_tls(void);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -355,10 +355,6 @@ static int cmd_hangup(struct re_printf *pf, void *unused)
 	(void)pf;
 	(void)unused;
 
-	/* Stop any ongoing ring-tones */
-	menu.play = mem_deref(menu.play);
-	alert_stop();
-
 	ua_hangup(uag_current(), NULL, 0, NULL);
 
 	/* note: must be called after ua_hangup() */

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -164,6 +164,30 @@ static void play_resume(const struct call *call)
 }
 
 
+static bool has_established_call(void)
+{
+	struct le *lec;
+	struct le *leu;
+
+	for (leu = uag_list()->head; leu; leu = leu->next) {
+		struct ua *ua = leu->data;
+
+		for (lec = ua_calls(ua)->head; lec; lec = lec->next) {
+
+			switch (call_state(lec->data)) {
+			case CALL_STATE_EARLY:
+			case CALL_STATE_ESTABLISHED:
+				return true;
+			default:
+				break;
+			}
+		}
+	}
+
+	return false;
+}
+
+
 static void check_registrations(void)
 {
 	static bool ual_ready = false;
@@ -1294,7 +1318,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_CALL_RINGING:
-		if (call == ua_call(uag_current()))
+		if (call == ua_call(uag_current()) && !has_established_call())
 			play_ringback();
 		break;
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -1252,6 +1252,9 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_CALL_RINGING:
+		if (call != ua_call(uag_current()))
+			break;
+
 		/* stop any ringtones */
 		menu.play = mem_deref(menu.play);
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -1317,6 +1317,9 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			play_ringback();
 		break;
 
+	case UA_EVENT_CALL_PROGRESS:
+		if (call == ua_call(uag_current()))
+			menu.play = mem_deref(menu.play);
 		break;
 
 	case UA_EVENT_CALL_ESTABLISHED:

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -46,7 +46,7 @@ static struct {
 
 
 static int  menu_set_incall(bool incall);
-static void update_callstatus(void);
+static void update_callstatus(bool incall);
 static void alert_stop(void);
 static int switch_audio_source(struct re_printf *pf, void *arg);
 static int switch_audio_player(struct re_printf *pf, void *arg);
@@ -489,7 +489,7 @@ static int cmd_ua_next(struct re_printf *pf, void *unused)
 
 	uag_current_set(list_ledata(menu.le_cur));
 
-	update_callstatus();
+	update_callstatus(uag_call_count());
 
 	return err;
 }
@@ -513,7 +513,7 @@ static int cmd_ua_find(struct re_printf *pf, void *arg)
 
 	uag_current_set(ua);
 
-	update_callstatus();
+	update_callstatus(uag_call_count());
 
 	return 0;
 }
@@ -1193,10 +1193,10 @@ static void tmrstat_handler(void *arg)
 }
 
 
-static void update_callstatus(void)
+static void update_callstatus(bool incall)
 {
 	/* if there are any active calls, enable the call status view */
-	if (uag_call_count())
+	if (incall)
 		tmr_start(&menu.tmr_stat, 100, tmrstat_handler, 0);
 	else
 		tmr_cancel(&menu.tmr_stat);
@@ -1268,6 +1268,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			     struct call *call, const char *prm, void *arg)
 {
 	struct call *call2 = NULL;
+	bool incall;
 	int err;
 	(void)prm;
 	(void)arg;
@@ -1414,9 +1415,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 	}
 
-	menu_set_incall(ev == UA_EVENT_CALL_CLOSED ?
-			uag_call_count() > 1 : uag_call_count());
-	update_callstatus();
+	incall = ev == UA_EVENT_CALL_CLOSED ?
+			uag_call_count() > 1 : uag_call_count();
+	menu_set_incall(incall);
+	update_callstatus(incall);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1532,7 +1532,7 @@ static void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 
 	/* handle multiple calls */
 	if (config->call.max_calls &&
-	    list_count(&ua->calls) + 1 > config->call.max_calls) {
+	    uag_call_count() + 1 > config->call.max_calls) {
 
 		info("ua: rejected call from %r (maximum %d calls)\n",
 		     &msg->from.auri, config->call.max_calls);
@@ -2153,6 +2153,26 @@ void ua_pub_gruu_set(struct ua *ua, const struct pl *pval)
 struct list *uag_list(void)
 {
 	return &uag.ual;
+}
+
+
+/**
+ * Counts the calls from all user agents.
+ *
+ * @return the number of calls over all user agents.
+ */
+uint32_t uag_call_count(void)
+{
+	struct le *le;
+	uint32_t c = 0;
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		c += list_count(&ua->calls);
+	}
+
+	return c;
 }
 
 

--- a/test/call.c
+++ b/test/call.c
@@ -640,8 +640,10 @@ int test_call_max(void)
 	unsigned i;
 	int err = 0;
 
-	/* Set the max-calls limit */
-	conf_config()->call.max_calls = 1;
+	/* Set the max-calls limit to accept 1 incoming call. */
+	/* We start 2 calls from a.ua to b.ua. */
+	/* This are 2 outgoing calls and 1 incoming. */
+	conf_config()->call.max_calls = 3;
 
 	fixture_init(f);
 


### PR DESCRIPTION
ua: count calls globally for max_calls check
menu: for an outgoing call only play ringback for the current call
menu: remove redundant stop of play tone in cmd_hangup
menu: on call termination resume adequate play tone
menu: stop play tone also for call progress
menu: remove redundant call to menu_set_incall()
menu: correct incall decision for update_callstatus()
menu: do not start ringback tone during established call
