### PR TITLE
make EXTRA_MODULES last, not first

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -268,7 +268,6 @@ endif
 
 # ------------------------------------------------------------------------- #
 
-MODULES   += $(EXTRA_MODULES)
 ifneq ($(BASIC_MODULES),no)
 MODULES   += account
 MODULES   += auloop
@@ -478,3 +477,5 @@ endif
 ifneq ($(USE_RTCPSUMMARY),)
 MODULES   += rtcpsummary
 endif
+
+MODULES   += $(EXTRA_MODULES)


### PR DESCRIPTION
Make and link EXTRA_MODULES last so that when they are linked, their static libs don't get used by non-extra modules.
