### PR TITLE
Adaptive jbuf

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -48,6 +48,7 @@ rtp_tos			184
 #rtp_bandwidth		512-1024 # [kbit/s]
 rtcp_mux		no
 jitter_buffer_delay	5-10		# frames
+#jitter_buffer_wish	6		# frames for start
 rtp_stats		no
 #rtp_timeout		60
 

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -47,6 +47,7 @@ rtp_tos			184
 #rtp_ports		10000-20000
 #rtp_bandwidth		512-1024 # [kbit/s]
 rtcp_mux		no
+jitter_buffer_type	fixed		# off, fixed, adaptive
 jitter_buffer_delay	5-10		# frames
 #jitter_buffer_wish	6		# frames for start
 rtp_stats		no

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -331,6 +331,7 @@ struct config_avt {
 	struct range rtp_bw;    /**< RTP Bandwidth range [bit/s]    */
 	bool rtcp_mux;          /**< RTP/RTCP multiplexing          */
 	struct range jbuf_del;  /**< Delay, number of frames        */
+	uint32_t jbuf_wish;     /**< Startup wish delay of frames   */
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 };

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -330,6 +330,7 @@ struct config_avt {
 	struct range rtp_ports; /**< RTP port range                 */
 	struct range rtp_bw;    /**< RTP Bandwidth range [bit/s]    */
 	bool rtcp_mux;          /**< RTP/RTCP multiplexing          */
+	enum jbuf_type jbtype;  /**< Jitter buffer type             */
 	struct range jbuf_del;  /**< Delay, number of frames        */
 	uint32_t jbuf_wish;     /**< Startup wish delay of frames   */
 	bool rtp_stats;         /**< Enable RTP statistics          */

--- a/src/config.c
+++ b/src/config.c
@@ -74,6 +74,7 @@ static struct config core_config = {
 		{0, 0},
 		false,
 		{5, 10},
+		0,
 		false,
 		0
 	},
@@ -336,6 +337,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_bool(conf, "rtcp_mux", &cfg->avt.rtcp_mux);
 	(void)conf_get_range(conf, "jitter_buffer_delay",
 			     &cfg->avt.jbuf_del);
+	(void)conf_get_u32(conf, "jitter_buffer_wish",
+			     &cfg->avt.jbuf_wish);
 	(void)conf_get_bool(conf, "rtp_stats", &cfg->avt.rtp_stats);
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
@@ -406,6 +409,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtp_bandwidth\t\t%H\n"
 			 "rtcp_mux\t\t%s\n"
 			 "jitter_buffer_delay\t%H\n"
+			 "jitter_buffer_wish\t%u\n"
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "\n"
@@ -439,6 +443,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 range_print, &cfg->avt.rtp_bw,
 			 cfg->avt.rtcp_mux ? "yes" : "no",
 			 range_print, &cfg->avt.jbuf_del,
+			 cfg->avt.jbuf_wish,
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 
@@ -611,6 +616,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#rtp_bandwidth\t\t512-1024 # [kbit/s]\n"
 			  "rtcp_mux\t\tno\n"
 			  "jitter_buffer_delay\t%u-%u\t\t# frames\n"
+			  "#jitter_buffer_wish\t%u\t\t# frames for start\n"
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "\n# Network\n"
@@ -619,6 +625,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#dns_fallback\t\t8.8.8.8:53\n"
 			  "#net_interface\t\t%H\n",
 			  cfg->avt.jbuf_del.min, cfg->avt.jbuf_del.max,
+			  cfg->avt.jbuf_del.min + 1,
 			  default_interface_print, NULL);
 
 	return err;

--- a/src/core.h
+++ b/src/core.h
@@ -363,8 +363,6 @@ void stream_reset(struct stream *s);
 void stream_set_bw(struct stream *s, uint32_t bps);
 int  stream_print(struct re_printf *pf, const struct stream *s);
 void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
-int  stream_jbuf_reset(struct stream *strm,
-		       uint32_t frames_min, uint32_t frames_max);
 bool stream_is_ready(const struct stream *strm);
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -364,6 +364,7 @@ void stream_set_bw(struct stream *s, uint32_t bps);
 int  stream_print(struct re_printf *pf, const struct stream *s);
 void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 bool stream_is_ready(const struct stream *strm);
+int  stream_decode(struct stream *s);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -365,6 +365,7 @@ int  stream_print(struct re_printf *pf, const struct stream *s);
 void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 bool stream_is_ready(const struct stream *strm);
 int  stream_decode(struct stream *s);
+void stream_silence_on(struct stream *s, bool on);
 
 
 /*

--- a/src/stream.c
+++ b/src/stream.c
@@ -362,6 +362,12 @@ int stream_decode(struct stream *s)
 }
 
 
+void stream_silence_on(struct stream *s, bool on)
+{
+	jbuf_silence(s->jbuf, on);
+}
+
+
 static void rtcp_handler(const struct sa *src, struct rtcp_msg *msg, void *arg)
 {
 	struct stream *s = arg;

--- a/src/stream.c
+++ b/src/stream.c
@@ -322,7 +322,8 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 			s->metric_rx.n_err++;
 		}
 
-		if (s->type == MEDIA_VIDEO) {
+		if (s->type == MEDIA_VIDEO ||
+			s->cfg.jbtype == JBUF_FIXED) {
 
 			if (stream_decode(s) == EAGAIN)
 				(void) stream_decode(s);
@@ -544,10 +545,12 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		goto out;
 
 	/* Jitter buffer */
-	if (cfg->jbuf_del.min && cfg->jbuf_del.max) {
+	if (cfg->jbtype != JBUF_OFF &&
+			cfg->jbuf_del.min && cfg->jbuf_del.max) {
 
 		err  = jbuf_alloc(&s->jbuf, cfg->jbuf_del.min,
 				cfg->jbuf_del.max);
+		err |= jbuf_set_type(s->jbuf, cfg->jbtype);
 		err |= jbuf_set_wish(s->jbuf, cfg->jbuf_wish);
 		if (err)
 			goto out;

--- a/src/stream.c
+++ b/src/stream.c
@@ -534,8 +534,9 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	/* Jitter buffer */
 	if (cfg->jbuf_del.min && cfg->jbuf_del.max) {
 
-		err = jbuf_alloc(&s->jbuf, cfg->jbuf_del.min,
-				 cfg->jbuf_del.max);
+		err  = jbuf_alloc(&s->jbuf, cfg->jbuf_del.min,
+				cfg->jbuf_del.max);
+		err |= jbuf_set_wish(s->jbuf, cfg->jbuf_wish);
 		if (err)
 			goto out;
 	}

--- a/src/stream.c
+++ b/src/stream.c
@@ -1025,21 +1025,6 @@ uint32_t stream_metric_get_rx_n_err(const struct stream *strm)
 }
 
 
-int stream_jbuf_reset(struct stream *strm,
-		      uint32_t frames_min, uint32_t frames_max)
-{
-	if (!strm)
-		return EINVAL;
-
-	strm->jbuf = mem_deref(strm->jbuf);
-
-	if (frames_min && frames_max)
-		return jbuf_alloc(&strm->jbuf, frames_min, frames_max);
-
-	return 0;
-}
-
-
 bool stream_is_ready(const struct stream *strm)
 {
 	if (!strm)


### PR DESCRIPTION
    audio, stream: put to and get from jitter buffer in two threads
    
    During a call there is the RTP receive thread (A) and the auplay thread (B).
    Previously the two threads had been connected by an aubuf. Thread A put the
    RTP packets in the jbuf and also did a get in the same thread. Thus jbuf did
    not really work as jitter buffer. Thread A did also the decoding and pushed the
    data into the aubuf. Thread B fetched the data from the aubuf and pushed it to
    the audio device.
    
![aubuf-2threads](https://user-images.githubusercontent.com/14180877/98796518-c13a5d80-240b-11eb-86aa-e1ef7cf6b66d.png)

    Now in libre the jbuf was made thread safe and it works now as adaptive jitter
    buffer. What means that the latency is controlled in reaction on the measured
    network jitter.

Thread B has real time constraints and decoding could be to time consuming (e.g. on slow HW). We added a third thread X for decoding. Like shown in this image: 
![jbuf-3threads](https://user-images.githubusercontent.com/14180877/98796684-f21a9280-240b-11eb-9107-11e4468e7ed1.png)
    
    
    Adapting of the latency in the jbuf is done during periods of silence. This
    commit also adds a silence detection. Which is disabled by default because it
    is the only O(n) complexity part, where n is the number of samples (sampc).

Related to: https://github.com/baresip/re/pull/41.