### PR TITLE
Cmd dialdir

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -759,6 +759,9 @@ int  ua_alloc(struct ua **uap, const char *aor);
 int  ua_connect(struct ua *ua, struct call **callp,
 		const char *from_uri, const char *req_uri,
 		enum vidmode vmode);
+int  ua_connect_dir(struct ua *ua, struct call **callp,
+		    const char *from_uri, const char *req_uri,
+		    enum vidmode vmode, enum sdp_dir adir, enum sdp_dir vdir);
 void ua_hangup(struct ua *ua, struct call *call,
 	       uint16_t scode, const char *reason);
 int  ua_answer(struct ua *ua, struct call *call, enum vidmode vmode);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -467,12 +467,8 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 		return EINVAL;
 	}
 
-	uri = mem_alloc(pluri.l + 1, NULL);
-	if (!uri)
-		return ENOMEM;
-
-	err = pl_strcpy(&pluri, uri, pluri.l + 1);
-	if (err)
+	err = pl_strdup(&uri, &pluri);
+	if(err)
 		goto out;
 
 	err = ua_connect_dir(ua, &call, NULL, uri, VIDMODE_ON, adir, vdir);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -441,7 +441,8 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			" inactive at the same time\n";
 
 	err = re_regex(carg->prm, str_len(carg->prm),
-		"[^ ]* audio=[^ ]* video=[^ ]*", &pluri, &argdir[0], &argdir[1]);
+		"[^ ]* audio=[^ ]* video=[^ ]*",
+		&pluri, &argdir[0], &argdir[1]);
 	if (err)
 		err = re_regex(carg->prm, str_len(carg->prm),
 			"[^ ]* [^ ]*",&pluri, &argdir[0]);
@@ -468,7 +469,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 	}
 
 	err = pl_strdup(&uri, &pluri);
-	if(err)
+	if (err)
 		goto out;
 
 	err = ua_connect_dir(ua, &call, NULL, uri, VIDMODE_ON, adir, vdir);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -441,10 +441,10 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			" inactive at the same time\n";
 
 	err = re_regex(carg->prm, str_len(carg->prm),
-		"audio=[^ ]* video=[^ ]*", &argdir[0], &argdir[1]);
+		"[^ ]* audio=[^ ]* video=[^ ]*", &pluri, &argdir[0], &argdir[1]);
 	if (err)
 		err = re_regex(carg->prm, str_len(carg->prm),
-			"[^ ]*", &argdir[0]);
+			"[^ ]* [^ ]*",&pluri, &argdir[0]);
 
 	if (err) {
 		warning("%s", usage);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -418,6 +418,74 @@ static int dial_handler(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_dialdir(struct re_printf *pf, void *arg)
+{
+	const struct cmd_arg *carg = arg;
+	enum sdp_dir adir, vdir;
+	struct pl argdir[2] = {PL_INIT, PL_INIT};
+	struct pl pluri;
+	struct call *call;
+	char *uri;
+	struct ua *ua = uag_current();
+
+	int err = 0;
+
+	(void) pf;
+
+	const char *usage = "Usage: /dialdir <address/telnr.>"
+			" audio=<inactive, sendonly, recvonly, sendrecv>"
+			" video=<inactive, sendonly, recvonly, sendrecv>\n"
+			"/dialdir <address/telnr.>"
+			" <sendonly, recvonly, sendrecv>\n"
+			"Audio & video must not be"
+			" inactive at the same time\n";
+
+	err = re_regex(carg->prm, str_len(carg->prm),
+		"audio=[^ ]* video=[^ ]*", &argdir[0], &argdir[1]);
+	if (err)
+		err = re_regex(carg->prm, str_len(carg->prm),
+			"[^ ]*", &argdir[0]);
+
+	if (err) {
+		warning("%s", usage);
+		return EINVAL;
+	}
+
+	if (!pl_isset(&argdir[1]))
+		argdir[1] = argdir[0];
+
+	adir = decode_sdp_enum(&argdir[0]);
+	vdir = decode_sdp_enum(&argdir[1]);
+
+	if (err) {
+		warning("%s", usage);
+		return err;
+	}
+
+	if (adir == SDP_INACTIVE && vdir == SDP_INACTIVE) {
+		warning("%s", usage);
+		return EINVAL;
+	}
+
+	uri = mem_alloc(pluri.l + 1, NULL);
+	if (!uri)
+		return ENOMEM;
+
+	err = pl_strcpy(&pluri, uri, pluri.l + 1);
+	if (err)
+		goto out;
+
+	err = ua_connect_dir(ua, &call, NULL, uri, VIDMODE_ON, adir, vdir);
+	if (err)
+		goto out;
+
+ out:
+	mem_deref(uri);
+
+	return err;
+}
+
+
 static void options_resp_handler(int err, const struct sip_msg *msg, void *arg)
 {
 	(void)arg;
@@ -753,6 +821,8 @@ static const struct cmd cmdv[] = {
 {"ausrc",     0,    CMD_PRM, "Switch audio source",     switch_audio_source  },
 {"callstat",  'c',        0, "Call status",             ua_print_call_status },
 {"dial",      'd',  CMD_PRM, "Dial",                    dial_handler         },
+{"dialdir",   0,    CMD_PRM, "Dial with audio and video"
+                             "direction.",              cmd_dialdir          },
 {"hangup",    'b',        0, "Hangup call",             cmd_hangup           },
 {"help",      'h',        0, "Help menu",               print_commands       },
 {"listcalls", 'l',        0, "List active calls",       cmd_print_calls      },

--- a/src/video.c
+++ b/src/video.c
@@ -904,7 +904,7 @@ int video_alloc(struct video **vp, struct list *streaml,
 		goto out;
 
 	if (vidisp_find(baresip_vidispl(), NULL) == NULL)
-		sdp_media_set_ldir(v->strm->sdp, SDP_SENDONLY);
+		stream_set_ldir(v->strm, SDP_SENDONLY);
 
 	stream_set_srate(v->strm, VIDEO_SRATE, VIDEO_SRATE);
 


### PR DESCRIPTION
Implementation of a new dial command which allows the user to control the media stream directions. The media directions are passed via command arguments. This PR depends on #1125.