### PR TITLE
Added g729 audio module

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -24,6 +24,7 @@
 #   USE_G722          G.722 audio codec
 #   USE_G722_1        G.722.1 audio codec
 #   USE_G726          G.726 audio codec
+#   USE_G729          G.729 audio codec
 #   USE_GSM           GSM audio codec
 #   USE_GST           Gstreamer audio module
 #   USE_GST_VIDEO     Gstreamer video module
@@ -120,6 +121,9 @@ USE_G722_1 := $(shell [ -f $(SYSROOT)/include/g722_1.h ] || \
 USE_G726 := $(shell [ -f $(SYSROOT)/include/spandsp/g726.h ] || \
 	[ -f $(SYSROOT_ALT)/include/spandsp/g726.h ] || \
 	[ -f $(SYSROOT_LOCAL)/include/spandsp/g726.h ] && echo "yes")
+USE_G729 := $(shell [ -f $(SYSROOT)/include/bcg729/decoder.h ] || \
+	[ -f $(SYSROOT_ALT)/include/bcg729/decoder.h ] || \
+	[ -f $(SYSROOT_LOCAL)/include/bcg729/decoder.h ] && echo "yes")
 USE_GSM := $(shell [ -f $(SYSROOT)/include/gsm.h ] || \
 	[ -f $(SYSROOT_ALT)/include/gsm.h ] || \
 	[ -f $(SYSROOT)/include/gsm/gsm.h ] || \
@@ -246,6 +250,8 @@ USE_COREAUDIO := \
 
 ifneq ($(USE_AVFOUNDATION),)
 USE_AVCAPTURE := yes
+else
+USE_QTCAPTURE := yes
 endif
 
 
@@ -344,6 +350,10 @@ endif
 ifneq ($(USE_DTLS_SRTP),)
 MODULES   += dtls_srtp
 endif
+ifneq ($(USE_QTCAPTURE),)
+MODULES   += qtcapture
+CFLAGS    += -DQTCAPTURE_RUNLOOP
+endif
 ifneq ($(USE_ECHO),)
 MODULES   += echo
 endif
@@ -361,6 +371,9 @@ MODULES   += g7221
 endif
 ifneq ($(USE_G726),)
 MODULES   += g726
+endif
+ifneq ($(USE_G729),)
+MODULES   += g729
 endif
 ifneq ($(USE_GSM),)
 MODULES   += gsm

--- a/modules/g729/g729.c
+++ b/modules/g729/g729.c
@@ -1,0 +1,195 @@
+/**
+ * @file g729.c G.729 Audio Codec
+ *
+ * Copyright (C) 2020 Juha Heinanen
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <bcg729/decoder.h>
+#include <bcg729/encoder.h>
+
+
+/**
+ * @defgroup g729 g729
+ *
+ * The G.729 audio codec
+ */
+
+
+struct auenc_state {
+	bcg729EncoderChannelContextStruct* enc;
+};
+
+struct audec_state {
+	bcg729DecoderChannelContextStruct* dec;
+};
+
+
+static void encode_destructor(void *data)
+{
+	struct auenc_state *st = data;
+
+	if (st->enc)
+		closeBcg729EncoderChannel(st->enc);
+}
+
+
+static int encode_update(struct auenc_state **aesp,
+			 const struct aucodec *ac,
+			 struct auenc_param *prm, const char *fmtp)
+{
+	struct auenc_state *st;
+	int err = 0;
+	(void)prm;
+	(void)fmtp;
+
+	if (!aesp || !ac)
+		return EINVAL;
+
+	if (*aesp)
+		return 0;
+
+	st = mem_zalloc(sizeof(*st), encode_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->enc = initBcg729EncoderChannel(0 /* no VAT/DTX detection */);
+	if (!st->enc) {
+		err = ENOMEM;
+		goto out;
+	}
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*aesp = st;
+
+	return err;
+}
+
+
+static void decode_destructor(void *data)
+{
+	struct audec_state *st = data;
+
+	if (st->dec)
+		closeBcg729DecoderChannel(st->dec);
+}
+
+
+static int decode_update(struct audec_state **adsp,
+			 const struct aucodec *ac, const char *fmtp)
+{
+	struct audec_state *st;
+	int err = 0;
+	(void)fmtp;
+
+	if (!adsp || !ac)
+		return EINVAL;
+
+	if (*adsp)
+		return 0;
+
+	st = mem_zalloc(sizeof(*st), decode_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->dec = initBcg729DecoderChannel();
+	if (!st->dec) {
+		err = ENOMEM;
+		goto out;
+	}
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*adsp = st;
+
+	return err;
+}
+
+
+static int encode(struct auenc_state *aes, bool *marker, uint8_t *buf,
+		  size_t *len, int fmt, const void *sampv, size_t sampc)
+{
+	unsigned int i, count;
+	uint8_t olen;
+	(void)marker;
+
+	if (!buf || !len || !sampv)
+		return EINVAL;
+
+	if ((sampc % 160) != 0)
+		return EPROTO;
+
+	count = sampc / 160;
+
+	for (i = 0; i < count; i++)
+		bcg729Encoder(aes->enc, (int16_t*)sampv, (uint8_t*)buf, &olen);
+
+	*len = count * 10;
+	
+	return 0;
+}
+
+
+static int decode(struct audec_state *ads, int fmt, void *sampv,
+		  size_t *sampc, bool marker, const uint8_t *buf, size_t len)
+{
+	(void)marker;
+	unsigned int i;
+
+	if (!sampv || !sampc || !buf)
+		return EINVAL;
+
+	for (i = 0; i < (len / 10); i++) {
+		bcg729Decoder(ads->dec, buf + i * 10, 10, 0, 0, 0,
+			      (int16_t *)sampv + i * 80);
+	}
+
+	*sampc = 80 * (len / 10);
+
+	return 0;
+}
+
+
+static struct aucodec g729 = {
+	.pt    = "18",
+	.name  = "G729",
+	.srate = 8000,
+	.crate = 8000,
+	.ch    = 1,
+	.pch   = 1,
+	.encupdh   = encode_update,
+	.ench      = encode,
+	.decupdh   = decode_update,
+	.dech      = decode,
+};
+
+
+static int module_init(void)
+{
+	aucodec_register(baresip_aucodecl(), &g729);
+
+	return 0;
+}
+
+
+static int module_close(void)
+{
+	aucodec_unregister(&g729);
+
+	return 0;
+}
+
+
+EXPORT_SYM const struct mod_export DECL_EXPORTS(g729) = {
+	"g729",
+	"audio codec",
+	module_init,
+	module_close,
+};

--- a/modules/g729/g729.c
+++ b/modules/g729/g729.c
@@ -132,7 +132,7 @@ static int encode(struct auenc_state *aes, bool *marker, uint8_t *buf,
 		bcg729Encoder(aes->enc, (int16_t*)sampv, (uint8_t*)buf, &olen);
 
 	*len = count * 10;
-	
+
 	return 0;
 }
 

--- a/modules/g729/g729.c
+++ b/modules/g729/g729.c
@@ -126,10 +126,14 @@ static int encode(struct auenc_state *aes, bool *marker, uint8_t *buf,
 	if ((sampc % 160) != 0)
 		return EPROTO;
 
+	/* Input should be processed in 160 bit (20 byte) segments */
+	/* Output of each segment is 80 bits (10 bytes) long */
+
 	count = sampc / 160;
 
 	for (i = 0; i < count; i++)
-		bcg729Encoder(aes->enc, (int16_t*)sampv, (uint8_t*)buf, &olen);
+		bcg729Encoder(aes->enc, (int16_t*)sampv + i * 20,
+			      (uint8_t*)buf + i * 10, &olen);
 
 	*len = count * 10;
 

--- a/modules/g729/g729.c
+++ b/modules/g729/g729.c
@@ -126,13 +126,10 @@ static int encode(struct auenc_state *aes, bool *marker, uint8_t *buf,
 	if ((sampc % 160) != 0)
 		return EPROTO;
 
-	/* Input should be processed in 160 bit (20 byte) segments */
-	/* Output of each segment is 80 bits (10 bytes) long */
-
-	count = sampc / 160;
+	count = sampc / 80;
 
 	for (i = 0; i < count; i++)
-		bcg729Encoder(aes->enc, (int16_t*)sampv + i * 20,
+		bcg729Encoder(aes->enc, (int16_t*)sampv + i * 80,
 			      (uint8_t*)buf + i * 10, &olen);
 
 	*len = count * 10;

--- a/modules/g729/module.mk
+++ b/modules/g729/module.mk
@@ -1,0 +1,12 @@
+#
+# module.mk
+#
+# Copyright (C) 2020 Juha Heinanen
+#
+
+MOD		:= g729
+$(MOD)_SRCS	+= g729.c
+
+$(MOD)_LFLAGS	+= -lbcg729
+
+include mk/mod.mk


### PR DESCRIPTION
Added g729 based on version 1.1.0 of https://github.com/BelledonneCommunications/bcg729 library. Debian packages of the
library can be created using debian directory from https://github.com/juha-h/bcg729-deb.

Decoding of audio works fine. Encoding may have some cracks, but they may be due to the built-in mic of my laptop.  Please review, since I don't know much about audio coding.