### PR TITLE
mqtt: fix printing port and add tls support

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -211,6 +211,7 @@ video_selfview		window # {window,pip}
 # MQTT
 #mqtt_broker_host	sollentuna.example.com
 #mqtt_broker_port	1883
+#mqtt_broker_cafile	/usr/share/ca-certificates/mozilla/Amazon_Root_CA_1.crt # set this to enforce TLS, default off
 #mqtt_broker_clientid	baresip01 # Has to be unique for each client, defaults to "baresip"
 #mqtt_broker_user	alfred
 #mqtt_broker_password	Crocus

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -11,6 +11,8 @@
 
 
 static char broker_host[256] = "127.0.0.1";
+/* Broker CA file for TLS usage, default none */
+static char broker_cafile[256] = "";
 /* Authentication user name, default none */
 static char mqttusername[256] = "";
 /* Authentication password, default none */
@@ -91,6 +93,8 @@ static int module_init(void)
 	/* Get configuration data */
 	conf_get_str(conf_cur(), "mqtt_broker_host",
 		     broker_host, sizeof(broker_host));
+	conf_get_str(conf_cur(), "mqtt_broker_cafile",
+		     broker_cafile, sizeof(broker_cafile));
 	conf_get_str(conf_cur(), "mqtt_broker_user",
 		     mqttusername, sizeof(mqttusername));
 	conf_get_str(conf_cur(), "mqtt_broker_password",
@@ -99,6 +103,7 @@ static int module_init(void)
 		     mqttclientid, sizeof(mqttclientid));
 	conf_get_str(conf_cur(), "mqtt_basetopic",
 		     mqttbasetopic, sizeof(mqttbasetopic));
+	conf_get_u32(conf_cur(), "mqtt_broker_port", &broker_port);
 
 	info("mqtt: connecting to broker at %s:%d as %s topic %s\n",
 		broker_host, broker_port, mqttclientid, mqttbasetopic);
@@ -115,7 +120,6 @@ static int module_init(void)
 	s_mqtt.subtopic = mqttsubscribetopic;
 	s_mqtt.pubtopic = mqttpublishtopic;
 
-	conf_get_u32(conf_cur(), "mqtt_broker_port", &broker_port);
 
 	s_mqtt.mosq = mosquitto_new(mqttclientid, true, &s_mqtt);
 	if (!s_mqtt.mosq) {
@@ -135,6 +139,12 @@ static int module_init(void)
 		if (ret != MOSQ_ERR_SUCCESS)
 			return ret == MOSQ_ERR_ERRNO ? errno : EIO;
 	}
+
+	if (*broker_cafile != '\0') {
+        ret = mosquitto_tls_set(s_mqtt.mosq, broker_cafile, NULL, NULL, NULL, NULL);
+		if (ret != MOSQ_ERR_SUCCESS)
+			return ret == MOSQ_ERR_ERRNO ? errno : EIO;
+    }
 
 	ret = mosquitto_connect(s_mqtt.mosq, broker_host, broker_port,
 				keepalive);

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -141,10 +141,11 @@ static int module_init(void)
 	}
 
 	if (*broker_cafile != '\0') {
-        ret = mosquitto_tls_set(s_mqtt.mosq, broker_cafile, NULL, NULL, NULL, NULL);
+		ret = mosquitto_tls_set(s_mqtt.mosq, broker_cafile,
+				NULL, NULL, NULL, NULL);
 		if (ret != MOSQ_ERR_SUCCESS)
 			return ret == MOSQ_ERR_ERRNO ? errno : EIO;
-    }
+	}
 
 	ret = mosquitto_connect(s_mqtt.mosq, broker_host, broker_port,
 				keepalive);

--- a/src/config.c
+++ b/src/config.c
@@ -956,6 +956,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "\n# mqtt\n"
 			 "#mqtt_broker_host\t127.0.0.1\n"
 			 "#mqtt_broker_port\t1883\n"
+			 "#mqtt_broker_cafile\t/path/to/broker-ca.crt\n"
 			 "#mqtt_broker_clientid\tbaresip01\n"
 			 "#mqtt_broker_user\tuser\n"
 			 "#mqtt_broker_password\tpass\n"


### PR DESCRIPTION
The port was printed in a debug message before the default value
got overwritten by our config value, which confuses users if a
port other than the default port is used.

When passing the CA certificate of the broker with the new
mqtt_broker_cafile, then a TLS connection is established to the
broker. Usually used with mqtt_broker_port=8883.