### PR TITLE
mqtt: fix printing port and add tls support

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -211,6 +211,7 @@ video_selfview		window # {window,pip}
 # MQTT
 #mqtt_broker_host	sollentuna.example.com
 #mqtt_broker_port	1883
+#mqtt_broker_cafile	/usr/share/ca-certificates/mozilla/Amazon_Root_CA_1.crt # set this to enforce TLS, default off
 #mqtt_broker_clientid	baresip01 # Has to be unique for each client, defaults to "baresip"
 #mqtt_broker_user	alfred
 #mqtt_broker_password	Crocus

--- a/src/config.c
+++ b/src/config.c
@@ -956,6 +956,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "\n# mqtt\n"
 			 "#mqtt_broker_host\t127.0.0.1\n"
 			 "#mqtt_broker_port\t1883\n"
+			 "#mqtt_broker_cafile\t/path/to/broker-ca.crt\n"
 			 "#mqtt_broker_clientid\tbaresip01\n"
 			 "#mqtt_broker_user\tuser\n"
 			 "#mqtt_broker_password\tpass\n"


### PR DESCRIPTION
The port was printed in a debug message before the default value
got overwritten by our config value, which confuses users if a
port other than the default port is used.

When passing the CA certificate of the broker with the new
mqtt_broker_cafile, then a TLS connection is established to the
broker. Usually used with mqtt_broker_port=8883.