### PR TITLE
mqtt: allow to separate pub from sub topic base

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -216,6 +216,8 @@ video_selfview		window # {window,pip}
 #mqtt_broker_user	alfred
 #mqtt_broker_password	Crocus
 #mqtt_basetopic		baresip/01 # May be uniqe for each client you want to control. Defaults to "baresip"
+#mqtt_subscribetopic	/my/baresip/+/control # defaults to /${mqtt_basetopic}/command/+
+#mqtt_publishtopic		/my/baresip/123/event # defaults to /${mqtt_basetopic}/event
 
 # sndfile
 #snd_path		/tmp

--- a/modules/mqtt/mqtt.c
+++ b/modules/mqtt/mqtt.c
@@ -21,8 +21,8 @@ static char mqttpassword[256] = "";
 static char mqttclientid[256] = "baresip";
 /* Base topic for MQTT - default "baresip" - i.e. /baresip/event */
 static char mqttbasetopic[128] = "baresip";
-static char mqttpublishtopic[256];
-static char mqttsubscribetopic[256];
+static char mqttpublishtopic[256] = "";
+static char mqttsubscribetopic[256] = "";
 
 static uint32_t broker_port = 1883;
 
@@ -103,15 +103,23 @@ static int module_init(void)
 		     mqttclientid, sizeof(mqttclientid));
 	conf_get_str(conf_cur(), "mqtt_basetopic",
 		     mqttbasetopic, sizeof(mqttbasetopic));
+	conf_get_str(conf_cur(), "mqtt_publishtopic",
+		     mqttpublishtopic, sizeof(mqttpublishtopic));
+	conf_get_str(conf_cur(), "mqtt_subscribetopic",
+		     mqttsubscribetopic, sizeof(mqttsubscribetopic));
 	conf_get_u32(conf_cur(), "mqtt_broker_port", &broker_port);
 
 	info("mqtt: connecting to broker at %s:%d as %s topic %s\n",
 		broker_host, broker_port, mqttclientid, mqttbasetopic);
 
-	re_snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),
-		    "/%s/command/+", mqttbasetopic);
-	re_snprintf(mqttpublishtopic, sizeof(mqttpublishtopic), "/%s/event",
-		    mqttbasetopic);
+	if (*mqttsubscribetopic == '\0') {
+		re_snprintf(mqttsubscribetopic, sizeof(mqttsubscribetopic),
+				"/%s/command/+", mqttbasetopic);
+	}
+	if (*mqttpublishtopic == '\0') {
+		re_snprintf(mqttpublishtopic, sizeof(mqttpublishtopic),
+				"/%s/event", mqttbasetopic);
+	}
 
 	info("mqtt: Publishing on %s, subscribing to %s\n",
 		mqttpublishtopic, mqttsubscribetopic);


### PR DESCRIPTION
By not setting the new mqtt_subscribetopic or mqtt_publishtopic,
the default behavior of using the mqtt_basetopic option as a base
is used.

However, one can now configure the pub- and sub-topics completely
independent as well to allow multi-level wildcards or some custom
topic tree.