### PR TITLE
menu: make audio files configurable

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -199,6 +199,12 @@ video_selfview		window # {window,pip}
 #ringback_disabled	no
 #statmode_default	off
 #menu_clean_number	no
+#ring_aufile		ring.wav
+#callwaiting_aufile	callwaiting.wav
+#ringback_aufile	ringback.wav
+#notfound_aufile	notfound.wav
+#busy_aufile		busy.wav
+#error_aufile		error.wav
 
 # GTK
 #gtk_clean_number	no

--- a/src/config.c
+++ b/src/config.c
@@ -985,6 +985,12 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#ringback_disabled\tno\n"
 			"#statmode_default\toff\n"
 			"#menu_clean_number\tno\n"
+			"#ring_aufile\t\tring.wav\n"
+			"#callwaiting_aufile\tcallwaiting.wav\n"
+			"#ringback_aufile\tringback.wav\n"
+			"#notfound_aufile\tnotfound.wav\n"
+			"#busy_aufile\t\tbusy.wav\n"
+			"#error_aufile\t\terror.wav\n"
 			);
 
 	(void)re_fprintf(f,

--- a/src/config.c
+++ b/src/config.c
@@ -983,7 +983,9 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#redial_attempts\t0 # Num or <inf>\n"
 			"#redial_delay\t\t5 # Delay in seconds\n"
 			"#ringback_disabled\tno\n"
-			"#statmode_default\toff\n");
+			"#statmode_default\toff\n"
+			"#menu_clean_number\tno\n"
+			);
 
 	(void)re_fprintf(f,
 			"\n# avcodec\n"


### PR DESCRIPTION
Adds these configurations for menu.c
- ring_aufile
- callwaiting_aufile
- ringback_aufile
- notfound_aufile
- busy_aufile
- error_aufile

Our next PR will make it possible to specify also mp3 or other files in the config. The playback then will be done with an ausrc. E.g. the module/gst makes it possible to play a couple of different file types.