### PR TITLE
play ausrc

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -58,6 +58,9 @@ rtp_stats		no
 #dns_server		1.0.0.1:53
 #net_interface		wlan1
 
+# Play tones
+#file_ausrc		aufile
+
 #------------------------------------------------------------------------------
 # Modules
 

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -104,7 +104,7 @@ static void timeout(void *arg)
 	tmr_start(&st->tmr, st->ptime, timeout, st);
 
 	/* check if audio buffer is empty */
-	if (aubuf_cur_size(st->aubuf) < (sizeof(int16_t) * st->sampc)) {
+	if (aubuf_cur_size(st->aubuf) == 0) {
 
 		info("aufile: end of file\n");
 

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -101,8 +101,7 @@ static void *play_thread(void *arg)
 static void timeout(void *arg)
 {
 	struct ausrc_st *st = arg;
-
-	tmr_start(&st->tmr, 1000, timeout, st);
+	tmr_start(&st->tmr, st->ptime, timeout, st);
 
 	/* check if audio buffer is empty */
 	if (aubuf_cur_size(st->aubuf) < (sizeof(int16_t) * st->sampc)) {
@@ -136,7 +135,7 @@ static int read_file(struct ausrc_st *st)
 			break;
 
 		if (mb->end == 0) {
-			info("aufile: end of file\n");
+			info("aufile: read end of file\n");
 			break;
 		}
 
@@ -233,7 +232,7 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 	if (err)
 		goto out;
 
-	tmr_start(&st->tmr, 1000, timeout, st);
+	tmr_start(&st->tmr, st->ptime, timeout, st);
 
 	st->run = true;
 	err = pthread_create(&st->thread, NULL, play_thread, st);

--- a/src/config.c
+++ b/src/config.c
@@ -658,7 +658,10 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"
 			  "#dns_fallback\t\t8.8.8.8:53\n"
-			  "#net_interface\t\t%H\n",
+			  "#net_interface\t\t%H\n"
+			  "\n"
+			  "# Play tones\n"
+			  "#file_ausrc\t\taufile\n",
 			  cfg->avt.jbuf_del.min, cfg->avt.jbuf_del.max,
 			  cfg->avt.jbuf_del.min + 1,
 			  default_interface_print, NULL);

--- a/src/play.c
+++ b/src/play.c
@@ -23,6 +23,15 @@ struct play {
 	struct tmr tmr;
 	int repeat;
 	bool eof;
+	bool restart;
+
+	char *filename;
+	const struct ausrc *ausrc;
+	struct ausrc_st *ausrc_st;
+	struct ausrc_prm sprm;
+	size_t minsz;
+	size_t maxsz;
+	struct aubuf *aubuf;
 };
 
 
@@ -38,7 +47,7 @@ struct player {
 };
 
 
-static void tmr_polling(void *arg);
+static int start_ausrc(struct play *play);
 
 
 static void tmr_stop(void *arg)
@@ -55,7 +64,7 @@ static void tmr_polling(void *arg)
 
 	lock_write_get(play->lock);
 
-	tmr_start(&play->tmr, 1000, tmr_polling, arg);
+	tmr_start(&play->tmr, PTIME, tmr_polling, play);
 
 	if (play->eof) {
 		if (play->repeat == 0)
@@ -63,6 +72,23 @@ static void tmr_polling(void *arg)
 	}
 
 	lock_rel(play->lock);
+}
+
+
+static bool check_restart(void *arg)
+{
+	struct play *play = arg;
+
+	if (play->repeat > 0)
+		play->repeat--;
+
+	if (play->repeat == 0) {
+		play->eof = true;
+		return false;
+	}
+
+	play->restart = true;
+	return true;
 }
 
 
@@ -91,13 +117,8 @@ static void write_handler(void *sampv, size_t sampc, void *arg)
 		pos += count;
 
 		if (pos < sz) {
-			if (play->repeat > 0)
-				play->repeat--;
-
-			if (play->repeat == 0) {
-				play->eof = true;
+			if (!check_restart(play))
 				goto silence;
-			}
 
 			play->mb->pos = 0;
 		}
@@ -122,12 +143,16 @@ static void destructor(void *arg)
 	play->eof = true;
 	lock_rel(play->lock);
 
+	mem_deref(play->ausrc_st);
 	mem_deref(play->auplay);
 	mem_deref(play->mb);
 	mem_deref(play->lock);
+	mem_deref(play->aubuf);
+	mem_deref(play->filename);
 
 	if (play->playp)
 		*play->playp = NULL;
+
 }
 
 
@@ -230,7 +255,7 @@ int play_tone(struct play **playp, struct player *player,
 		return ENOMEM;
 
 	tmr_init(&play->tmr);
-	play->repeat = repeat;
+	play->repeat = repeat ? repeat : 1;
 	play->mb     = mem_ref(tone);
 
 	err = lock_alloc(&play->lock);
@@ -249,7 +274,7 @@ int play_tone(struct play **playp, struct player *player,
 		goto out;
 
 	list_append(&player->playl, &play->le, play);
-	tmr_start(&play->tmr, 1000, tmr_polling, play);
+	tmr_start(&play->tmr, PTIME,  tmr_polling, play);
 
  out:
 	if (err) {
@@ -261,6 +286,160 @@ int play_tone(struct play **playp, struct player *player,
 	}
 
 	return err;
+}
+
+
+static void ausrc_read_handler(struct auframe *af, void *arg)
+{
+	struct play *play = arg;
+	size_t fsize    = auframe_size(af);
+	int err = 0;
+
+	if (play->eof)
+		return;
+
+
+	err = aubuf_write(play->aubuf, af->sampv, fsize);
+	if (err)
+		warning("play: aubuf_write: %m \n", err);
+}
+
+
+static void aubuf_write_handler(void *sampv, size_t sampc, void *arg)
+{
+	struct play *play = arg;
+	size_t sz = sampc * aufmt_sample_size(play->sprm.fmt);
+
+	aubuf_read(play->aubuf, sampv, sz);
+
+	lock_write_get(play->lock);
+	if (!play->ausrc_st && play->restart)
+		start_ausrc(play);
+
+	lock_rel(play->lock);
+}
+
+
+static void ausrc_error_handler(int err, const char *str, void *arg)
+{
+	struct play *play = arg;
+
+	if (err == 0) {
+		lock_write_get(play->lock);
+		play->ausrc_st = mem_deref(play->ausrc_st);
+		check_restart(play);
+		lock_rel(play->lock);
+	}
+}
+
+
+static int start_ausrc(struct play *play)
+{
+	int err;
+	const struct ausrc *ausrc = play->ausrc;
+
+	err = ausrc->alloch(&play->ausrc_st, ausrc, NULL, &play->sprm,
+			play->filename,
+			ausrc_read_handler, ausrc_error_handler, play);
+
+	return err;
+}
+
+
+static int play_file_ausrc(struct play **playp, struct player *player,
+		    const struct ausrc *ausrc,
+		    const char *filename, int repeat,
+		    const char *play_mod, const char *play_dev)
+{
+	int err = 0;
+	size_t sampsz;
+	struct auplay_prm wprm;
+	struct ausrc_prm sprm;
+	struct play *play;
+	struct config *cfg = conf_config();
+	uint32_t srate = cfg->audio.srate_src;
+	uint32_t channels = cfg->audio.channels_src;
+
+	play = mem_zalloc(sizeof(*play), destructor);
+	if (!play)
+		return ENOMEM;
+
+	if (!srate)
+		srate = 16000;
+
+	if (!channels)
+		channels = 1;
+
+	err = lock_alloc(&play->lock);
+	if (err)
+		goto out;
+
+	wprm.ch = channels;
+	wprm.srate = srate;
+	wprm.ptime = PTIME;
+	wprm.fmt = AUFMT_S16LE;
+
+	sprm.ch = channels;
+	sprm.srate = srate;
+	sprm.ptime = PTIME;
+	sprm.fmt = AUFMT_S16LE;
+
+	play->sprm = sprm;
+	play->repeat = repeat ? repeat : 1;
+	str_dup(&play->filename, filename);
+
+	sampsz = aufmt_sample_size(sprm.fmt);
+	play->maxsz = (5 * sampsz * srate * channels * PTIME) / 1000;
+	play->minsz = (3 * sampsz * srate * channels * PTIME) / 1000;
+	err = aubuf_alloc(&play->aubuf, play->minsz, play->maxsz);
+	if (err)
+		goto out;
+
+	err = auplay_alloc(&play->auplay, baresip_auplayl(),
+			   play_mod, &wprm,
+			   play_dev, aubuf_write_handler, play);
+	if (err)
+		goto out;
+
+	play->ausrc = ausrc;
+	err = start_ausrc(play);
+	if (err)
+		goto out;
+
+	tmr_start(&play->tmr, PTIME,  tmr_polling, play);
+
+out:
+	if (err) {
+		mem_deref(play);
+	}
+	else if (playp) {
+		play->playp = playp;
+		*playp = play;
+	}
+
+	return err;
+}
+
+
+static void parse_play_settings(char *file, int *repeat)
+{
+	struct pl f = PL_INIT;
+	struct pl r = PL_INIT;
+	int err;
+
+	if (!file || !repeat)
+		return;
+
+	err = re_regex(file, str_len(file), "[^,]+,[ ]*[^,]+",
+			&f, NULL, &r);
+	if (err || !pl_isset(&r))
+		return;
+
+	*repeat = (int) pl_u32(&r);
+	if (*repeat == 0 && r.p[0] == '-')
+		*repeat = -1;
+
+	(void)pl_strcpy(&f, file, str_len(file));
 }
 
 
@@ -280,10 +459,16 @@ int play_file(struct play **playp, struct player *player,
 	      const char *filename, int repeat,
 	      const char *play_mod, const char *play_dev)
 {
-	struct mbuf *mb;
+	char file[FS_PATH_MAX];
 	char path[FS_PATH_MAX];
+	const struct ausrc *ausrc;
+	struct mbuf *mb = NULL;
 	uint32_t srate = 0;
 	uint8_t ch = 0;
+	struct play *play = NULL;
+
+	char srcn[FS_PATH_MAX];
+
 	int err;
 
 	if (!player)
@@ -291,9 +476,24 @@ int play_file(struct play **playp, struct player *player,
 	if (playp && *playp)
 		return EALREADY;
 
+	str_ncpy(file, filename, sizeof(file));
+	parse_play_settings(file, &repeat);
+
 	if (re_snprintf(path, sizeof(path), "%s/%s",
-			player->play_path, filename) < 0)
+			player->play_path, file) < 0)
 		return ENOMEM;
+
+
+	if (!conf_get_str(conf_cur(), "file_ausrc", srcn, sizeof(srcn))) {
+		ausrc = ausrc_find(baresip_ausrcl(), srcn);
+		if (ausrc) {
+			err = play_file_ausrc(&play, player, ausrc,
+					      path, repeat,
+					      play_mod, play_dev);
+
+			goto out;
+		}
+	}
 
 	mb = mbuf_alloc(1024);
 	if (!mb)
@@ -305,11 +505,19 @@ int play_file(struct play **playp, struct player *player,
 		goto out;
 	}
 
-	err = play_tone(playp, player, mb, srate,
+	err = play_tone(&play, player, mb, srate,
 	                ch, repeat, play_mod, play_dev);
 
  out:
 	mem_deref(mb);
+
+	if (err) {
+		mem_deref(play);
+	}
+	else if (playp) {
+		play->playp = playp;
+		*playp = play;
+	}
 
 	return err;
 }


### PR DESCRIPTION
Adds improved tone playback (play.c) by means of coupling ausrc with auplay.

- Uses aufile as first example.
- The aufile commits are only small fixes. (Depends on rem PR: https://github.com/baresip/rem/pull/1)
- By means of modules/gst it will be possible to play e.g. mp3 ring tones.
