### PR TITLE
Fix compiler warnings

### DIFF
--- a/modules/aac/decode.c
+++ b/modules/aac/decode.c
@@ -82,12 +82,13 @@ int aac_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 {
 	struct audec_state *ads;
 	AAC_DECODER_ERROR error;
-	int err = 0;
-	(void)fmtp;
-
 	struct pl config;
+	UCHAR *conf;
+	UINT length;
 	char config_str[64];
 	uint8_t config_bin[32];
+	int err = 0;
+	(void)fmtp;
 
 	if (!adsp || !ac || !ac->ch)
 		return EINVAL;
@@ -122,8 +123,8 @@ int aac_decode_update(struct audec_state **adsp, const struct aucodec *ac,
 	if (err)
 		goto out;
 
-	UCHAR *conf = config_bin;
-	const UINT length = (UINT)strlen(config_str)/2;
+	conf = config_bin;
+	length = (UINT)strlen(config_str)/2;
 
 	error = aacDecoder_ConfigRaw(ads->dec, &conf, &length);
 	if (error != AAC_DEC_OK) {

--- a/modules/ctrl_dbus/module.mk
+++ b/modules/ctrl_dbus/module.mk
@@ -11,6 +11,7 @@ $(MOD)_LFLAGS	+= $(shell pkg-config --libs glib-2.0 gio-unix-2.0)
 $(MOD)_CFLAGS	+= \
 	$(shell pkg-config --cflags glib-2.0 gio-unix-2.0 | \
 		sed -e 's/-I/-isystem/g' )
+$(MOD)_CFLAGS	+= -Wno-unused-parameter -Wno-declaration-after-statement
 
 $(MOD)_CCHECK_OPT	= -e baresipbus.h -e baresipbus.c
 

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -83,18 +83,20 @@ static int start_jack(struct auplay_st *st)
 	const char **ports;
 	const char *client_name = "baresip";
 	const char *server_name = NULL;
+	char *conf_name;
 	jack_options_t options = JackNullOption;
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;
+	size_t len;
 
 	bool jack_connect_ports = true;
 	(void)conf_get_bool(conf, "jack_connect_ports",
 				  &jack_connect_ports);
 
 	/* open a client connection to the JACK server */
-	size_t len = jack_client_name_size();
-	char *conf_name = mem_alloc(len+1, NULL);
+	len = jack_client_name_size();
+	conf_name = mem_alloc(len+1, NULL);
 
 	if (!conf_get_str(conf, "jack_client_name",
 			conf_name, len)) {

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -83,18 +83,20 @@ static int start_jack(struct ausrc_st *st)
 	const char **ports;
 	const char *client_name = "baresip";
 	const char *server_name = NULL;
+	char *conf_name;
 	jack_options_t options = JackNullOption;
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;
+	size_t len;
 
 	bool jack_connect_ports = true;
 	(void)conf_get_bool(conf, "jack_connect_ports",
 				&jack_connect_ports);
 
 	/* open a client connection to the JACK server */
-	size_t len = jack_client_name_size();
-	char *conf_name = mem_alloc(len+1, NULL);
+	len = jack_client_name_size();
+	conf_name = mem_alloc(len+1, NULL);
 
 	if (!conf_get_str(conf, "jack_client_name",
 			conf_name, len)) {


### PR DESCRIPTION
Needed for `mk/re.mk` re-enabled -Werror and -Wdeclaration-after-statement Flags. See baresip/re#58