### PR TITLE
Play aufile extended support

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -60,6 +60,8 @@ rtp_stats		no
 
 # Play tones
 #file_ausrc		aufile
+#file_srate		16000
+#file_channels		1
 
 #------------------------------------------------------------------------------
 # Modules

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -31,6 +31,7 @@ struct ausrc_st {
 	struct tmr tmr;
 	struct aufile *aufile;
 	struct aubuf *aubuf;
+	struct ausrc_prm *prm;          /**< Audio src parameter             */
 	uint32_t ptime;
 	size_t sampc;
 	bool run;
@@ -188,6 +189,7 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 	st->rh   = rh;
 	st->errh = errh;
 	st->arg  = arg;
+	st->prm  = prm;
 
 	err = aufile_open(&st->aufile, &fprm, dev, AUFILE_READ);
 	if (err) {
@@ -198,26 +200,11 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 	info("aufile: %s: %u Hz, %d channels\n",
 	     dev, fprm.srate, fprm.channels);
 
-	if (fprm.srate != prm->srate) {
-		warning("aufile: input file (%s) must have sample-rate"
-			" %u Hz\n", dev, prm->srate);
-		err = ENODEV;
-		goto out;
-	}
-	if (fprm.channels != prm->ch) {
-		warning("aufile: input file (%s) must have channels = %d\n",
-			dev, prm->ch);
-		err = ENODEV;
-		goto out;
-	}
-	if (fprm.fmt != AUFMT_S16LE) {
-		warning("aufile: input file must have format S16LE\n");
-		err = ENODEV;
-		goto out;
-	}
+	/* return wav format to caller */
+	prm->srate = fprm.srate;
+	prm->ch    = fprm.channels;
 
 	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
-
 	st->ptime = prm->ptime;
 
 	info("aufile: audio ptime=%u sampc=%zu\n",

--- a/src/config.c
+++ b/src/config.c
@@ -657,7 +657,9 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#net_interface\t\t%H\n"
 			  "\n"
 			  "# Play tones\n"
-			  "#file_ausrc\t\taufile\n",
+			  "#file_ausrc\t\taufile\n"
+			  "#file_srate\t\t16000\n"
+			  "#file_channels\t\t1\n",
 			  cfg->avt.jbuf_del.min, cfg->avt.jbuf_del.max,
 			  cfg->avt.jbuf_del.min + 1,
 			  default_interface_print, NULL);

--- a/src/play.c
+++ b/src/play.c
@@ -396,9 +396,11 @@ static int play_file_ausrc(struct play **playp,
 	size_t sampsz;
 	struct ausrc_prm sprm;
 	struct play *play;
-	struct config *cfg = conf_config();
-	uint32_t srate = cfg->audio.srate_src;
-	uint32_t channels = cfg->audio.channels_src;
+	uint32_t srate = 0;
+	uint32_t channels = 0;
+
+	conf_get_u32(conf_cur(), "file_srate", &srate);
+	conf_get_u32(conf_cur(), "file_channels", &channels);
 
 	play = mem_zalloc(sizeof(*play), destructor);
 	if (!play)


### PR DESCRIPTION
This PR adds support for playing ring tones and other signal tones with an ausrc with different sample rates without resampling.

- As example we use aufile. We made aufile returning the sample rate and channels number.
- Adds PCMA/PCMU support to aufile.
- Fixes read until the end of aubuf in play.c.
- If the ausrc does not support returning the sample rate and channels number, new config settings are used.