### PR TITLE
stream: add function to send a RTP dummy packet

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1297,6 +1297,7 @@ void stream_set_secure(struct stream *strm, bool secure);
 bool stream_is_secure(const struct stream *strm);
 int  stream_start_mediaenc(struct stream *strm);
 int  stream_start(const struct stream *strm);
+int stream_open_natpinhole(const struct stream *strm);
 void stream_set_session_handlers(struct stream *strm,
 				 stream_mnatconn_h *mnatconnh,
 				 stream_rtpestab_h *rtpestabh,

--- a/src/stream.c
+++ b/src/stream.c
@@ -1155,7 +1155,7 @@ int stream_start(const struct stream *strm)
 int stream_open_natpinhole(const struct stream *strm)
 {
 	int err = 0;
-	struct mbuf *mb;
+	struct mbuf *mb = NULL;
 	const struct sdp_format *sc = NULL;
 
 	if (!strm)

--- a/src/video.c
+++ b/src/video.c
@@ -1066,10 +1066,13 @@ int video_update(struct video *v, struct media_ctx **ctx, const char *peer)
 		else
 			video_stop_source(v);
 
-		if (dir & SDP_RECVONLY)
+		if (dir & SDP_RECVONLY) {
+			err |= stream_open_natpinhole(v->strm);
 			err |= video_start_display(v, peer);
-		else
+		}
+		else {
 			video_stop_display(v);
+		}
 
 		if (err) {
 			warning("video: video stream error: %m\n", err);


### PR DESCRIPTION
The new function will open a NAT pinhole by sending a dummy
packet via the RTP port in case of no running video source.

This patch should fix the NAT pinhole topic in #1142 