### PR TITLE
Video dir rename

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -242,7 +242,7 @@ static const struct cmd callcmdv[] = {
 {"statmode",    'S',       0, "Statusmode toggle",    toggle_statmode      },
 {"transfer",    't', CMD_PRM, "Transfer call",        call_xfer            },
 {"video_debug", 'V',       0, "Video stream",         call_video_debug     },
-{"video_dir",     0, CMD_PRM, "Set video direction",  set_video_dir        },
+{"videodir",      0, CMD_PRM, "Set video direction",  set_video_dir        },
 
 /* Numeric keypad for DTMF events: */
 {NULL, '#',         0, NULL,                  digit_handler         },


### PR DESCRIPTION
See Issue #1142

Rename video_dir command to videodir to be consistent with the acceptdir and dialdir
Add stream direction information to output at re-Invite