### PR TITLE
clang shorten-64-to-32 warnings

### DIFF
--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -67,12 +67,12 @@ static void *write_thread(void *arg)
 
 		sampv = st->sampv;
 
-		n = snd_pcm_writei(st->write, sampv, samples);
+		n = (int)snd_pcm_writei(st->write, sampv, samples);
 
 		if (-EPIPE == n) {
 			snd_pcm_prepare(st->write);
 
-			n = snd_pcm_writei(st->write, sampv, samples);
+			n = (int)snd_pcm_writei(st->write, sampv, samples);
 			if (n != samples) {
 				warning("alsa: write error: %s\n",
 					snd_strerror(n));

--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -54,7 +54,7 @@ static void auplay_destructor(void *arg)
 static void *write_thread(void *arg)
 {
 	struct auplay_st *st = arg;
-	int n;
+	long n;
 	int num_frames;
 
 	num_frames = st->prm.srate * st->prm.ptime / 1000;
@@ -67,12 +67,12 @@ static void *write_thread(void *arg)
 
 		sampv = st->sampv;
 
-		n = (int)snd_pcm_writei(st->write, sampv, samples);
+		n = snd_pcm_writei(st->write, sampv, samples);
 
 		if (-EPIPE == n) {
 			snd_pcm_prepare(st->write);
 
-			n = (int)snd_pcm_writei(st->write, sampv, samples);
+			n = snd_pcm_writei(st->write, sampv, samples);
 			if (n != samples) {
 				warning("alsa: write error: %s\n",
 					snd_strerror(n));

--- a/modules/omx/omx.c
+++ b/modules/omx/omx.c
@@ -313,7 +313,7 @@ int omx_display_enable(struct omx_state* st,
 	if (!st->buffers) {
 		st->buffers =
 			malloc(portdef.nBufferCountActual * sizeof(void*));
-		st->num_buffers = portdef.nBufferCountActual;
+		st->num_buffers = (int)portdef.nBufferCountActual;
 		st->current_buffer = 0;
 
 		for (i = 0; i < portdef.nBufferCountActual; i++) {
@@ -345,7 +345,7 @@ int omx_display_input_buffer(struct omx_state* st,
 	if (!st->buffers) return EINVAL;
 
 	*pbuf = st->buffers[0]->pBuffer;
-	*plen = st->buffers[0]->nAllocLen;
+	*plen = (uint32_t)st->buffers[0]->nAllocLen;
 
 	st->buffers[0]->nFilledLen = *plen;
 	st->buffers[0]->nOffset = 0;

--- a/modules/oss/oss.c
+++ b/modules/oss/oss.c
@@ -187,7 +187,7 @@ static void *record_thread(void *arg)
 
 	while (st->run) {
 
-		n = read(st->fd, st->sampv, st->sampc*2);
+		n = (int)read(st->fd, st->sampv, st->sampc*2);
 		if (n <= 0)
 			continue;
 
@@ -214,7 +214,7 @@ static void *play_thread(void *arg)
 
 		st->wh(st->sampv, st->sampc, st->arg);
 
-		n = write(st->fd, st->sampv, st->sampc*2);
+		n = (int)write(st->fd, st->sampv, st->sampc*2);
 		if (n < 0) {
 			warning("oss: write: %m\n", errno);
 			break;
@@ -266,7 +266,7 @@ static int src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		goto out;
 	}
 
-	err = oss_reset(st->fd, prm->srate, prm->ch, st->sampc, 0);
+	err = oss_reset(st->fd, prm->srate, prm->ch, (int)st->sampc, 0);
 	if (err)
 		goto out;
 
@@ -324,7 +324,7 @@ static int play_alloc(struct auplay_st **stp, const struct auplay *ap,
 		goto out;
 	}
 
-	err = oss_reset(st->fd, prm->srate, prm->ch, st->sampc, 0);
+	err = oss_reset(st->fd, prm->srate, prm->ch, (int)st->sampc, 0);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
This fixes some remaining shorten-64-to-32 warnings. I leave `mixausrc` as is, so if @cspiel1 wants to provide a pull request for this.