### PR TITLE
ua: for answer-mode early also send INCOMING event

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -415,6 +415,7 @@ static void call_event_handler(struct call *call, enum call_event ev,
 		switch (ua->acc->answermode) {
 
 		case ANSWERMODE_EARLY:
+			ua_event(ua, UA_EVENT_CALL_INCOMING, call, peeruri);
 			(void)call_progress(call);
 			break;
 


### PR DESCRIPTION
If ANSWERMODE_EARLY is set for the account an incoming call could not be
declined or hangup, because module menu did not set the current UA.