### PR TITLE
Sip auto answer caller

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -205,6 +205,7 @@ video_selfview		window # {window,pip}
 #statmode_default	off
 #menu_clean_number	no
 #sip_autoanswer_beep	yes
+#sip_autoanswer_method	rfc5373 # {rfc5373,call-info,alert-info}
 #ring_aufile		ring.wav
 #callwaiting_aufile	callwaiting.wav
 #ringback_aufile	ringback.wav

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -753,6 +753,14 @@ enum ua_event {
 	UA_EVENT_MAX,
 };
 
+/** SIP auto answer method */
+enum answer_method {
+	ANSM_NONE = 0,
+	ANSM_RFC5373,
+	ANSM_CALLINFO,
+	ANSM_ALERTINFO,
+};
+
 /** Defines the User-Agent event handler */
 typedef void (ua_event_h)(struct ua *ua, enum ua_event ev,
 			  struct call *call, const char *prm, void *arg);
@@ -804,6 +812,9 @@ int  ua_set_custom_hdrs(struct ua *ua, struct list *custom_hdrs);
 int  ua_add_custom_hdr(struct ua *ua, const struct pl *name,
 		       const struct pl *value);
 int  ua_rm_custom_hdr(struct ua *ua, struct pl *name);
+int  ua_enable_autoanswer(struct ua *ua, int32_t adelay,
+		enum answer_method met);
+int  ua_disable_autoanswer(struct ua *ua, enum answer_method met);
 int  ua_uri_complete(struct ua *ua, struct mbuf *buf, const char *uri);
 int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   enum vidmode vidmode, const struct sip_msg *msg,

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -801,6 +801,9 @@ void ua_set_media_af(struct ua *ua, int af_media);
 void ua_set_catchall(struct ua *ua, bool enabled);
 int ua_add_xhdr_filter(struct ua *ua, const char *hdr_name);
 int  ua_set_custom_hdrs(struct ua *ua, struct list *custom_hdrs);
+int  ua_add_custom_hdr(struct ua *ua, const struct pl *name,
+		       const struct pl *value);
+int  ua_rm_custom_hdr(struct ua *ua, struct pl *name);
 int  ua_uri_complete(struct ua *ua, struct mbuf *buf, const char *uri);
 int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   enum vidmode vidmode, const struct sip_msg *msg,

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -609,6 +609,7 @@ static int module_init(void)
 	menu.statmode = STATMODE_CALL;
 	menu.clean_number = false;
 	menu.play = NULL;
+	menu.adelay = -1;
 
 	/*
 	 * Read the config values

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -29,6 +29,7 @@ struct menu{
 	enum statmode statmode;       /**< Status mode                    */
 	bool clean_number;            /**< Remove -/() from diald numbers */
 	char redial_aor[128];
+	int32_t adelay;               /**< Outgoing auto answer delay     */
 };
 
 /*Get menu object*/

--- a/src/config.c
+++ b/src/config.c
@@ -1003,6 +1003,8 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#statmode_default\toff\n"
 			"#menu_clean_number\tno\n"
 			"#sip_autoanswer_beep\tyes\n"
+			"#sip_autoanswer_method\trfc5373 "
+				"# {rfc5373,call-info,alert-info}\n"
 			"#ring_aufile\t\tring.wav\n"
 			"#callwaiting_aufile\tcallwaiting.wav\n"
 			"#ringback_aufile\tringback.wav\n"


### PR DESCRIPTION
Adds SIP auto answer for outgoing calls. Used SIP header can be chosen by config "sip_autoanswer_method":

sip_autoanswer_method | SIP Header                                                   
------------ | ------------------------------------------------------------ 
rfc5373      | Answer-Mode: Auto                                            
call-info    | Call-Info: \<http://www.notused.com>;answer-after=0           
alert-info   | Alert-Info: <...>;info=alert-autoanswer;delay=0              
