### PR TITLE
menu: fix segfault on last account deletion

### DIFF
--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -705,6 +705,10 @@ static int cmd_ua_delete(struct re_printf *pf, void *arg)
 
 	if (ua == menu_current()) {
 		(void)cmd_ua_next(pf, NULL);
+
+		if (ua == menu_current()) {
+			menu_current_set(NULL);
+		}
 	}
 
 	(void)re_hprintf(pf, "deleting ua: %s\n", carg->prm);


### PR DESCRIPTION
Remove current account when no more accounts exist.

This should solve the issue: https://github.com/baresip/baresip/issues/1189