### PR TITLE
Ua auto select incoming

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -831,7 +831,7 @@ void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);
 void uag_set_sub_handler(sip_msg_h *subh);
 int  uag_set_extra_params(const char *eprm);
-struct ua   *uag_find(const struct pl *cuser);
+struct ua   *uag_find(const struct sip_msg *msg);
 struct ua   *uag_find_aor(const char *aor);
 struct ua   *uag_find_param(const char *name, const char *val);
 struct sip  *uag_sip(void);

--- a/src/message.c
+++ b/src/message.c
@@ -71,7 +71,7 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 	if (pl_strcmp(&msg->met, "MESSAGE"))
 		return false;
 
-	ua = uag_find(&msg->uri.user);
+	ua = uag_find(msg);
 	if (!ua) {
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
 		return true;

--- a/test/message.c
+++ b/test/message.c
@@ -136,7 +136,7 @@ static int endpoint_alloc(struct endpoint **epp, struct test *test,
 	ep->test = test;
 
 	if (re_snprintf(aor, sizeof(aor),
-			"%s <sip:%s@%j;transport=%s>;regint=0",
+			"%s <sip:%s@%J;transport=%s>;regint=0",
 			name, name, &laddr,
 			sip_transp_name(transp)) < 0) {
 		err = ENOMEM;

--- a/test/ua.c
+++ b/test/ua.c
@@ -758,7 +758,9 @@ static int test_ua_options_base(enum sip_transp transp)
 	err = sip_transp_laddr(uag_sip(), &laddr, transp, NULL);
 	TEST_ERR(err);
 
-	err = ua_alloc(&t.ua, "Foo <sip:user@127.0.0.1>;regint=0");
+	re_snprintf(uri, sizeof(uri), "Foo <sip:user@%J%s>;regint=0", &laddr,
+			sip_transp_param(transp));
+	err = ua_alloc(&t.ua, uri);
 	TEST_ERR(err);
 
 	/* NOTE: no angle brackets in the Request URI */


### PR DESCRIPTION
ua: improve UA selection for incoming calls

This avoids wrong selection especially if multiple local accounts are specified
with different address family or transport protocol.