### PR TITLE
Sip message to application

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -457,6 +457,8 @@ int  message_listen(struct message *message,
 void message_unlisten(struct message *message, message_recv_h *recvh);
 int  message_send(struct ua *ua, const char *peer, const char *msg,
 		  sip_resp_h *resph, void *arg);
+int message_encode_dict(struct odict *od, struct ua *ua, const struct pl *peer,
+			      const struct pl *ctype, struct mbuf *body);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -457,8 +457,9 @@ int  message_listen(struct message *message,
 void message_unlisten(struct message *message, message_recv_h *recvh);
 int  message_send(struct ua *ua, const char *peer, const char *msg,
 		  sip_resp_h *resph, void *arg);
-int message_encode_dict(struct odict *od, struct ua *ua, const struct pl *peer,
-			      const struct pl *ctype, struct mbuf *body);
+int message_encode_dict(struct odict *od, struct account *acc,
+			const struct pl *peer, const struct pl *ctype,
+			struct mbuf *body);
 
 
 /*

--- a/modules/ctrl_dbus/com.github.Baresip.xml
+++ b/modules/ctrl_dbus/com.github.Baresip.xml
@@ -37,5 +37,19 @@ on the implementation of the command.
 		<arg name="evtype" type="s" direction="out" />
 		<arg name="param" type="s" direction="out" />
 		</signal>
+
+<!--
+     message:
+     @ua:    User-Agent local SIP URI (aor)
+     @peer:  Peer address URI
+     @ctype: Content type ("text/plain")
+     @body:  SIP message body
+-->
+		<signal name="message">
+		<arg name="ua" type="s" direction="out" />
+		<arg name="peer" type="s" direction="out" />
+		<arg name="ctype" type="s" direction="out" />
+		<arg name="body" type="s" direction="out" />
+		</signal>
 	</interface>
 </node>

--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -218,7 +218,7 @@ static bool command_handler(struct mbuf *mb, void *arg)
 	resp->pos = NETSTRING_HEADER_SIZE;
 	err = tcp_send(st->tc, resp);
 	if (err) {
-		warning("ctrl_tcp: failed to send the message (%m)\n", err);
+		warning("ctrl_tcp: failed to send the response (%m)\n", err);
 	}
 
  out:
@@ -281,7 +281,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	err = json_encode_odict(&pf, od);
 	if (err) {
-		warning("ctrl_tcp: failed to encode json (%m)\n", err);
+		warning("ctrl_tcp: failed to encode event JSON (%m)\n", err);
 		goto out;
 	}
 
@@ -289,8 +289,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		buf->pos = NETSTRING_HEADER_SIZE;
 		err = tcp_send(st->tc, buf);
 		if (err) {
-			warning("ctrl_tcp: failed to send the message (%m)\n",
-				err);
+			warning("ctrl_tcp: failed to send event (%m)\n", err);
 		}
 	}
 

--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -316,7 +316,7 @@ static void message_handler(struct ua *ua, const struct pl *peer,
 		return;
 
 	err  = odict_entry_add(od, "message", ODICT_BOOL, true);
-	err |= message_encode_dict(od, ua, peer, ctype, body);
+	err |= message_encode_dict(od, ua_account(ua), peer, ctype, body);
 	if (err) {
 		warning("ctrl_tcp: failed to encode message (%m)\n", err);
 		goto out;

--- a/src/message.c
+++ b/src/message.c
@@ -231,15 +231,16 @@ int message_send(struct ua *ua, const char *peer, const char *msg,
  * Encode a SIP instant MESSAGE to a dictionary
  *
  * @param od    Dictionary to encode into
- * @param ua    User-Agent
+ * @param acc   User-Agent account
  * @param peer  Peer address URI
  * @param ctype Content type ("text/plain")
  * @param body  Buffer containing the SIP message body
  *
  * @return 0 if success, otherwise errorcode
  */
-int message_encode_dict(struct odict *od, struct ua *ua, const struct pl *peer,
-			      const struct pl *ctype, struct mbuf *body)
+int message_encode_dict(struct odict *od, struct account *acc,
+			const struct pl *peer, const struct pl *ctype,
+			struct mbuf *body)
 {
 	int err = 0;
 	char *buf1 = NULL;
@@ -247,7 +248,7 @@ int message_encode_dict(struct odict *od, struct ua *ua, const struct pl *peer,
 	char *buf3 = NULL;
 	size_t pos = 0;
 
-	if (!od || !ua || !pl_isset(peer))
+	if (!od || !acc || !pl_isset(peer))
 		return EINVAL;
 
 	err  = pl_strdup(&buf1, peer);
@@ -261,8 +262,7 @@ int message_encode_dict(struct odict *od, struct ua *ua, const struct pl *peer,
 	if (err)
 		goto out;
 
-	err |= odict_entry_add(od, "ua", ODICT_STRING,
-			account_aor(ua_account(ua)));
+	err |= odict_entry_add(od, "ua", ODICT_STRING, account_aor(acc));
 	err |= odict_entry_add(od, "from",  ODICT_STRING, buf1);
 	err |= odict_entry_add(od, "ctype", ODICT_STRING, buf2);
 	if (buf3)


### PR DESCRIPTION
relay SIP MESSAGE to the application via:
- ctrl_tcp
- ctrl_dbus

The ctrl_dbus extension can be tested with:
```
dbus-monitor interface=com.github.Baresip
```