### PR TITLE
Fix interaction between CLI menu and GTK menu

### DIFF
--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -8,7 +8,7 @@
 #include <baresip.h>
 #include <gtk/gtk.h>
 #include "gtk_mod.h"
-
+#include <pthread.h>
 
 struct call_window {
 	struct gtk_mod *mod;
@@ -46,6 +46,7 @@ enum call_window_events {
 	MQ_TRANSFER,
 };
 
+static pthread_mutex_t last_data_mut = PTHREAD_MUTEX_INITIALIZER;
 static struct call_window *last_call_win = NULL;
 static struct vumeter_dec *last_dec = NULL;
 static struct vumeter_enc *last_enc = NULL;
@@ -143,30 +144,36 @@ static void call_window_set_vu_enc(struct call_window *win,
 
 void call_window_got_vu_dec(struct vumeter_dec *dec)
 {
+	pthread_mutex_lock(&last_data_mut);
 	if (last_call_win)
 		call_window_set_vu_dec(last_call_win, dec);
 	else
 		last_dec = dec;
+	pthread_mutex_unlock(&last_data_mut);
 }
 
 
 void call_window_got_vu_enc(struct vumeter_enc *enc)
 {
+	pthread_mutex_lock(&last_data_mut);
 	if (last_call_win)
 		call_window_set_vu_enc(last_call_win, enc);
 	else
 		last_enc = enc;
+	pthread_mutex_unlock(&last_data_mut);
 }
 
 
 static void got_call_window(struct call_window *win)
 {
+	pthread_mutex_lock(&last_data_mut);
 	if (last_enc)
 		call_window_set_vu_enc(win, last_enc);
 	if (last_dec)
 		call_window_set_vu_dec(win, last_dec);
 	if (!last_enc || !last_dec)
 		last_call_win = win;
+	pthread_mutex_unlock(&last_data_mut);
 }
 
 
@@ -277,7 +284,10 @@ static void mqueue_handler(int id, void *data, void *arg)
 	switch ((enum call_window_events)id) {
 
 	case MQ_HANGUP:
-		ua_hangup(call_get_ua(win->call), win->call, 0, NULL);
+		if (!win->closed) {
+			ua_hangup(call_get_ua(win->call), win->call, 0, NULL);
+			win->closed = true;
+		}
 		break;
 
 	case MQ_CLOSE:
@@ -323,8 +333,9 @@ static void call_window_destructor(void *arg)
 	if (window->vumeter_timer_tag)
 		g_source_remove(window->vumeter_timer_tag);
 
-	/* TODO: avoid race conditions here */
+	pthread_mutex_lock(&last_data_mut);
 	last_call_win = NULL;
+	pthread_mutex_unlock(&last_data_mut);
 }
 
 
@@ -516,7 +527,9 @@ void call_window_progress(struct call_window *win)
 		return;
 
 	win->duration_timer_tag = g_timeout_add_seconds(1, call_timer, win);
+	pthread_mutex_lock(&last_data_mut);
 	last_call_win = win;
+	pthread_mutex_unlock(&last_data_mut);
 	call_window_set_status(win, "progress");
 }
 
@@ -533,7 +546,9 @@ void call_window_established(struct call_window *win)
 								win);
 	}
 
+	pthread_mutex_lock(&last_data_mut);
 	last_call_win = win;
+	pthread_mutex_unlock(&last_data_mut);
 	call_window_set_status(win, "established");
 }
 

--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -146,8 +146,10 @@ static void call_window_set_vu_enc(struct call_window *win,
 void call_window_got_vu_dec(struct vumeter_dec *dec)
 {
 	pthread_mutex_lock(&last_data_mut);
-	if (last_call_win)
+	if (last_call_win) {
 		call_window_set_vu_dec(last_call_win, dec);
+		last_dec = NULL;
+	}
 	else
 		last_dec = dec;
 	pthread_mutex_unlock(&last_data_mut);
@@ -157,8 +159,10 @@ void call_window_got_vu_dec(struct vumeter_dec *dec)
 void call_window_got_vu_enc(struct vumeter_enc *enc)
 {
 	pthread_mutex_lock(&last_data_mut);
-	if (last_call_win)
+	if (last_call_win) {
 		call_window_set_vu_enc(last_call_win, enc);
+		last_enc = NULL;
+	}
 	else
 		last_enc = enc;
 	pthread_mutex_unlock(&last_data_mut);
@@ -168,10 +172,14 @@ void call_window_got_vu_enc(struct vumeter_enc *enc)
 static void got_call_window(struct call_window *win)
 {
 	pthread_mutex_lock(&last_data_mut);
-	if (last_enc)
+	if (last_enc) {
 		call_window_set_vu_enc(win, last_enc);
-	if (last_dec)
+		last_enc = NULL;
+	}
+	if (last_dec) {
 		call_window_set_vu_dec(win, last_dec);
+		last_dec = NULL;
+	}
 	if (!last_enc || !last_dec)
 		last_call_win = win;
 	pthread_mutex_unlock(&last_data_mut);

--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -9,6 +9,7 @@
 #include <gtk/gtk.h>
 #include "gtk_mod.h"
 #include <pthread.h>
+#include <string.h>
 
 struct call_window {
 	struct gtk_mod *mod;
@@ -488,6 +489,7 @@ void call_window_closed(struct call_window *win, const char *reason)
 {
 	char buf[256];
 	const char *status;
+	const char *user_trigger_reason = "Connection reset by user";
 
 	if (!win)
 		return;
@@ -512,6 +514,12 @@ void call_window_closed(struct call_window *win, const char *reason)
 	call_window_set_status(win, status);
 	win->transfer_dialog = mem_deref(win->transfer_dialog);
 	win->closed = true;
+
+	if (strncmp(reason, user_trigger_reason,
+	    strlen(user_trigger_reason)) == 0) {
+		mqueue_push(win->mq, MQ_CLOSE, win);
+		return;
+	}
 }
 
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -529,8 +529,7 @@ static void ua_event_handler(struct ua *ua,
 		win = get_call_window(mod, call);
 		if (win)
 			call_window_closed(win, prm);
-		else
-			denotify_incoming_call(mod, call);
+		denotify_incoming_call(mod, call);
 		break;
 
 	case UA_EVENT_CALL_RINGING:
@@ -549,6 +548,7 @@ static void ua_event_handler(struct ua *ua,
 		win = get_create_call_window(mod, call);
 		if (win)
 			call_window_established(win);
+		denotify_incoming_call(mod, call);
 		break;
 
 	case UA_EVENT_CALL_TRANSFER_FAILED:


### PR DESCRIPTION
Fix parallel usage of CLI and GTK menu:
* Let notifications disappear, when accepting from CLI
* Fix race condition in call_window with mutex
* Fix use_after_free of vu enc/dec in call_window