### PR TITLE
mod_gtk: switch to gtk 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get update && sudo apt-get install -y libavcodec-dev \
                             libavdevice-dev \
                             libavformat-dev \
-                            libgtk2.0-dev \
+                            libgtk-3-dev \
                             libjack-jackd2-dev \
                             libmosquitto-dev \
                             libmpg123-dev \
@@ -35,7 +35,7 @@ jobs:
                             libspandsp-dev \
                             libssl-dev \
                             libglib2.0-dev
-    
+
     - name: install aac
       if: ${{ matrix.os == 'ubuntu-20.04' }}
       run: |

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -127,7 +127,7 @@ USE_GSM := $(shell [ -f $(SYSROOT)/include/gsm.h ] || \
 USE_GST := $(shell pkg-config --exists gstreamer-1.0 && echo "yes")
 USE_GST_VIDEO := $(shell pkg-config --exists gstreamer-1.0 gstreamer-app-1.0 \
 		&& echo "yes")
-USE_GTK := $(shell pkg-config 'gtk+-2.0 >= 2.22' && \
+USE_GTK := $(shell pkg-config 'gtk+-3.0 >= 3.0' && \
 		   pkg-config 'glib-2.0 >= 2.32' && echo "yes")
 USE_ILBC := $(shell [ -f $(SYSROOT)/include/iLBC_define.h ] || \
 	[ -f $(SYSROOT_LOCAL)/include/iLBC_define.h ] || \

--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -369,7 +369,7 @@ struct call_window *call_window_new(struct call *call, struct gtk_mod *mod)
 	gtk_window_set_type_hint(GTK_WINDOW(window),
 			GDK_WINDOW_TYPE_HINT_DIALOG);
 
-	vbox = gtk_vbox_new(FALSE, 0);
+	vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
 	gtk_container_add(GTK_CONTAINER(window), vbox);
 
 	/* Peer name and URI */
@@ -388,7 +388,7 @@ struct call_window *call_window_new(struct call *call, struct gtk_mod *mod)
 	gtk_box_pack_start(GTK_BOX(vbox), status, FALSE, FALSE, 0);
 
 	/* Progress bars */
-	hbox = gtk_hbox_new(FALSE, 0);
+	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_set_spacing(GTK_BOX(hbox), 6);
 	gtk_container_set_border_width(GTK_CONTAINER(hbox), 5);
 	gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
@@ -410,7 +410,7 @@ struct call_window *call_window_new(struct call *call, struct gtk_mod *mod)
 	gtk_box_pack_end(GTK_BOX(hbox), image, FALSE, FALSE, 0);
 
 	/* Buttons */
-	button_box = gtk_hbutton_box_new();
+	button_box = gtk_button_box_new(GTK_ORIENTATION_HORIZONTAL);
 	gtk_button_box_set_layout(GTK_BUTTON_BOX(button_box),
 			GTK_BUTTONBOX_END);
 	gtk_box_set_spacing(GTK_BOX(button_box), 6);

--- a/modules/gtk/dial_dialog.c
+++ b/modules/gtk/dial_dialog.c
@@ -103,7 +103,7 @@ struct dial_dialog *dial_dialog_alloc(struct gtk_mod *mod)
 	if (!dd)
 		return NULL;
 
-	dial = gtk_dialog_new_with_buttons("Dial", NULL, 0, NULL);
+	dial = gtk_dialog_new_with_buttons("Dial", NULL, 0, NULL, NULL);
 
 	/* Cancel */
 	button = gtk_button_new_with_label("Cancel");

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -174,7 +174,7 @@ static void menu_on_account_toggled(GtkCheckMenuItem *menu_item,
 				    struct gtk_mod *mod)
 {
 	struct ua *ua = g_object_get_data(G_OBJECT(menu_item), "ua");
-	if (menu_item->active)
+	if (gtk_check_menu_item_get_active(menu_item))
 		mqueue_push(mod->mq, MQ_SELECT_UA, ua);
 }
 
@@ -244,8 +244,8 @@ static GtkMenuItem *accounts_menu_get_item(struct gtk_mod *mod,
 					   struct ua *ua)
 {
 	GtkMenuItem *item;
-	GtkMenuShell *accounts_menu = GTK_MENU_SHELL(mod->accounts_menu);
-	GList *items = accounts_menu->children;
+	GtkContainer *accounts_menu_cont = GTK_CONTAINER(mod->accounts_menu);
+	GList *items = gtk_container_get_children(accounts_menu_cont);
 
 	for (; items; items = items->next) {
 		item = items->data;
@@ -271,8 +271,8 @@ static void update_ua_presence(struct gtk_mod *mod)
 	GtkCheckMenuItem *item = 0;
 	enum presence_status cur_status;
 	void *status;
-	GtkMenuShell *status_menu = GTK_MENU_SHELL(mod->status_menu);
-	GList *items = status_menu->children;
+	GtkContainer *status_menu_cont = GTK_CONTAINER(mod->status_menu);
+	GList *items = gtk_container_get_children(status_menu_cont);
 
 	cur_status = ua_presence_status(gtk_current_ua());
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -22,9 +22,9 @@
 #endif
 
 /* About */
-#define COPYRIGHT " Copyright (C) 2010 - 2019 Alfred E. Heggestad et al."
+#define COPYRIGHT " Copyright (C) 2010 - 2021 Alfred E. Heggestad et al."
 #define COMMENTS "A modular SIP User-Agent with audio and video support"
-#define WEBSITE "http://www.creytiv.com/baresip.html"
+#define WEBSITE "https://github.com/baresip/baresip"
 #define LICENSE "BSD"
 
 

--- a/modules/gtk/module.mk
+++ b/modules/gtk/module.mk
@@ -12,7 +12,7 @@ $(MOD)_LFLAGS	+= $(shell pkg-config --libs gtk+-3.0 $($(MOD)_EXTRA))
 $(MOD)_CFLAGS	+= \
 	$(shell pkg-config --cflags gtk+-3.0 $($(MOD)_EXTRA) | \
 		sed -e 's/-I/-isystem/g' )
-$(MOD)_CFLAGS	+= -Wno-strict-prototypes
+$(MOD)_CFLAGS	+= -Wno-strict-prototypes -Wno-deprecated-declarations
 
 ifneq ($(USE_LIBNOTIFY),)
 $(MOD)_EXTRA	 = libnotify

--- a/modules/gtk/module.mk
+++ b/modules/gtk/module.mk
@@ -8,9 +8,9 @@
 MOD		:= gtk
 $(MOD)_SRCS	+= gtk_mod.c call_window.c dial_dialog.c transfer_dialog.c \
 	uri_entry.c
-$(MOD)_LFLAGS	+= $(shell pkg-config --libs gtk+-2.0 $($(MOD)_EXTRA))
+$(MOD)_LFLAGS	+= $(shell pkg-config --libs gtk+-3.0 $($(MOD)_EXTRA))
 $(MOD)_CFLAGS	+= \
-	$(shell pkg-config --cflags gtk+-2.0 $($(MOD)_EXTRA) | \
+	$(shell pkg-config --cflags gtk+-3.0 $($(MOD)_EXTRA) | \
 		sed -e 's/-I/-isystem/g' )
 $(MOD)_CFLAGS	+= -Wno-strict-prototypes
 

--- a/modules/gtk/transfer_dialog.c
+++ b/modules/gtk/transfer_dialog.c
@@ -99,7 +99,7 @@ struct transfer_dialog *transfer_dialog_alloc(struct call_window *call_win)
 			 G_CALLBACK(gtk_widget_hide_on_delete), win);
 
 	/* Spinner and status */
-	hbox = gtk_hbox_new(FALSE, 0);
+	hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 	gtk_box_pack_start(GTK_BOX(content), hbox, FALSE, FALSE, 0);
 
 	spinner = gtk_spinner_new();


### PR DESCRIPTION
Transition to a compiling GTK 3 build is rather seamless, but some deprecation warnings need further attention:
* Deprecation of status menu icon -> Should the application use a standalone widget instead of a status icon?
* Deprecation of gdk_threads_enter and friends -> Can be dealt with the/another message queue.