### PR TITLE
ua: improve UA selection for incoming calls

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -835,6 +835,7 @@ int  uag_reset_transp(bool reg, bool reinvite);
 void uag_set_sub_handler(sip_msg_h *subh);
 int  uag_set_extra_params(const char *eprm);
 struct ua   *uag_find(const struct pl *cuser);
+struct ua   *uag_find_msg(const struct sip_msg *msg);
 struct ua   *uag_find_aor(const char *aor);
 struct ua   *uag_find_param(const char *name, const char *val);
 struct sip  *uag_sip(void);

--- a/src/message.c
+++ b/src/message.c
@@ -71,7 +71,7 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 	if (pl_strcmp(&msg->met, "MESSAGE"))
 		return false;
 
-	ua = uag_find(&msg->uri.user);
+	ua = uag_find_msg(msg);
 	if (!ua) {
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
 		return true;

--- a/src/ua.c
+++ b/src/ua.c
@@ -686,7 +686,7 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 	if (pl_strcmp(&msg->met, "OPTIONS"))
 		return false;
 
-	ua = uag_find(&msg->uri.user);
+	ua = uag_find_msg(msg);
 	if (!ua) {
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
 		return true;
@@ -930,6 +930,46 @@ int ua_uri_complete(struct ua *ua, struct mbuf *buf, const char *uri)
 
 	return err;
 }
+
+
+static bool uri_host_local(const struct uri *uri)
+{
+	const struct sa *sal;
+	struct sa sap;
+	int err;
+
+	if (!uri)
+		return false;
+
+	if (!pl_strcmp(&uri->host, "localhost"))
+		return true;
+
+	if (!pl_strcmp(&uri->host, "127.0.0.1"))
+		return true;
+
+	if (!pl_strcmp(&uri->host, "::1"))
+		return true;
+
+	sal = net_laddr_af(baresip_network(), AF_INET);
+
+	err = sa_set(&sap, &uri->host, 0);
+	if (err)
+		return false;
+
+	if (sal && sa_cmp(sal, &sap, SA_ADDR))
+		return true;
+
+#ifdef HAVE_INET6
+	sal = net_laddr_af(baresip_network(), AF_INET6);
+	if (sal && sa_cmp(sal, &sap, SA_ADDR))
+		return true;
+#endif
+
+	return false;
+}
+
+
+static bool uri_match_af(const struct uri *accu, const struct uri *peeru);
 
 
 /**
@@ -1528,7 +1568,7 @@ static void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 	      sip_transp_name(msg->tp),
 	      &msg->src, &msg->dst);
 
-	ua = uag_find(&msg->uri.user);
+	ua = uag_find_msg(msg);
 	if (!ua) {
 		warning("ua: %r: UA not found: %r\n",
 			&msg->from.auri, &msg->uri.user);
@@ -1673,7 +1713,7 @@ static bool sub_handler(const struct sip_msg *msg, void *arg)
 
 	(void)arg;
 
-	ua = uag_find(&msg->uri.user);
+	ua = uag_find_msg(msg);
 	if (!ua) {
 		warning("subscribe: no UA found for %r\n", &msg->uri.user);
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
@@ -1982,6 +2022,59 @@ struct sipevent_sock *uag_sipevent_sock(void)
 }
 
 
+static bool uri_match_transport(const struct uri *accu, enum sip_transp tp)
+{
+	struct pl pl;
+	int err;
+
+	err = msg_param_decode(&accu->params, "transport", &pl);
+	if (err)
+		return true;
+
+	return !pl_strcasecmp(&pl, sip_transp_name(tp));
+}
+
+
+static bool uri_match_af(const struct uri *accu, const struct uri *peeru)
+{
+#ifdef HAVE_INET6
+	struct sa sa1;
+	struct sa sa2;
+	int err;
+#endif
+
+	/* we list cases where we know there is a mismatch in af */
+#ifdef HAVE_INET6
+	if (accu->af == AF_INET && peeru->af == AF_INET6)
+		return false;
+
+	if (accu->af == AF_INET6 && peeru->af == AF_INET)
+		return false;
+
+	if (accu->af == AF_INET6 && peeru->af == AF_INET6) {
+		err =  sa_set(&sa1, &accu->host, 0);
+		err |= sa_set(&sa2, &peeru->host, 0);
+
+		if (err) {
+			warning("ua: No valid IPv6 URI %r, %r (%m)\n",
+					&accu->host,
+					&peeru->host, err);
+			return false;
+		}
+
+		return sa_is_linklocal(&sa1) == sa_is_linklocal(&sa2);
+	}
+
+	/* if peer uri is a domain, we simply return true */
+	if (peeru->af == AF_UNSPEC)
+		return true;
+#endif
+
+	/* both IPv4 or we can't decide if af will match */
+	return true;
+}
+
+
 /**
  * Find the correct UA from the contact user
  *
@@ -2017,6 +2110,69 @@ struct ua *uag_find(const struct pl *cuser)
 	}
 
 	return NULL;
+}
+
+
+/**
+ * Find the correct UA from SIP message
+ *
+ * @param msg SIP message
+ *
+ * @return Matching UA if found, NULL if not found
+ */
+struct ua *uag_find_msg(const struct sip_msg *msg)
+{
+	struct le *le;
+	const struct pl *cuser = &msg->uri.user;
+	struct ua *uaf = NULL;  /* fallback ua */
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (0 == pl_strcasecmp(cuser, ua->cuser)) {
+			ua_printf(ua, "selected for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	/* Try also matching by AOR, for better interop and for peer-to-peer
+	 * calls */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua->acc;
+
+		if (!uri_match_transport(&acc->luri, msg->tp))
+			continue;
+
+		if (!uri_match_af(&acc->luri, &msg->uri))
+			continue;
+
+		if (uri_host_local(&acc->luri) != uri_host_local(&msg->uri))
+			continue;
+
+		if (!uaf)
+			uaf = ua;
+
+		if (0 == pl_casecmp(cuser, &ua->acc->luri.user)) {
+			ua_printf(ua, "account match for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	/* Last resort, try any catchall UAs */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (ua->catchall) {
+			ua_printf(ua, "use catch-all account for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	if (uaf)
+		ua_printf(uaf, "selected\n");
+
+	return uaf;
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -2049,10 +2049,10 @@ static bool uri_match_af(const struct uri *accu, const struct uri *peeru)
 
 	/* we list cases where we know there is a mismatch in af */
 #ifdef HAVE_INET6
-	if (accu->af == AF_INET && peeru->af == AF_INET6)
-		return false;
+	if (peeru->af == AF_UNSPEC || accu->af == AF_UNSPEC)
+		return true;
 
-	if (accu->af == AF_INET6 && peeru->af == AF_INET)
+	if (accu->af != peeru->af)
 		return false;
 
 	if (accu->af == AF_INET6 && peeru->af == AF_INET6) {
@@ -2068,10 +2068,6 @@ static bool uri_match_af(const struct uri *accu, const struct uri *peeru)
 
 		return sa_is_linklocal(&sa1) == sa_is_linklocal(&sa2);
 	}
-
-	/* if peer uri is a domain, we simply return true */
-	if (peeru->af == AF_UNSPEC)
-		return true;
 #endif
 
 	/* both IPv4 or we can't decide if af will match */

--- a/src/ua.c
+++ b/src/ua.c
@@ -2145,17 +2145,20 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 		struct ua *ua = le->data;
 		struct account *acc = ua->acc;
 
-		if (!uri_match_transport(&acc->luri, msg->tp))
-			continue;
+		if (!acc->regint) {
+			if (!uri_match_transport(&acc->luri, msg->tp))
+				continue;
 
-		if (!uri_match_af(&acc->luri, &msg->uri))
-			continue;
+			if (!uri_match_af(&acc->luri, &msg->uri))
+				continue;
 
-		if (uri_host_local(&acc->luri) != uri_host_local(&msg->uri))
-			continue;
+			if (uri_host_local(&acc->luri) !=
+					uri_host_local(&msg->uri))
+				continue;
 
-		if (!uaf)
-			uaf = ua;
+			if (!uaf)
+				uaf = ua;
+		}
 
 		if (0 == pl_casecmp(cuser, &ua->acc->luri.user)) {
 			ua_printf(ua, "account match for %r\n", cuser);

--- a/src/ua.c
+++ b/src/ua.c
@@ -2123,9 +2123,13 @@ struct ua *uag_find(const struct pl *cuser)
 struct ua *uag_find_msg(const struct sip_msg *msg)
 {
 	struct le *le;
-	const struct pl *cuser = &msg->uri.user;
+	const struct pl *cuser;
 	struct ua *uaf = NULL;  /* fallback ua */
 
+	if (!msg)
+		return NULL;
+
+	cuser = &msg->uri.user;
 	for (le = uag.ual.head; le; le = le->next) {
 		struct ua *ua = le->data;
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -2027,13 +2027,15 @@ struct sipevent_sock *uag_sipevent_sock(void)
 static bool uri_match_transport(const struct uri *accu, enum sip_transp tp)
 {
 	struct pl pl;
+	enum sip_transp tpa;
 	int err;
 
 	err = msg_param_decode(&accu->params, "transport", &pl);
 	if (err)
 		return true;
 
-	return !pl_strcasecmp(&pl, sip_transp_name(tp));
+	tpa = sip_transp_decode(&pl);
+	return tpa == tp;
 }
 
 

--- a/test/main.c
+++ b/test/main.c
@@ -38,6 +38,7 @@ static const struct test tests[] = {
 	TEST(test_call_rtcp),
 	TEST(test_call_rtp_timeout),
 	TEST(test_call_tcp),
+	TEST(test_call_deny_udp),
 	TEST(test_call_transfer),
 	TEST(test_call_video),
 	TEST(test_call_webrtc),

--- a/test/test.h
+++ b/test/test.h
@@ -228,6 +228,7 @@ int test_call_reject(void);
 int test_call_rtcp(void);
 int test_call_rtp_timeout(void);
 int test_call_tcp(void);
+int test_call_deny_udp(void);
 int test_call_transfer(void);
 int test_call_video(void);
 int test_call_webrtc(void);


### PR DESCRIPTION
This allows to deny certain transport protocols (e.g. only allow TLS) for
incoming peer-to-peer calls. Also checks for correct address family which is
important if there is no af hint in the SDP.

@juha-h Now loosened the transport check. If the account does not specify a transport protocol, the check is omitted.