### PR TITLE
opus: Ensure (re)init of fmtp strings

### DIFF
--- a/modules/opus/opus.c
+++ b/modules/opus/opus.c
@@ -41,7 +41,7 @@
 
 
 static bool opus_mirror;
-static char fmtp[256] = "";
+static char fmtp[256];
 static char fmtp_mirror[256];
 
 uint32_t opus_complexity = 10;
@@ -97,10 +97,13 @@ static int module_init(void)
 {
 	struct conf *conf = conf_cur();
 	uint32_t value;
-	char *p = fmtp + str_len(fmtp);
+	char *p = fmtp;
 	bool b, stereo = true, sprop_stereo = true;
 	struct pl pl;
 	int n = 0;
+
+	fmtp[0] = '\0';
+	fmtp_mirror[0] = '\0';
 
 	conf_get_bool(conf, "opus_stereo", &stereo);
 	conf_get_bool(conf, "opus_sprop_stereo", &sprop_stereo);


### PR DESCRIPTION
This change fixes a malformation and eventual buffer overflow of the `fmtp` string that is generated when the Opus codec module is unloaded and reloaded in a static build configuration.

The issue is that the `fmtp` string relies on static initialization upon `dlopen` of the module - subsequent `init` does not reset back to a clean state in a static build configuration, and the string grows until it overflows its buffer.

The change forces `fmtp` to be reset to an empty string at `init` time.