### PR TITLE
RFC: Make avformat decode mjpeg v4l2 with vaapi

### DIFF
--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -14,6 +14,7 @@
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
 #include <libavdevice/avdevice.h>
+#include <libavutil/hwcontext.h>
 #include "mod_avformat.h"
 
 
@@ -27,6 +28,9 @@
  \verbatim
   audio_source            avformat,/tmp/testfile.mp4
   video_source            avformat,/tmp/testfile.mp4
+
+  avformat_hwaccel      vaapi
+  avformat_inputformat  mjpeg
  \endverbatim
  */
 
@@ -34,6 +38,8 @@
 static struct ausrc *ausrc;
 static struct vidsrc *mod_avf;
 
+static enum AVHWDeviceType avformat_hwdevice = AV_HWDEVICE_TYPE_NONE;
+static char avformat_inputformat[64];
 
 static void shared_destructor(void *arg)
 {
@@ -173,17 +179,20 @@ static int open_codec(struct stream *s, const struct AVStream *strm, int i,
 		return ENOMEM;
 	}
 
-	AVBufferRef *hwctx;
-	ret = av_hwdevice_ctx_create(&hwctx, AV_HWDEVICE_TYPE_VAAPI,
-			NULL, NULL, 0);
-	if (ret < 0) {
-		warning("avformat: error opening hw device vaapi (%i)\n", ret);
-		return ENOMEM;
-	}
+    if (avformat_hwdevice != AV_HWDEVICE_TYPE_NONE)
+    {
+        AVBufferRef *hwctx;
+        ret = av_hwdevice_ctx_create(&hwctx, avformat_hwdevice,
+                NULL, NULL, 0);
+        if (ret < 0) {
+            warning("avformat: error opening hw device vaapi (%i)\n", ret);
+            return ENOMEM;
+        }
 
-	ctx->hw_device_ctx = av_buffer_ref(hwctx);
+        ctx->hw_device_ctx = av_buffer_ref(hwctx);
 
-	av_buffer_unref(&hwctx);
+        av_buffer_unref(&hwctx);
+    }
 
 	s->time_base = strm->time_base;
 	s->ctx = ctx;
@@ -284,13 +293,15 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 		}
 	}
 
-	ret = av_dict_set(&format_opts, "input_format", "mjpeg", 0);
-	if (ret != 0) {
-		warning("avformat: av_dict_set(input_format) failed"
-				" (ret=%s)\n", av_err2str(ret));
-		err = ENOENT;
-		goto out;
-	}
+    if (strnlen(avformat_inputformat, sizeof avformat_inputformat)  > 0) {
+        ret = av_dict_set(&format_opts, "input_format", avformat_inputformat, 0);
+        if (ret != 0) {
+            warning("avformat: av_dict_set(input_format) failed"
+                    " (ret=%s)\n", av_err2str(ret));
+            err = ENOENT;
+            goto out;
+        }
+    }
 
 	ret = avformat_open_input(&st->ic, dev, input_format, &format_opts);
 	if (ret < 0) {
@@ -388,7 +399,19 @@ void avformat_shared_set_video(struct shared *sh, struct vidsrc_st *st)
 
 static int module_init(void)
 {
-	int err;
+    int err;
+    char hwaccel[64] = "";
+
+    conf_get_str(conf_cur(), "avformat_hwaccel", hwaccel, sizeof(hwaccel));
+    if (strnlen(hwaccel, sizeof(hwaccel)) > 0) {
+        avformat_hwdevice = av_hwdevice_find_type_by_name(hwaccel);
+        if (avformat_hwdevice == AV_HWDEVICE_TYPE_NONE) {
+            warning("avformat: hwdevice not found (%s)\n", hwaccel);
+        }
+    }
+
+    conf_get_str(conf_cur(), "avformat_inputformat", avformat_inputformat,
+            sizeof(avformat_inputformat));
 
 	avformat_network_init();
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -173,6 +173,18 @@ static int open_codec(struct stream *s, const struct AVStream *strm, int i,
 		return ENOMEM;
 	}
 
+	AVBufferRef *hwctx;
+	ret = av_hwdevice_ctx_create(&hwctx, AV_HWDEVICE_TYPE_VAAPI,
+			NULL, NULL, 0);
+	if (ret < 0) {
+		warning("avformat: error opening hw device vaapi (%i)\n", ret);
+		return ENOMEM;
+	}
+
+	ctx->hw_device_ctx = av_buffer_ref(hwctx);
+
+	av_buffer_unref(&hwctx);
+
 	s->time_base = strm->time_base;
 	s->ctx = ctx;
 	s->idx = i;
@@ -270,6 +282,14 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 			err = ENOENT;
 			goto out;
 		}
+	}
+
+	ret = av_dict_set(&format_opts, "input_format", "mjpeg", 0);
+	if (ret != 0) {
+		warning("avformat: av_dict_set(input_format) failed"
+				" (ret=%s)\n", av_err2str(ret));
+		err = ENOENT;
+		goto out;
 	}
 
 	ret = avformat_open_input(&st->ic, dev, input_format, &format_opts);

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -28,8 +28,8 @@
  *
  * Example config:
  \verbatim
-  audio_source			  avformat,/tmp/testfile.mp4
-  video_source			  avformat,/tmp/testfile.mp4
+  audio_source            avformat,/tmp/testfile.mp4
+  video_source            avformat,/tmp/testfile.mp4
 
   avformat_hwaccel		vaapi
   avformat_inputformat	mjpeg
@@ -116,10 +116,10 @@ static void *read_thread(void *data)
 				sys_msleep(1000);
 
 				ret = av_seek_frame(st->ic, -1, 0,
-							AVSEEK_FLAG_BACKWARD);
+						    AVSEEK_FLAG_BACKWARD);
 				if (ret < 0) {
 					info("avformat: seek error (%d)\n",
-						 ret);
+					     ret);
 					goto out;
 				}
 
@@ -164,7 +164,7 @@ static void *read_thread(void *data)
 
 
 static int open_codec(struct stream *s, const struct AVStream *strm, int i,
-			  AVCodecContext *ctx)
+		      AVCodecContext *ctx)
 {
 	AVCodec *codec = avformat_decoder;
 	int ret;
@@ -209,8 +209,8 @@ static int open_codec(struct stream *s, const struct AVStream *strm, int i,
 	s->idx = i;
 
 	debug("avformat: '%s' using decoder '%s' (%s)\n",
-		  av_get_media_type_string(ctx->codec_type),
-		  codec->name, codec->long_name);
+	      av_get_media_type_string(ctx->codec_type),
+	      codec->name, codec->long_name);
 
 	return 0;
 }
@@ -239,7 +239,7 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 
 	st->id = "avformat";
 
-	st->au.idx	= -1;
+	st->au.idx  = -1;
 	st->vid.idx = -1;
 
 	if (0 == re_regex(dev, str_len(dev), "[^,]+,[^]+", &pl_fmt, &pl_dev)) {
@@ -259,7 +259,7 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 		input_format = av_find_input_format(format);
 		if (input_format) {
 			debug("avformat: using format '%s' (%s)\n",
-				  input_format->name, input_format->long_name);
+			      input_format->name, input_format->long_name);
 		}
 		else {
 			warning("avformat: input format not found (%s)\n",
@@ -444,10 +444,10 @@ static int module_init(void)
 	avdevice_register_all();
 
 	err  = ausrc_register(&ausrc, baresip_ausrcl(),
-				  "avformat", avformat_audio_alloc);
+			      "avformat", avformat_audio_alloc);
 
 	err |= vidsrc_register(&mod_avf, baresip_vidsrcl(),
-				   "avformat", avformat_video_alloc, NULL);
+			       "avformat", avformat_video_alloc, NULL);
 
 	return err;
 }

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -141,13 +141,14 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 		goto out;
 #endif
 
+#if LIBAVUTIL_VERSION_MAJOR >= 56
 	if (st->vid.ctx->hw_device_ctx) {
 		AVFrame *frame2;
 		frame2 = av_frame_alloc();
 		if (!frame2)
 			goto out;
 
-		// Many hw decoders are happy about YUV420P
+		/* Many hw decoders are happy about YUV420P */
 		frame2->format = AV_PIX_FMT_YUV420P;
 		ret = av_hwframe_transfer_data(frame2, frame, 0);
 		if (ret < 0) {
@@ -165,6 +166,7 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 		av_frame_move_ref(frame, frame2);
 		av_frame_free(&frame2);
 	}
+#endif
 
 	vf.fmt = avpixfmt_to_vidfmt(frame->format);
 	if (vf.fmt == (enum vidfmt)-1) {

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -39,11 +39,11 @@ static enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt)
 	case AV_PIX_FMT_YUV420P:  return VID_FMT_YUV420P;
 	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
 	case AV_PIX_FMT_YUV444P:  return VID_FMT_YUV444P;
-	case AV_PIX_FMT_NV12:     return VID_FMT_NV12;
-	case AV_PIX_FMT_NV21:     return VID_FMT_NV21;
+	case AV_PIX_FMT_NV12:	  return VID_FMT_NV12;
+	case AV_PIX_FMT_NV21:	  return VID_FMT_NV21;
 	case AV_PIX_FMT_UYVY422:  return VID_FMT_UYVY422;
 	case AV_PIX_FMT_YUYV422:  return VID_FMT_YUYV422;
-	default:                  return (enum vidfmt)-1;
+	default:				  return (enum vidfmt)-1;
 	}
 }
 
@@ -69,7 +69,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	if (!st)
 		return ENOMEM;
 
-	st->vs     = vs;
+	st->vs	   = vs;
 	st->frameh = frameh;
 	st->arg    = arg;
 
@@ -78,7 +78,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	}
 	else {
 		err = avformat_shared_alloc(&st->shared, dev,
-					    prm->fps, size, true);
+						prm->fps, size, true);
 		if (err)
 			goto out;
 
@@ -141,30 +141,30 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 		goto out;
 #endif
 
-    if (st->vid.ctx->hw_device_ctx) {
-        AVFrame *frame2;
-        frame2 = av_frame_alloc();
-        if (!frame2)
-            goto out;
+	if (st->vid.ctx->hw_device_ctx) {
+		AVFrame *frame2;
+		frame2 = av_frame_alloc();
+		if (!frame2)
+			goto out;
 
-        // Many hw decoders are happy about YUV420P
-        frame2->format = AV_PIX_FMT_YUV420P;
-        ret = av_hwframe_transfer_data(frame2, frame, 0);
-        if (ret < 0) {
-            av_frame_free(&frame2);
-            goto out;
-        }
+		// Many hw decoders are happy about YUV420P
+		frame2->format = AV_PIX_FMT_YUV420P;
+		ret = av_hwframe_transfer_data(frame2, frame, 0);
+		if (ret < 0) {
+			av_frame_free(&frame2);
+			goto out;
+		}
 
-        ret = av_frame_copy_props(frame2, frame);
-        if (ret < 0) {
-            av_frame_free(&frame2);
-            goto out;
-        }
+		ret = av_frame_copy_props(frame2, frame);
+		if (ret < 0) {
+			av_frame_free(&frame2);
+			goto out;
+		}
 
-        av_frame_unref(frame);
-        av_frame_move_ref(frame, frame2);
-        av_frame_free(&frame2);
-    }
+		av_frame_unref(frame);
+		av_frame_move_ref(frame, frame2);
+		av_frame_free(&frame2);
+	}
 
 	vf.fmt = avpixfmt_to_vidfmt(frame->format);
 	if (vf.fmt == (enum vidfmt)-1) {
@@ -179,7 +179,7 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 	vf.size.h = st->vid.ctx->height;
 
 	for (i=0; i<4; i++) {
-		vf.data[i]     = frame->data[i];
+		vf.data[i]	   = frame->data[i];
 		vf.linesize[i] = frame->linesize[i];
 	}
 

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -39,11 +39,11 @@ static enum vidfmt avpixfmt_to_vidfmt(enum AVPixelFormat pix_fmt)
 	case AV_PIX_FMT_YUV420P:  return VID_FMT_YUV420P;
 	case AV_PIX_FMT_YUVJ420P: return VID_FMT_YUV420P;
 	case AV_PIX_FMT_YUV444P:  return VID_FMT_YUV444P;
-	case AV_PIX_FMT_NV12:	  return VID_FMT_NV12;
-	case AV_PIX_FMT_NV21:	  return VID_FMT_NV21;
+	case AV_PIX_FMT_NV12:     return VID_FMT_NV12;
+	case AV_PIX_FMT_NV21:     return VID_FMT_NV21;
 	case AV_PIX_FMT_UYVY422:  return VID_FMT_UYVY422;
 	case AV_PIX_FMT_YUYV422:  return VID_FMT_YUYV422;
-	default:				  return (enum vidfmt)-1;
+	default:                  return (enum vidfmt)-1;
 	}
 }
 
@@ -69,7 +69,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	if (!st)
 		return ENOMEM;
 
-	st->vs	   = vs;
+	st->vs     = vs;
 	st->frameh = frameh;
 	st->arg    = arg;
 
@@ -78,7 +78,7 @@ int avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 	}
 	else {
 		err = avformat_shared_alloc(&st->shared, dev,
-						prm->fps, size, true);
+					    prm->fps, size, true);
 		if (err)
 			goto out;
 
@@ -181,7 +181,7 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 	vf.size.h = st->vid.ctx->height;
 
 	for (i=0; i<4; i++) {
-		vf.data[i]	   = frame->data[i];
+		vf.data[i]     = frame->data[i];
 		vf.linesize[i] = frame->linesize[i];
 	}
 


### PR DESCRIPTION
This makes mjpeg decoding on avformat+v4l2 with hwaccel vaapi (common in GNU/Linux specially with Intel CPUs). It works fine here with almost no cpu use on vidloop at 720p 30fps.

All is hardcoded so... how do you see adding some config values to handle this?

Something like:
avformat_hwaccel vaapi           # ffmpeg -hwaccel vaapi ....
avformat_inputformat mjpeg     # ffmpeg -input_format -f v4l2 ...