### PR TITLE
Intelligent call answer

### DIFF
--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -72,13 +72,18 @@ static int cmd_answer(struct re_printf *pf, void *arg)
 	struct menu *menu = menu_get();
 	int err;
 
+	if (!ua)
+		re_hprintf(pf, "no current User-Agent\n");
+
 	err = re_hprintf(pf, "%s: Answering incoming call\n",
 			 account_aor(ua_account(ua)));
 
 	/* Stop any ongoing ring-tones */
 	menu->play = mem_deref(menu->play);
 
-	ua_hold_answer(ua, NULL, VIDMODE_ON);
+	err = ua_hold_answer(ua, NULL, VIDMODE_ON);
+	if (err)
+		re_hprintf(pf, "no incoming call found\n");
 
 	return err;
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -379,6 +379,25 @@ static struct call *ua_find_call_onhold(const struct ua *ua)
 }
 
 
+static struct call *ua_find_call_state(const struct ua *ua, enum call_state st)
+{
+	struct le *le;
+
+	if (!ua)
+		return NULL;
+
+	for (le = ua->calls.tail; le; le = le->prev) {
+
+		struct call *call = le->data;
+
+		if (call_state(call) == st)
+			return call;
+	}
+
+	return NULL;
+}
+
+
 static void resume_call(struct ua *ua)
 {
 	struct call *call;
@@ -1119,10 +1138,10 @@ int ua_answer(struct ua *ua, struct call *call, enum vidmode vmode)
 
 
 /**
- * Put the current call on hold and answer the incoming call
+ * Put the established call on hold and answer the given call
  *
  * @param ua    User-Agent
- * @param call  Call to answer, or NULL for current call
+ * @param call  Call to answer, or NULL for last incoming call
  * @param vmode Wanted video mode for the incoming call
  *
  * @return 0 if success, otherwise errorcode
@@ -1136,13 +1155,13 @@ int ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode)
 		return EINVAL;
 
 	if (!call) {
-		call = ua_call(ua);
+		call = ua_find_call_state(ua, CALL_STATE_INCOMING);
 		if (!call)
 			return ENOENT;
 	}
 
-	/* put previous call on-hold */
-	pcall = ua_prev_call(ua);
+	/* put established call on-hold */
+	pcall = ua_find_call_state(ua, CALL_STATE_ESTABLISHED);
 	if (pcall) {
 		ua_printf(ua, "putting call with '%s' on hold\n",
 		     call_peeruri(pcall));


### PR DESCRIPTION
A first small step toward an intelligent call answer.

It is bound to the menu_uacur(). After merge of https://github.com/baresip/baresip/pull/1207 this is the UA of the active call.

For further improvements, should we consider an overall UA call answer strategy? 