### PR TITLE
Disable verify server cert

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -28,6 +28,7 @@
 #    ;regq=0.5
 #    ;sipnat={outbound}
 #    ;stunserver=stun:[user:pass]@host[:port]
+#    ;verify_server_cert=yes
 #    ;video_codecs=h264,h263,...
 #
 # Examples:

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -108,6 +108,7 @@ const char *account_mwi(const struct account *acc);
 const char *account_call_transfer(const struct account *acc);
 const char *account_extra(const struct account *acc);
 bool account_sip_autoanswer(const struct account *acc);
+bool account_verify_server(const struct account *acc);
 
 
 /*

--- a/src/account.c
+++ b/src/account.c
@@ -200,6 +200,18 @@ static void autoanswer_allow_decode(struct account *prm, const struct pl *pl)
 }
 
 
+static void verify_decode(struct account *prm, const struct pl *pl)
+{
+	struct pl v;
+
+	if (0 == msg_param_decode(pl, "verify_server_cert", &v)) {
+		if (0 == pl_strcasecmp(&v, "no")) {
+			prm->verify = false;
+		}
+	}
+}
+
+
 static int csl_parse(struct pl *pl, char *str, size_t sz)
 {
 	struct pl ws = PL_INIT, val, ws2 = PL_INIT, cma = PL_INIT;
@@ -430,9 +442,11 @@ int account_alloc(struct account **accp, const char *sipaddr)
 
 	/* Decode parameters */
 	acc->ptime = 20;
+	acc->verify = true;
 	err |= sip_params_decode(acc, &acc->laddr);
 	       answermode_decode(acc, &acc->laddr.params);
 	       autoanswer_allow_decode(acc, &acc->laddr.params);
+	       verify_decode(acc, &acc->laddr.params);
 	err |= audio_codecs_decode(acc, &acc->laddr.params);
 	err |= video_codecs_decode(acc, &acc->laddr.params);
 	err |= media_decode(acc, &acc->laddr.params);
@@ -1268,6 +1282,18 @@ uint16_t account_stun_port(const struct account *acc)
 bool account_sip_autoanswer(const struct account *acc)
 {
 	return acc ? acc->sipans : false;
+}
+
+
+/**
+ * Returns if the server certificate for SIP TLS should be verified
+ *
+ * @param acc User-Agent account
+ * @return true by default, false if verify_server=no in accounts
+ */
+bool account_verify_server(const struct account *acc)
+{
+	return acc ? acc->verify : true;
 }
 
 

--- a/src/call.c
+++ b/src/call.c
@@ -1945,6 +1945,9 @@ static int send_invite(struct call *call)
 		goto out;
 	}
 
+	if (!account_verify_server(call->acc))
+		(void) sipsess_enverify(call->sess, false);
+
 	err = str_dup(&call->id,
 		      sip_dialog_callid(sipsess_dialog(call->sess)));
 

--- a/src/core.h
+++ b/src/core.h
@@ -80,6 +80,7 @@ struct account {
 	struct list vidcodecl;       /**< List of preferred video-codecs     */
 	bool mwi;                    /**< MWI on/off                         */
 	bool refer;                  /**< REFER method on/off                */
+	bool verify;                 /**< Verify server certificate on/off   */
 	char *ausrc_mod;
 	char *ausrc_dev;
 	char *auplay_mod;


### PR DESCRIPTION
Allows to disable the SIP TLS server verification if configured in accounts. By default the server verification is enabled for SIP TLS.

TODO: testing