### PR TITLE
disable_verify_server_general

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -12,6 +12,7 @@ poll_method		epoll		# poll, select, epoll ..
 #sip_certificate	cert.pem
 #sip_cafile		ca.crt
 #sip_trans_def		udp
+#sip_verify_server	yes
 
 # Call
 call_local_timeout	120

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -285,6 +285,7 @@ struct config_sip {
 	char cert[256];         /**< SIP Certificate                */
 	char cafile[256];       /**< SIP CA-file                    */
 	enum sip_transp transp; /**< Default outgoing SIP transport protocol */
+	bool verify_server;     /**< Enable SIP TLS verify server   */
 };
 
 /** Call config */

--- a/src/config.c
+++ b/src/config.c
@@ -31,6 +31,7 @@ static struct config core_config = {
 		"",
 		"",
 		SIP_TRANSP_UDP,
+		true,
 	},
 
 	/** Call config */
@@ -290,6 +291,9 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	if (!conf_get(conf, "sip_trans_def", &tr))
 		cfg->sip.transp = sip_transp_decode(&tr);
 
+	(void)conf_get_bool(conf, "sip_verify_server",
+			&cfg->sip.verify_server);
+
 	/* Call */
 	(void)conf_get_u32(conf, "call_local_timeout",
 			   &cfg->call.local_timeout);
@@ -419,6 +423,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "sip_certificate\t%s\n"
 			 "sip_cafile\t\t%s\n"
 			 "sip_trans_def\t%s\n"
+			 "sip_verify_server\t%s\n"
 			 "\n"
 			 "# Call\n"
 			 "call_local_timeout\t%u\n"
@@ -462,6 +467,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 
 			 cfg->sip.local, cfg->sip.cert, cfg->sip.cafile,
 			 sip_transp_name(cfg->sip.transp),
+			 cfg->sip.verify_server ? "yes" : "no",
 
 			 cfg->call.local_timeout,
 			 cfg->call.max_calls,
@@ -610,6 +616,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			 "#sip_cafile\t\t%s\n"
 #endif
 			  "#sip_trans_def\tudp\n"
+			  "#sip_verify_server\tyes\n"
 			  "\n"
 			  "# Call\n"
 			  "call_local_timeout\t%u\n"

--- a/src/ua.c
+++ b/src/ua.c
@@ -1531,6 +1531,9 @@ static int add_transp_af(const struct sa *laddr)
 						" %m\n", err);
 				}
 			}
+
+			if (!uag.cfg->verify_server)
+				tls_disable_verify_server(uag.tls);
 		}
 
 		if (sa_isset(&local, SA_PORT))

--- a/test/main.c
+++ b/test/main.c
@@ -220,6 +220,7 @@ int main(int argc, char *argv[])
 		goto out;
 
 	str_ncpy(config->sip.local, "127.0.0.1:0", sizeof(config->sip.local));
+	config->sip.verify_server = false;
 
 	uag_set_exit_handler(ua_exit_handler, NULL);
 


### PR DESCRIPTION
Adds a config flag sip_verfiy_server that disables the SIP TLS server verification.

By default server verification is turned on.