### PR TITLE
Multicast module

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -291,6 +291,7 @@ MODULES   += vidinfo
 MODULES   += vidloop
 MODULES   += vumeter
 MODULES   += mixausrc
+MODULES   += multicast
 
 ifneq ($(HAVE_PTHREAD),)
 MODULES   += aubridge aufile ausine

--- a/modules/multicast/module.mk
+++ b/modules/multicast/module.mk
@@ -1,0 +1,12 @@
+#
+# module.mk
+#
+# Copyright (C) 2021 Commend.com - c.huber@commend.com
+#
+
+MOD		:= multicast
+
+$(MOD)_SRCS	+= multicast.c sender.c receiver.c
+$(MOD)_SRCS	+= player.c source.c
+
+include mk/mod.mk

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -1,0 +1,265 @@
+/**
+ * @file multicast.c
+ *
+ * @note only std payload types (pt) of RTP are acceped! (PCMU, PCMA, G722 ...)
+ *
+ * Copyright (C) 2021 Commend.com - c.huber@commend.com
+ */
+
+#include <re.h>
+#include <baresip.h>
+
+#include "multicast.h"
+
+#define DEBUG_MODULE "multicast"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+/**
+ * @brief Decode IP-addess <IP>:<PORT>
+ *
+ * @param pladdr	Parameter string
+ * @param addr		Address ptr
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int decode_addr(struct pl *pladdr, struct sa *addr)
+{
+	int err = 0;
+
+	err = sa_decode(addr, pladdr->p, pladdr->l);
+	if (err)
+		warning ("multicast: addess decode %m\n", err);
+
+
+	if (sa_port(addr) % 2) {
+		err = EINVAL;
+		warning("multicast: addess port for RTP should be even (%d)\n",
+			sa_port(addr));
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Decode Audiocodec <CODEC>
+ *
+ * @param plcodec	Parameter string
+ * @param codecptr	Codec ptr
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int decode_codec(struct pl *plcodec, struct aucodec **codecptr)
+{
+	int err = 0;
+	struct list *acodeclist = baresip_aucodecl();
+	struct aucodec *codec;
+	struct le *le;
+
+	LIST_FOREACH(acodeclist, le) {
+		codec = list_ledata(le);
+		if (0 == pl_strcasecmp(plcodec, codec->name))
+			break;
+
+		codec = NULL;
+	}
+
+	if (!codec) {
+		err = EINVAL;
+		warning ("multicast: codec not found (%r)\n", plcodec);
+	}
+
+	*codecptr = codec;
+	return err;
+}
+
+
+/**
+ * @brief Check audio encoder RTP payload type
+ *
+ * @param ac	Audiocodec object
+ *
+ * @return int 0 if succes, errorcode otherwise
+ */
+static int check_rtp_pt(struct aucodec *ac)
+{
+	if (!ac)
+		return EINVAL;
+
+	return ac->pt ? 0 : ENOTSUP;
+}
+
+
+/**
+ * @brief Create a new multicast sender
+ *
+ * @param pf	Printer
+ * @param arg	Command arguments
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int cmd_mcsend(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	const struct cmd_arg *carg = arg;
+	struct pl pladdr, plcodec;
+	struct sa addr;
+	struct aucodec *codec = NULL;
+
+	err = re_regex(carg->prm, str_len(carg->prm),
+		"addr=[^ ]* codec=[^ ]*", &pladdr, &plcodec);
+	if (err)
+		goto out;
+
+	err = decode_addr(&pladdr, &addr);
+	err |= decode_codec(&plcodec, &codec);
+	if (err)
+		goto out;
+
+	err = check_rtp_pt(codec);
+	if (err) {
+		warning ("multicast: non standardized RTP "
+			"payload type found as codec: %m\n", err);
+		goto out;
+	}
+
+	err = mcsender_alloc(&addr, codec);
+
+  out:
+	if (err) {
+		re_hprintf(pf,
+			"usage: /mcsend addr=<IP>:<PORT> codec=<CODEC>\n");
+		re_hprintf(pf, "errorcode: %d (%m)\n", err, err);
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Stop all multicast sender
+ *
+ * @param pf	Printer
+ * @param arg	Command arguments
+ *
+ * @return int always 0
+ */
+static int cmd_mcstopall(struct re_printf *pf, void *arg)
+{
+	(void) pf;
+	(void) arg;
+
+	mcsender_stopall();
+	return 0;
+}
+
+
+/**
+ * @brief Stop a specified multicast sender
+ *
+ * @param pf	Printer
+ * @param arg	Command arguments
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int cmd_mcstop(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	const struct cmd_arg *carg = arg;
+	struct pl pladdr;
+	struct sa addr;
+
+	err = re_regex(carg->prm, str_len(carg->prm),
+		"addr=[^ ]*", &pladdr);
+	if (err)
+		goto out;
+
+	err = decode_addr(&pladdr, &addr);
+	if (err)
+		goto out;
+
+	mcsender_stop(&addr);
+
+  out:
+	if (err)
+		re_hprintf(pf, "usage: /mcstop addr=<IP>:<PORT>\n");
+
+	return err;
+}
+
+
+/**
+ * Print all multicast information
+ */
+static int cmd_mcinfo(struct re_printf *pf, void *arg)
+{
+	(void)pf;
+	(void)arg;
+
+	mcsender_print(pf);
+	/* mcrecv_printinfo(); */
+
+	return 0;
+}
+
+
+/**
+ * user callable methods via menue
+ */
+static const struct cmd cmdv[] = {
+	{"mcinfo",    0, CMD_PRM, "Show multicast information", cmd_mcinfo   },
+
+	{"mcsend",    0, CMD_PRM, "Send multicast"            , cmd_mcsend   },
+	{"mcstop",    0, CMD_PRM, "Stop multicast"            , cmd_mcstop   },
+	{"mcstopall", 0, CMD_PRM, "Stop all multicast"        , cmd_mcstopall},
+
+	/*
+	{"mc_register", 0, CMD_PRM, "Register a new MC to listen on",
+		cmd_mc_register},
+	{"mc_unregister", 0, CMD_PRM, "Unregister an MC", cmd_mc_unregister},
+	{"mc_chprio", 0, CMD_PRM, "Change priority of existing MC listener",
+		cmd_mc_chprio},
+	{"mc_clearl", 0, CMD_PRM, "Clear all existing MC listeners",
+	cmd_mc_clearl},
+	{"mc_clears", 0, CMD_PRM, "Clear all existing MC sender",
+	cmd_mc_clears},
+	{"mc_create", 0, CMD_PRM, "Create a MC", cmd_mc_create},
+	{"mc_stop", 0, CMD_PRM, "Stop a MC", cmd_mc_stop},
+	{"mc_prio_en", 0, CMD_PRM, "Enable/Disable all MC lower than given",
+		cmd_mc_disableprio},
+	{"mc_send_en", 0, CMD_PRM, "Enable/Disable MC send", cmd_mc_send_en},
+	{"mc_receive_en", 0, CMD_PRM, "Enable/Disable MC receive",
+		cmd_mc_receive_en}
+	*/
+};
+
+
+static int module_init(void)
+{
+	int err = 0;
+
+	err = cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
+
+	return err;
+}
+
+
+static int module_close(void)
+{
+	mcsender_stopall();
+	/* mcrecever_stopall(); */
+
+	cmd_unregister(baresip_commands(), cmdv);
+
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(multicast) = {
+	"multicast",
+	"application",
+	module_init,
+	module_close
+};

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -1,0 +1,46 @@
+/**
+ * @file multicast.h  Private multicast interface
+ *
+ * Copyright (c) 2020 Commend.com - c.huber@commend.com
+ */
+
+
+/* Multicast */
+enum {
+	MAX_SRATE	= 48000,              /* Maximum sample rate in [Hz] */
+	MAX_CHANNELS	= 2,                  /* Maximum number of channels  */
+	MAX_PTIME	= 60,                 /* Maximum packet time in [ms] */
+
+	STREAM_PRESZ	= RTP_HEADER_SIZE + 4,/* same as RTP_HEADER_SIZE */
+
+	AUDIO_SAMPSZ	= MAX_SRATE * MAX_CHANNELS * MAX_PTIME / 1000,
+	PTIME		= 20,
+};
+
+
+/* Sender */
+typedef int (mcsender_send_h)(uint32_t ext_len, bool marker, uint32_t rtp_ts,
+	struct mbuf *mb, void *arg);
+
+int  mcsender_alloc(struct sa *addr, const struct aucodec *codec);
+void mcsender_stopall(void);
+void mcsender_stop(struct sa *addr);
+
+void mcsender_print(struct re_printf *pf);
+
+/* Receiver */
+int mcreceiver_alloc(struct sa *addr, uint8_t prio);
+void mcreceiver_unregall(void);
+void mcreceiver_unreg(struct sa *addr);
+int mcreceiver_chprio(struct sa *addr, uint32_t prio);
+
+void mcreceiver_print(struct re_printf *pf);
+
+/* Player <exchangable player> */
+int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac);
+void mcplayer_stop(void);
+
+/* Source <exchangable source> */
+struct mcsource;
+int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
+	mcsender_send_h *sendh, void *arg);

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -19,12 +19,13 @@ enum {
 
 
 /* Sender */
-typedef int (mcsender_send_h)(uint32_t ext_len, bool marker, uint32_t rtp_ts,
+typedef int (mcsender_send_h)(size_t ext_len, bool marker, uint32_t rtp_ts,
 	struct mbuf *mb, void *arg);
 
 int  mcsender_alloc(struct sa *addr, const struct aucodec *codec);
 void mcsender_stopall(void);
 void mcsender_stop(struct sa *addr);
+void mcsender_enable(bool enable);
 
 void mcsender_print(struct re_printf *pf);
 
@@ -33,6 +34,8 @@ int mcreceiver_alloc(struct sa *addr, uint8_t prio);
 void mcreceiver_unregall(void);
 void mcreceiver_unreg(struct sa *addr);
 int mcreceiver_chprio(struct sa *addr, uint32_t prio);
+void mcreceiver_enprio(uint32_t prio);
+void mcreceiver_enable(bool enable);
 
 void mcreceiver_print(struct re_printf *pf);
 

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -1,0 +1,559 @@
+/**
+ * @file player.c
+ *
+ * Copyright (C) 2021 Commend.com - c.huber@commend.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
+
+#include "multicast.h"
+
+
+#define DEBUG_MODULE "mcplayer"
+#define DEBUG_LEVEL 6
+#include <re_dbg.h>
+
+
+/**
+ * Multicast player struct
+ *
+ * Contains configuration of the audio player and buffer for the audio data
+ */
+struct mcplayer{
+	struct config_audio *cfg;
+	struct jbuf *jbuf;
+	bool jbuf_started;
+
+	struct auplay_st *auplay;
+	struct auplay_prm auplay_prm;
+	const struct aucodec *ac;
+	struct audec_state *dec;
+	struct aubuf *aubuf;
+	volatile bool aubuf_started;
+	size_t aubuf_minsz;
+	size_t aubuf_maxsz;
+	size_t num_bytes;
+
+	struct auresamp resamp;
+	struct list filterl;
+	char *module;
+	char *device;
+	void*sampv;
+	int16_t *sampv_rs;
+	uint32_t ptime;
+	enum aufmt play_fmt;
+	enum aufmt dec_fmt;
+	uint32_t again;
+
+#ifdef HAVE_PTHREAD
+	struct {
+		pthread_t tid;
+		bool run;
+		pthread_cond_t cond;
+		pthread_mutex_t mutex;
+	} thr;
+#else
+	struct tmr tmr;
+#endif
+};
+
+
+static struct mcplayer *player;
+
+
+static void mcplayer_destructor(void *arg)
+{
+	(void) arg;
+
+	player->auplay = mem_deref(player->auplay);
+
+#ifdef HAVE_PTHREAD
+	if (player->thr.run) {
+		player->thr.run = false;
+		pthread_join(player->thr.tid, NULL);
+	}
+
+	pthread_mutex_destroy(&player->thr.mutex);
+	pthread_cond_destroy(&player->thr.cond);
+#else
+	tmr_cancel(&player_tmr);
+#endif
+
+	player->jbuf     = mem_deref(player->jbuf);
+	player->module   = mem_deref(player->module);
+	player->device   = mem_deref(player->device);
+	player->dec      = mem_deref(player->dec);
+
+	player->sampv    = mem_deref(player->sampv);
+	player->sampv_rs = mem_deref(player->sampv_rs);
+	player->aubuf    = mem_deref(player->aubuf);
+}
+
+
+/**
+ * Decode the payload of the RTP packet
+ *
+ * @param hdr RTP header
+ * @param mb  RTP payload
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int stream_recv_handler(const struct rtp_header *hdr, struct mbuf *mb)
+{
+	struct auframe af;
+	struct le *le;
+	size_t sampc = AUDIO_SAMPSZ;
+	bool marker = hdr->m;
+	void *sampv;
+	int err = 0;
+
+	if (!player)
+		return EINVAL;
+
+	if (!player->ac)
+		return 0;
+
+	if (hdr->ext && hdr->x.len && mb)
+		return ENOTSUP;
+
+	if (mbuf_get_left(mb)) {
+		err = player->ac->dech(player->dec, player->dec_fmt,
+			player->sampv, &sampc, marker,
+			mbuf_buf(mb), mbuf_get_left(mb));
+		if (err)
+			goto out;
+	}
+	else if (player->ac->plch && player->dec_fmt == AUFMT_S16LE) {
+		err = player->ac->plch(player->dec, player->dec_fmt,
+			player->sampv, &sampc,
+			mbuf_buf(mb), mbuf_get_left(mb));
+		if (err)
+			goto out;
+	}
+	else {
+		sampc = 0;
+	}
+
+	auframe_init(&af, player->dec_fmt, player->sampv, sampc);
+
+	for (le = player->filterl.tail; le; le = le->prev) {
+		struct aufilt_dec_st *st = le->data;
+
+		if (st->af && st->af->dech)
+			err |= st->af->dech(st, &af);
+
+	}
+
+	if (!player->aubuf)
+		goto out;
+
+	sampv = af.sampv;
+	sampc = af.sampc;
+
+	if (player->resamp.resample) {
+		size_t sampc_rs = AUDIO_SAMPSZ;
+
+		if (player->dec_fmt != AUFMT_S16LE)
+			return ENOTSUP;
+
+		err = auresamp(&player->resamp, player->sampv_rs, &sampc_rs,
+			player->sampv, sampc);
+		if (err)
+			goto out;
+
+		sampv = player->sampv_rs;
+		sampc = sampc_rs;
+	}
+
+	if (player->play_fmt == player->dec_fmt) {
+		size_t num_bytes = sampc * aufmt_sample_size(player->play_fmt);
+		err = aubuf_write(player->aubuf, sampv, num_bytes);
+		if (err)
+			goto out;
+	}
+	else if (player->dec_fmt == AUFMT_S16LE) {
+		void *tmp_sampv;
+
+		size_t num_bytes = sampc * aufmt_sample_size(player->play_fmt);
+
+		tmp_sampv = mem_zalloc(num_bytes, NULL);
+		if (!tmp_sampv)
+			return ENOMEM;
+
+		auconv_from_s16(player->play_fmt, tmp_sampv, sampv, sampc);
+		err = aubuf_write(player->aubuf, tmp_sampv, num_bytes);
+		mem_deref(tmp_sampv);
+
+		if (err)
+			goto out;
+	}
+	else {
+		warning ("multicast player: invalid sample format "
+			"(%s -> %s)\n", aufmt_name(player->dec_fmt),
+			aufmt_name(player->play_fmt));
+	}
+
+	player->aubuf_started = true;
+
+  out:
+
+	return err;
+}
+
+
+/**
+ * Decode RTP packet
+ *
+ * @param arg Multicast player object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int stream_decode(void *arg)
+{
+	void *mb = NULL;
+	struct rtp_header hdr;
+	int err = 0;
+
+	(void) arg;
+
+	if (!player)
+		return EINVAL;
+
+	if (!player->jbuf)
+		return ENOENT;
+
+	err = jbuf_get(player->jbuf, &hdr, &mb);
+	if (err && err != EAGAIN)
+		return ENOENT;
+
+	player->jbuf_started = true;
+
+	err = stream_recv_handler(&hdr, mb);
+	mb = mem_deref(mb);
+
+	return err;
+}
+
+
+/**
+ * Decode audio
+ *
+ * @param arg Multicast player object
+ */
+static void audio_decode(void *arg)
+{
+	int err = 0;
+
+	(void) arg;
+
+	while (err == EAGAIN ||
+		(!err && aubuf_cur_size(player->aubuf) < player->num_bytes)) {
+		if (err == EAGAIN)
+			player->again++;
+
+		err = stream_decode(player);
+		if (err && err != EAGAIN)
+			break;
+
+#ifdef HAVE_PTHREAD
+		if (!player->thr.run)
+			break;
+#endif
+	}
+	return;
+}
+
+
+#ifdef HAVE_PTHREAD
+/**
+ * Receiver Thread, which decodecs the stream contained in the jbuf
+ *
+ * @param arg Multicast player object
+ *
+ * @return NULL
+ */
+static void *rx_thread(void *arg)
+{
+	struct timespec ts;
+	uint64_t ms;
+	int err = 0;
+
+	(void) arg;
+
+	while (player->thr.run) {
+		ms = tmr_jiffies() + 500;
+		ts.tv_sec = ms / 1000;
+		ts.tv_nsec = (ms % 1000) * 1000000UL;
+
+		err = pthread_mutex_lock(&player->thr.mutex);
+		if (err)
+			return NULL;
+
+		pthread_cond_timedwait(&player->thr.cond,
+			&player->thr.mutex, &ts);
+
+		err = pthread_mutex_unlock(&player->thr.mutex);
+		if (!player->thr.run || err)
+			break;
+
+		audio_decode(player);
+	}
+
+	return NULL;
+}
+#endif
+
+
+/**
+ * Audio player write handler
+ *
+ * @param sampv Sample buffer
+ * @param sampc Sample counter
+ * @param arg   Multicast player object (unused)
+ */
+static void auplay_write_handler(void *sampv, size_t sampc, void *arg)
+{
+	int err = 0;
+
+	(void) arg;
+
+	if (!player)
+		return;
+
+	player->num_bytes = sampc * aufmt_sample_size(player->play_fmt);
+
+	aubuf_read(player->aubuf, sampv, player->num_bytes);
+
+#ifdef HAVE_PTHREAD
+	pthread_mutex_lock(&player->thr.mutex);
+	if (!player->thr.run) {
+		player->thr.run = true;
+		err = pthread_create(&player->thr.tid, NULL,
+			rx_thread, player);
+		if (err) {
+			player->thr.run = false;
+			return;
+		}
+	}
+
+	pthread_cond_signal(&player->thr.cond);
+	pthread_mutex_unlock(&player->thr.mutex);
+#else
+	tmr_start(&player->tmr, 0, audio_decode, player);
+#endif
+}
+
+
+/**
+ * Setup all available audio filter for the decoder
+ *
+ * @param aufiltl List of audio filter
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int aufilt_setup(struct list *aufiltl)
+{
+	struct aufilt_prm prm;
+	struct le *le;
+	int err = 0;
+
+	if (!player->ac)
+		return 0;
+
+	if (!list_isempty(&player->filterl))
+		return 0;
+
+	prm.srate = player->ac->srate;
+	prm.ch = player->ac->ch;
+	prm.fmt = player->dec_fmt;
+
+	for (le = list_head(aufiltl); le; le = le->next) {
+		struct aufilt *af = le->data;
+		struct aufilt_dec_st *decst = NULL;
+		void *ctx = NULL;
+
+		if (af->decupdh) {
+			err = af->decupdh(&decst, &ctx, af, &prm, NULL);
+			if (err) {
+				warning("multicast player: error in decoder"
+					"autio-filter '%s' (%m)\n",
+					af->name, err);
+			}
+			else {
+				decst->af = af;
+				list_append(&player->filterl, &decst->le,
+					decst);
+			}
+		}
+
+		if (err) {
+			warning("multicast player: audio-filter '%s' "
+				"update failed (%m)\n", af->name, err);
+			break;
+		}
+	}
+
+	return err;
+}
+
+
+/**
+ * Allocate and start a media player for the multicast
+ *
+ * @note singleton
+ *
+ * @param jbuf Jitter buffer containing the RTP stream
+ * @param ac   Audio codec
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac)
+{
+	int err = 0;
+	struct config_audio *cfg = &conf_config()->audio;
+	uint32_t srate_dsp;
+	uint32_t channels_dsp;
+	struct auplay_prm prm;
+	bool resamp = false;
+
+	if (!jbuf || !ac)
+		return EINVAL;
+
+	if (player) {
+		warning ("multicast player: already started\n");
+		return EINPROGRESS;
+	}
+
+	player = mem_zalloc(sizeof(*player), mcplayer_destructor);
+	if (!player)
+		return ENOMEM;
+
+	player->cfg = cfg;
+	player->ac = ac;
+	player->jbuf = mem_ref(jbuf);
+	player->play_fmt = cfg->play_fmt;
+	player->dec_fmt = cfg->dec_fmt;
+
+	err = str_dup(&player->module, cfg->play_mod);
+	err |= str_dup(&player->device, cfg->play_dev);
+	player->sampv = mem_zalloc(AUDIO_SAMPSZ *
+		aufmt_sample_size(player->dec_fmt), NULL);
+	if (!player->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	auresamp_init(&player->resamp);
+	player->ptime = PTIME;
+
+#ifdef HAVE_PTHREAD
+	err = pthread_mutex_init(&player->thr.mutex, NULL);
+	err |= pthread_cond_init(&player->thr.cond, NULL);
+	if (err)
+		goto out;
+#endif
+
+	if (player->ac->decupdh) {
+		err = player->ac->decupdh(&player->dec, player->ac, NULL);
+		if (err) {
+			warning ("multicast player: alloc decoder(%m)\n",
+				err);
+			goto out;
+		}
+	}
+
+	srate_dsp = player->ac->srate;
+	channels_dsp = player->ac->ch;
+	if (cfg->srate_play && cfg->srate_play != srate_dsp) {
+		resamp = true;
+		srate_dsp = cfg->srate_play;
+	}
+	if (cfg->channels_play && cfg->channels_play != channels_dsp) {
+		resamp = true;
+		channels_dsp = cfg->channels_play;
+	}
+
+	if (resamp && !player->sampv_rs) {
+		player->sampv_rs = mem_zalloc(AUDIO_SAMPSZ * sizeof(int16_t),
+			NULL);
+
+		if (!player->sampv_rs) {
+			err = ENOMEM;
+			goto out;
+		}
+
+		err = auresamp_setup(&player->resamp,
+			player->ac->srate, player->ac->ch,
+			srate_dsp, channels_dsp);
+		if (err) {
+			warning("multicast player: could not setup auplay"
+				" resampler (%m)\n", err);
+			goto out;
+		}
+	}
+
+	prm.srate = srate_dsp;
+	prm.ch = channels_dsp;
+	prm.ptime = player->ptime;
+	prm.fmt = player->play_fmt;
+	if (!player->aubuf) {
+		const size_t sz = aufmt_sample_size(player->play_fmt);
+		const size_t ptime_min = cfg->buffer.min;
+		const size_t ptime_max = cfg->buffer.max;
+		size_t min_sz;
+		size_t max_sz;
+
+		if (!ptime_min || !ptime_max) {
+			err = EINVAL;
+			goto out;
+		}
+
+		min_sz = sz * ((prm.srate * prm.ch * ptime_min) / 10000);
+		max_sz = sz * ((prm.srate * prm.ch * ptime_max) / 10000);
+
+		err = aubuf_alloc(&player->aubuf, min_sz, max_sz * 2);
+		if (err) {
+			warning("multicast player: aubuf alloc error (%m)\n",
+				err);
+			goto out;
+		}
+	}
+
+	err = aufilt_setup(baresip_aufiltl());
+	if (err)
+	{
+		warning("multicast player: aufilt setup error (%m)\n)", err);
+		goto out;
+	}
+
+	err = auplay_alloc(&player->auplay, baresip_auplayl(), player->module,
+		&prm, player->device, auplay_write_handler, player);
+	if (err) {
+		warning("multicast player: start of %s.%s failed (%m)\n",
+			player->module, player->device, err);
+		goto out;
+	}
+
+	player->auplay_prm = prm;
+
+  out:
+	if (err)
+		player = mem_deref(player);
+
+	return err;
+}
+
+
+/**
+ * Stop multicast player
+ */
+void mcplayer_stop(void)
+{
+	player = mem_deref(player);
+}

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -1,0 +1,528 @@
+/**
+ * @file receiver.c
+ *
+ * Copyright (C) 2021 Commend.com - c.huber@commend.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+
+#include <stdlib.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
+#include "multicast.h"
+
+#define DEBUG_MODULE "mcreceiver"
+#define DEBUG_LEVEL 6
+#include <re_dbg.h>
+
+
+struct list mcreceivl = LIST_INIT;
+struct lock *mcreceivl_lock = NULL;
+
+
+enum {
+	TIMEOUT = 500,
+};
+
+/**
+ * Multicast receiver struct
+ *
+ * Contains data to collect and controll all listeners
+ */
+struct mcreceiver {
+	struct le le;
+	struct sa addr;
+	uint8_t prio;
+
+	struct rtp_sock *rtp;
+	uint32_t ssrc;
+	struct jbuf *jbuf;
+
+	const struct aucodec *ac;
+
+	struct tmr timeout;
+
+	bool running;
+	bool enable;
+	bool globenable;
+};
+
+
+static void mcreceiver_destructor(void *arg)
+{
+	struct mcreceiver *mcreceiver = arg;
+
+	tmr_cancel(&mcreceiver->timeout);
+
+	if (mcreceiver->running)
+		mcplayer_stop();
+
+	mcreceiver->rtp  = mem_deref(mcreceiver->rtp);
+	mcreceiver->jbuf = mem_deref(mcreceiver->jbuf);
+
+}
+
+
+/**
+ * Multicast address comparison
+ *
+ * @param le	List element (mcreceiver)
+ * @param arg	Argument     (address)
+ *
+ * @return true  if mcreceiver->addr == address
+ * @return false if mcreceiver->addr != address
+ */
+static bool mcreceiver_addr_cmp(struct le *le, void *arg)
+{
+	struct mcreceiver *mcreceiver = le->data;
+	struct sa *addr = arg;
+
+	return sa_cmp(&mcreceiver->addr, addr, SA_ALL);
+}
+
+
+/**
+ * Multicast receiver priority comparison
+ *
+ * @param le	List element (mcreceiver)
+ * @param arg	Argument     (priority)
+ * @return true if mcreceiver->prio == prio
+ * @return false if mcreceiver->prio != prio
+ */
+static bool mcreceiver_prio_cmp(struct le *le, void *arg)
+{
+	struct mcreceiver *mcreceiver = le->data;
+	uint32_t *prio = (uint32_t *)arg;
+
+	return mcreceiver->prio == *prio;
+}
+
+
+/**
+ * Get running multicast receiver
+ *
+ * @param le	multicast receiver list element
+ * @param arg
+ *
+ * @return true if multicast receiver is running
+ * @return false if multicast receiver is not running
+ */
+static bool mcreceiver_running(struct le *le, void *arg)
+{
+	struct mcreceiver *mcreceiver = le->data;
+	(void) arg;
+
+	return mcreceiver->running;
+}
+
+
+/**
+ * Convert std rtp codec payload type to audio codec
+ *
+ * @param hdr
+ * @return struct aucodec*
+ */
+static const struct aucodec *pt2codec(const struct rtp_header *hdr)
+{
+	const struct aucodec *codec = NULL;
+
+	switch (hdr->pt) {
+		case 0:
+			codec = aucodec_find(baresip_aucodecl(), "PCMU", 0, 1);
+			break;
+
+		case 8:
+			codec = aucodec_find(baresip_aucodecl(), "PCMA", 0, 1);
+			break;
+
+		case 9:
+			codec = aucodec_find(baresip_aucodecl(), "G722", 0, 1);
+			break;
+
+		default:
+			warning ("multicast receiver: RTP Payload "
+				"Type %d not found.\n");
+			break;
+	}
+
+	return codec;
+}
+
+
+/**
+ * Multicast Priority handling
+ *
+ * @param mcreceiver	Multicast receiver object
+ * @param ssrc		SSRC of received RTP packet
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int prio_handling(struct mcreceiver *mcreceiver, uint32_t ssrc)
+{
+	int err = 0;
+	struct le *le;
+	struct mcreceiver *hprio = NULL;
+
+	if (!mcreceiver)
+		return EINVAL;
+
+	err = lock_write_try(mcreceivl_lock);
+	if (err)
+		return err;
+
+	le = list_apply(&mcreceivl, true, mcreceiver_running, NULL);
+	if (!le) {
+		/* start the player now */
+		mcplayer_stop();
+		jbuf_flush(mcreceiver->jbuf);
+		mcreceiver->running = true;
+		mcreceiver->ssrc = ssrc;
+		ua_event(NULL, UA_EVENT_CUSTOM, NULL,
+			"multicast: receive start %J (%d)", &mcreceiver->addr,
+			mcreceiver->prio);
+		err = mcplayer_start(mcreceiver->jbuf, mcreceiver->ac);
+		goto out;
+	}
+
+	hprio = le->data;
+	if (hprio->prio < mcreceiver->prio)
+		/*received lower prio -> noting todo*/
+		goto out;
+
+	if (hprio->prio == mcreceiver->prio && mcreceiver->ssrc != ssrc) {
+		/*SSRC changed -> restart player*/
+		mcplayer_stop();
+		jbuf_flush(hprio->jbuf);
+		hprio->ssrc = ssrc;
+		ua_event(NULL, UA_EVENT_CUSTOM, NULL,
+			"multicast: receive start %J (%d)", &hprio->addr,
+			hprio->prio);
+		err = mcplayer_start(hprio->jbuf, hprio->ac);
+		goto out;
+	}
+	else if (hprio->prio == mcreceiver->prio) {
+		/*same prio but no new stream -> nothing todo*/
+		goto out;
+	}
+
+	/*higher prio -> stop old player and start new one*/
+	mcplayer_stop();
+	hprio->running = false;
+	jbuf_flush(mcreceiver->jbuf);
+	mcreceiver->ssrc = ssrc;
+	mcreceiver->running = true;
+	ua_event(NULL, UA_EVENT_CUSTOM, NULL,
+		"multicast: receive start %J (%d)", &mcreceiver->addr,
+		mcreceiver->prio);
+
+	err = mcplayer_start(mcreceiver->jbuf, mcreceiver->ac);
+
+  out:
+	lock_rel(mcreceivl_lock);
+	return err;
+}
+
+
+/**
+ * RTP timeout handler
+ *
+ * @param arg Multicast receiver object
+ */
+static void timeout_handler(void *arg)
+{
+	struct mcreceiver *mcreceiver = arg;
+	info ("multicast receiver: timeout of %J (prio=%d)\n",
+		&mcreceiver->addr, mcreceiver->prio);
+
+	lock_write_get(mcreceivl_lock);
+
+	if (mcreceiver->running) {
+		ua_event(NULL, UA_EVENT_CUSTOM, NULL,
+			"multicast: receive timeout %J", &mcreceiver->addr);
+		mcplayer_stop();
+	}
+
+	mcreceiver->running = false;
+	mcreceiver->ssrc = 0;
+	mcreceiver->ac = NULL;
+
+	lock_rel(mcreceivl_lock);
+	return;
+}
+
+
+/**
+ * Handle incoming RTP packages
+ *
+ * @param src	Source address
+ * @param hdr	RTP headers
+ * @param mb	RTP payload
+ * @param arg	Multicast receiver object
+ */
+static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
+	struct mbuf *mb, void *arg)
+{
+	int err = 0;
+	struct mcreceiver *mcreceiver = arg;
+
+	(void) src;
+	(void) mb;
+
+	if (!mcreceiver->enable)
+		return;
+
+	if (!mcreceiver->globenable)
+		return;
+
+	if (uag_call_count())
+		return;
+
+	mcreceiver->ac = pt2codec(hdr);
+	if (!mcreceiver->ac)
+		return;
+
+	if (!mbuf_get_left(mb))
+		return;
+
+	if (err) {
+		warning ("multicast receiver: "
+			"Decoder update failed. (%m)\n", err);
+		return;
+	}
+
+	err = prio_handling(mcreceiver, hdr->ssrc);
+	if (err)
+		return;
+
+	tmr_start(&mcreceiver->timeout, TIMEOUT, timeout_handler, mcreceiver);
+
+	err = jbuf_put(mcreceiver->jbuf, hdr, mb);
+	if (err)
+		return;
+
+	return;
+}
+
+
+/**
+ * Enable / Disable all mcreceiver with prio > @prio
+ *
+ * @param prio Priority
+ */
+void mcreceiver_enprio(uint32_t prio)
+{
+	struct le *le;
+	struct mcreceiver *mcreceiver;
+
+	if (!prio)
+		return;
+
+	lock_write_get(mcreceivl_lock);
+	LIST_FOREACH(&mcreceivl, le) {
+		mcreceiver = le->data;
+
+		if (mcreceiver->prio <= prio)
+			mcreceiver->enable = true;
+		else
+			mcreceiver->enable = false;
+	}
+
+	lock_rel(mcreceivl_lock);
+}
+
+
+/**
+ * Enable / Disable all multicast receiver
+ *
+ * @param enable
+ */
+void mcreceiver_enable(bool enable)
+{
+	struct le *le;
+	struct mcreceiver *mcreceiver;
+
+	lock_write_get(mcreceivl_lock);
+	LIST_FOREACH(&mcreceivl, le) {
+		mcreceiver = le->data;
+		mcreceiver->globenable = enable;
+	}
+	lock_rel(mcreceivl_lock);
+}
+
+
+/**
+ * Change the priority of a multicast receiver
+ *
+ * @param addr	Listen address
+ * @param prio	Priority
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+int mcreceiver_chprio(struct sa *addr, uint32_t prio)
+{
+	struct le *le;
+	struct mcreceiver *mcreceiver;
+
+	if (!addr || !prio)
+		return EINVAL;
+
+	le = list_apply(&mcreceivl, true, mcreceiver_addr_cmp, addr);
+	if (!le) {
+		warning ("multicast receiver: receiver %J not found\n", addr);
+		return EINVAL;
+	}
+
+	if (list_apply(&mcreceivl, true, mcreceiver_prio_cmp, &prio)) {
+		warning ("multicast receiver: priority %d already in use\n",
+			prio);
+		return EADDRINUSE;
+	}
+
+	mcreceiver = le->data;
+	lock_write_get(mcreceivl_lock);
+	mcreceiver->prio = prio;
+	lock_rel(mcreceivl_lock);
+
+	return 0;
+}
+
+
+/**
+ * Un-register all multicast listener
+ */
+void mcreceiver_unregall(void)
+{
+	lock_write_get(mcreceivl_lock);
+	list_flush(&mcreceivl);
+	lock_rel(mcreceivl_lock);
+	mcreceivl_lock = mem_deref(mcreceivl_lock);
+}
+
+
+/**
+ * Un-register a multicast listener
+ *
+ * @param addr Listen address
+ */
+void mcreceiver_unreg(struct sa *addr){
+	struct mcreceiver *mcreceiver = NULL;
+	struct le *le;
+
+	le = list_apply(&mcreceivl, true, mcreceiver_addr_cmp, addr);
+	if (!le) {
+		warning ("multicast: multicast receiver %J not found\n", addr);
+		return;
+	}
+
+	mcreceiver = le->data;
+	lock_write_get(mcreceivl_lock);
+	list_unlink(&mcreceiver->le);
+	lock_rel(mcreceivl_lock);
+	mcreceiver = mem_deref(mcreceiver);
+
+	if (list_isempty(&mcreceivl))
+		mcreceivl_lock = mem_deref(mcreceivl_lock);
+}
+
+
+/**
+ * Allocate a new multicast receiver object
+ *
+ * @param addr	Listen address
+ * @param prio	Listener priority
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+int mcreceiver_alloc(struct sa *addr, uint8_t prio)
+{
+	int err = 0;
+	uint16_t port;
+	struct mcreceiver *mcreceiver = NULL;
+	struct config_avt *cfg = &conf_config()->avt;
+
+	if (!addr || !prio)
+		return EINVAL;
+
+	if (list_apply(&mcreceivl, true, mcreceiver_addr_cmp, addr)) {
+		warning ("multicast receiver: address %J already in use\n",
+			addr);
+		return EADDRINUSE;
+	}
+
+	if (list_apply(&mcreceivl, true, mcreceiver_prio_cmp, &prio)) {
+		warning ("multicast receiver: priority %d already in use\n",
+			prio);
+		return EADDRINUSE;
+	}
+
+	mcreceiver = mem_zalloc(sizeof(*mcreceiver), mcreceiver_destructor);
+	if (!mcreceiver)
+		return ENOMEM;
+
+	if (!mcreceivl_lock) {
+		err = lock_alloc(&mcreceivl_lock);
+		if (err)
+			goto out;
+	}
+
+	sa_cpy(&mcreceiver->addr, addr);
+	port = sa_port(&mcreceiver->addr);
+	mcreceiver->prio = prio;
+
+	mcreceiver->running = false;
+	mcreceiver->enable = true;
+	mcreceiver->globenable = true;
+
+	err = jbuf_alloc(&mcreceiver->jbuf,
+		cfg->jbuf_del.min, cfg->jbuf_del.max);
+	err |= jbuf_set_type(mcreceiver->jbuf, cfg->jbtype);
+	err |= jbuf_set_wish(mcreceiver->jbuf, cfg->jbuf_wish);
+	if (err)
+		goto out;
+
+
+	err = rtp_listen(&mcreceiver->rtp, IPPROTO_UDP, &mcreceiver->addr,
+		port, port + 1, false, rtp_handler, NULL, mcreceiver);
+	if (err) {
+		warning("multicast receiver: rtp listen failed:"
+			"af=%s port=%u-&u (%m)\n", net_af2name(sa_af(addr)),
+			port, port + 1, err);
+		goto out;
+	}
+
+	lock_write_get(mcreceivl_lock);
+	list_append(&mcreceivl, &mcreceiver->le, mcreceiver);
+	lock_rel(mcreceivl_lock);
+
+  out:
+	if (err)
+		mcreceiver = mem_deref(mcreceiver);
+
+	return err;
+}
+
+
+/**
+ * Print all available multicast receiver
+ *
+ * @param pf Printer
+ */
+void mcreceiver_print(struct re_printf *pf)
+{
+	struct le *le = NULL;
+	struct mcreceiver *mcreceiver = NULL;
+
+	re_hprintf(pf, "Multicast Receiver List:\n");
+	LIST_FOREACH(&mcreceivl, le) {
+		mcreceiver = le->data;
+		re_hprintf(pf, "   %J - %d%s%s\n", &mcreceiver->addr,
+			mcreceiver->prio,
+			mcreceiver->enable  && mcreceiver->globenable ?
+			" (enable)" : "",
+			mcreceiver->running ? " (active)" : "");
+	}
+}

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -1,0 +1,189 @@
+/**
+ * @file sender.c
+ *
+ * Copyright (C) 2021 Commend.com - c.huber@commend.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+
+#include <stdlib.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
+#include "multicast.h"
+
+#define DEBUG_MODULE "mcsend"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+static struct list mcsenderl = LIST_INIT;
+
+
+struct mcsender {
+	struct le le;
+
+	struct sa addr;
+	struct rtp_sock *rtp;
+
+	struct config_audio *cfg;
+	const struct aucodec *ac;
+
+	struct mcsource *src;
+};
+
+
+/**
+ * @brief Multicasta sender destructor
+ *
+ * @param arg Multicast sender object
+ */
+static void mcsender_destructor(void *arg)
+{
+	struct mcsender *mcsender = arg;
+
+	mcsender->src = mem_deref(mcsender->src);
+	mcsender->rtp = mem_deref(mcsender->rtp);
+}
+
+
+/**
+ * @brief Multicast addess comparison
+ *
+ * @param le	List element (mcsender)
+ * @param arg	Argument     (address)
+ *
+ * @return true  if mcsender->addr == address
+ * @return false if mcsender->addr != address
+ */
+static bool mcsender_addr_cmp(struct le *le, void *arg)
+{
+	struct mcsender *mcsender = le->data;
+	struct sa *addr = arg;
+
+	return sa_cmp(&mcsender->addr, addr, SA_ALL);
+}
+
+
+/**
+ * @brief Multicast send handler
+ *
+ * @param ext_len	RTP extension header Length
+ * @param marker 	RTP marker
+ * @param mb		Data to send
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int mcsender_send_handler(uint32_t ext_len, bool marker,
+	uint32_t rtp_ts, struct mbuf *mb, void *arg)
+{
+	struct mcsender *mcsender = arg;
+	struct pl placpt = PL_INIT;
+	int err = 0;
+
+	if (!mb)
+		return EINVAL;
+
+	pl_set_str(&placpt, mcsender->ac->pt);
+	err = rtp_send(mcsender->rtp, &mcsender->addr, ext_len != 0, marker,
+		pl_u32(&placpt), rtp_ts, mb);
+
+	return err;
+}
+
+
+/**
+ * @brief Stop all existing multicast sender
+ */
+void mcsender_stopall(void)
+{
+	list_flush(&mcsenderl);
+}
+
+
+/**
+ * @brief Stop the multicast sender with @addr
+ *
+ * @param addr Address
+ */
+void mcsender_stop(struct sa *addr)
+{
+	struct mcsender *mcsender = NULL;
+	struct le *le;
+
+	le = list_apply(&mcsenderl, true, mcsender_addr_cmp, addr);
+	if (!le) {
+		warning ("multicast: multicast sender %J not found\n", addr);
+		return;
+	}
+
+	mcsender = le->data;
+	list_unlink(&mcsender->le);
+	mem_deref(mcsender);
+}
+
+
+/**
+ * @brief Allocate a new multicast sender object
+ *
+ * @param addr	Destination address
+ * @param codec	Used audio codec
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+int mcsender_alloc(struct sa *addr, const struct aucodec *codec)
+{
+	int err = 0;
+	struct mcsender *mcsender = NULL;
+
+	if (!addr || !codec)
+		return EINVAL;
+
+	if (list_apply(&mcsenderl, true, mcsender_addr_cmp, addr))
+		return EADDRINUSE;
+
+
+	mcsender = mem_zalloc(sizeof(*mcsender), mcsender_destructor);
+	if (!mcsender)
+		return ENOMEM;
+
+	sa_cpy(&mcsender->addr, addr);
+	mcsender->ac = codec;
+
+	err = rtp_open(&mcsender->rtp, sa_af(&mcsender->addr));
+	if (err)
+		goto out;
+
+	err = mcsource_start(&mcsender->src, mcsender->ac,
+		mcsender_send_handler, mcsender);
+
+	list_append(&mcsenderl, &mcsender->le, mcsender);
+
+ out:
+	if (err)
+		mem_deref(mcsender);
+
+	return err;
+}
+
+
+/**
+ * @brief Print all available multicast sender
+ *
+ * @param pf Printer
+ */
+void mcsender_print(struct re_printf *pf)
+{
+	struct le *le;
+	struct mcsender *mcsender;
+
+	re_hprintf(pf, "Multicast Sender List:\n");
+	LIST_FOREACH(&mcsenderl, le) {
+		mcsender = le->data;
+		re_hprintf(pf, "   %J - %s\n", &mcsender->addr,
+			mcsender->ac->name);
+	}
+}

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -1,0 +1,574 @@
+/**
+ * @file source.c
+ *
+ * Copyright (C) 2021 Commend.com - c.huber@commend.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+
+#include <stdlib.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+
+#include "multicast.h"
+
+#define DEBUG_MODULE "mcsource"
+#define DEBUG_LEVEL 5
+#include <re_dbg.h>
+
+
+struct mcsource {
+	struct config_audio *cfg;
+	struct ausrc_st *ausrc;
+	struct ausrc_prm ausrc_prm;
+	const struct aucodec *ac;
+	struct auenc_state *enc;
+	enum aufmt src_fmt;
+	enum aufmt enc_fmt;
+
+	void *sampv;
+	struct aubuf *aubuf;
+	size_t aubuf_maxsz;
+	volatile bool aubuf_started;
+	struct auresamp resamp;
+	int16_t *sampv_rs;
+	struct list filtl;
+
+	struct mbuf *mb;
+	uint32_t ptime;
+	uint64_t ts_ext;
+	uint32_t ts_base;
+	size_t psize;
+	bool marker;
+
+	char *module;
+	char *device;
+
+	mcsender_send_h *sendh;
+	void *arg;
+
+#ifdef HAVE_PTHREAD
+	struct {
+		pthread_t tid;
+		bool run;
+	} thr;
+#endif
+};
+
+
+/**
+ * @brief Multicast source destructor
+ *
+ * @param arg Multicast source object
+ */
+static void mcsource_destructor(void *arg)
+{
+	struct mcsource *src = arg;
+
+	switch (src->cfg->txmode) {
+#ifdef HAVE_PTHREAD
+		case AUDIO_MODE_THREAD:
+			if (src->thr.run) {
+				src->thr.run = false;
+				pthread_join(src->thr.tid, NULL);
+			}
+#endif
+		default:
+			break;
+	}
+
+	src->ausrc = mem_deref(src->ausrc);
+	src->aubuf = mem_deref(src->aubuf);
+	list_flush(&src->filtl);
+
+	src->enc = mem_deref(src->enc);
+	src->mb = mem_deref(src->mb);
+	src->sampv = mem_deref(src->sampv);
+	src->sampv_rs = mem_deref(src->sampv_rs);
+
+	src->module = mem_deref(src->module);
+	src->device = mem_deref(src->device);
+}
+
+
+/**
+ * @brief Encode and send audio data via @src->sendh
+ *
+ * @note This function hase REAL-TIME properties
+ *
+ * @param src	Multicast source object
+ * @param sampv Samplebuffer
+ * @param sampc Samplecounter
+ */
+static void encode_rtp_send(struct mcsource *src, uint16_t *sampv,
+	size_t sampc)
+{
+	size_t frame_size;
+	size_t sampc_rtp;
+	size_t len;
+
+	size_t ext_len = 0;
+	uint32_t ts_delta = 0;
+	int err = 0;
+
+	if (!src->ac || !src->ac->ench)
+		return;
+
+	src->mb->pos = src->mb->end = STREAM_PRESZ;
+
+	len = mbuf_get_space(src->mb);
+	err = src->ac->ench(src->enc, &src->marker, mbuf_buf(src->mb), &len,
+		src->enc_fmt, sampv, sampc);
+
+	if ((err & 0xffff0000) == 0x00010000) {
+		ts_delta = err & 0xffff;
+		sampc = 0;
+	}
+	else if (err) {
+		warning ("multicast send: &s encode error: &d samples (%m)\n",
+			src->ac->name, sampc, err);
+		goto out;
+	}
+
+	src->mb->pos = STREAM_PRESZ;
+	src->mb->end = STREAM_PRESZ + ext_len + len;
+
+	if (mbuf_get_left(src->mb)) {
+		uint32_t rtp_ts = src->ts_ext & 0xffffffff;
+
+		if (len) {
+			err = src->sendh(ext_len, src->marker,
+				rtp_ts, src->mb, src->arg);
+			if (err)
+				goto out;
+		}
+
+		if (ts_delta) {
+			src->ts_ext += ts_delta;
+			goto out;
+		}
+	}
+
+	sampc_rtp = sampc * src->ac->crate / src->ac->srate;
+	frame_size = sampc_rtp / src->ac->ch;
+	src->ts_ext += (uint32_t) frame_size;
+
+  out:
+	src->marker = false;
+}
+
+
+/**
+ * @brief Poll timed read from audio buffer
+ *
+ * @note This function has REAL-TIME properties
+ *
+ * @param src Multicast source object
+ */
+static void poll_aubuf_tx(struct mcsource *src)
+{
+	struct auframe af;
+	int16_t *sampv = src->sampv;
+	size_t sampc;
+	size_t sz;
+	size_t num_bytes;
+	struct le *le;
+	int err = 0;
+
+	sz = aufmt_sample_size(src->src_fmt);
+	if (!sz)
+		return;
+
+	num_bytes = src->psize;
+	sampc = num_bytes / sz;
+
+	if (src->enc_fmt == AUFMT_S16LE) {
+		aubuf_read(src->aubuf, (uint8_t *)sampv, num_bytes);
+	}
+	else if (src->enc_fmt == AUFMT_S16LE) {
+		void *tmp_sampv = NULL;
+
+		tmp_sampv = mem_zalloc(num_bytes, NULL);
+		if (!tmp_sampv)
+			return;
+
+		aubuf_read(src->aubuf, tmp_sampv, num_bytes);
+		auconv_to_s16(sampv, src->src_fmt, tmp_sampv, sampc);
+		mem_deref(tmp_sampv);
+	}
+	else {
+		warning("multicast send: invalid sample formats (%s -> %s)\n",
+			aufmt_name(src->src_fmt),
+			aufmt_name(src->enc_fmt));
+	}
+
+	if (src->resamp.resample) {
+		size_t sampc_rs = AUDIO_SAMPSZ;
+
+		if (src->enc_fmt != AUFMT_S16LE) {
+			warning("multicast send: skipping resampler due to"
+				" incompatible format (%s)\n",
+				aufmt_name(src->enc_fmt));
+			return;
+		}
+
+		err = auresamp(&src->resamp, src->sampv_rs, &sampc_rs,
+			src->sampv, sampc);
+			if (err)
+				return;
+
+		sampv = src->sampv_rs;
+		sampc = sampc_rs;
+	}
+
+	auframe_init (&af, src->enc_fmt, sampv, sampc);
+
+	/* Process exactly one audio-frame in list order */
+	for (le = src->filtl.head; le; le = le->next) {
+		struct aufilt_enc_st * st = le->data;
+
+		if (st->af && st->af->ench)
+			err |= st->af->ench(st, &af);
+	}
+
+	if (err)
+		warning("multicast source: aufilter encode: &m\n", err);
+
+	encode_rtp_send(src, af.sampv, af.sampc);
+}
+
+
+/**
+ * @brief Audio source error handler
+ *
+ * @param err Error code
+ * @param str Error string
+ * @param arg Multicast source object
+ */
+static void ausrc_error_handler(int err, const char *str, void *arg)
+{
+	(void) err;
+	(void) str;
+	(void) arg;
+}
+
+
+/**
+ * @brief Audio source read handler
+ *
+ * @note This function has REAL-TIME properties
+ *
+ * @param af	Audioframe
+ * @param arg	Multicast source object
+ */
+static void ausrc_read_handler(struct auframe *af, void *arg)
+{
+	struct mcsource *src = arg;
+	size_t num_bytes = auframe_size(af);
+
+	if ((int)src->src_fmt != af->fmt) {
+		warning ("multicast source: ausrc format mismatch: "
+			"expected=%d(%s), actual=%d(%s)\n",
+			src->src_fmt, aufmt_name(src->src_fmt),
+			af->fmt, aufmt_name(af->fmt));
+		return;
+	}
+
+	/*mute !?!?!? have to check what happens if call is active*/
+
+	(void) aubuf_write(src->aubuf, af->sampv, num_bytes);
+	src->aubuf_started = true;
+
+	if (src->cfg->txmode == AUDIO_MODE_POLL) {
+		unsigned i;
+
+		for (i = 0; i < 16; i++) {
+			if (aubuf_cur_size(src->aubuf) < src->psize)
+				break;
+
+			poll_aubuf_tx(src);
+		}
+	}
+}
+
+
+#ifdef HAVE_PTHREAD
+/**
+ * @brief Standalone trasmitter thread function
+ *
+ * @param arg Multicast source object
+ *
+ * @return void* NULL ptr
+ */
+static void *tx_thread(void *arg)
+{
+	struct mcsource *src = arg;
+	uint32_t ts = 0;
+
+	while (src->thr.run) {
+		uint64_t now;
+		sys_msleep(4);
+
+		if (!src->aubuf_started)
+			continue;
+
+		if (!src->thr.run)
+			break;
+
+		now = tmr_jiffies();
+		if (!ts)
+			ts = now;
+
+		if (ts > now)
+			continue;
+
+		if (aubuf_cur_size(src->aubuf) >= src->psize)
+			poll_aubuf_tx(src);
+
+		ts += src->ptime;
+	}
+
+	return NULL;
+}
+#endif
+
+
+/**
+ * @brief Start audio source
+ *
+ * @param src Multicast source object
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int start_source(struct mcsource *src)
+{
+	int err = 0;
+	uint32_t srate_dsp;
+	uint32_t channels_dsp;
+	bool resamp = false;
+
+	if (!src)
+		return EINVAL;
+
+	srate_dsp = src->ac->srate;
+	channels_dsp = src->ac->ch;
+
+	if (src->cfg->srate_src && src->cfg->srate_src != srate_dsp) {
+		resamp = true;
+		srate_dsp = src->cfg->srate_src;
+	}
+	if (src->cfg->channels_src && src->cfg->channels_src != channels_dsp) {
+		resamp = true;
+		channels_dsp = src->cfg->channels_src;
+	}
+
+	if (resamp && src->sampv_rs) {
+		src->sampv_rs = mem_zalloc(
+			AUDIO_SAMPSZ * sizeof(int16_t), NULL);
+		if (!src->sampv_rs)
+			return ENOMEM;
+
+		err = auresamp_setup(&src->resamp, srate_dsp, channels_dsp,
+			src->ac->srate, src->ac->ch);
+		if (err) {
+			warning ("multicast source: could not setup ausrc "
+				"resample (%m)\n", err);
+			return err;
+		}
+	}
+
+	if (!src->ausrc && ausrc_find(baresip_ausrcl(), NULL)) {
+		struct ausrc_prm prm;
+		size_t sz;
+
+		prm.srate = srate_dsp;
+		prm.ch = channels_dsp;
+		prm.ptime = src->ptime;
+		prm.fmt = src->src_fmt;
+
+		sz = aufmt_sample_size(src->src_fmt);
+		src->psize = sz * (prm.srate * prm.ch * prm.ptime / 1000);
+		src->aubuf_maxsz = src->psize * 30;
+		if (!src->aubuf) {
+			err = aubuf_alloc(&src->aubuf, src->psize,
+				src->aubuf_maxsz);
+			if (err)
+				return err;
+		}
+
+		err = ausrc_alloc(&src->ausrc, baresip_ausrcl(), NULL/*ctx*/,
+			src->module, &prm, src->device,
+			ausrc_read_handler, ausrc_error_handler, src);
+		if (err) {
+			warning ("multicast source: start_source faild (%s-%s)"
+				" :%m\n", src->module, src->device, err);
+			return err;
+		}
+
+		switch (src->cfg->txmode) {
+			case AUDIO_MODE_POLL:
+				break;
+#ifdef HAVE_PTHREAD
+			case AUDIO_MODE_THREAD:
+				if (!src->thr.run) {
+					src->thr.run = true;
+					err = pthread_create(&src->thr.tid,
+						NULL, tx_thread, src);
+					if (err) {
+						src->thr.run = false;
+						return err;
+					}
+				}
+				break;
+#endif
+
+			default:
+				warning ("multicast source: tx mode "
+					"not supported (%d)\n",
+					src->cfg->txmode);
+				return ENOTSUP;
+		}
+
+		src->ausrc_prm = prm;
+		info ("multicast source: source started with sample format "
+			"%s\n", aufmt_name(src->src_fmt));
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Setup all available audio filter for the encoder
+ *
+ * @param src		Multicast source object
+ * @param aufiltl	List of audio filter
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+static int aufilt_setup(struct mcsource *src, struct list *aufiltl)
+{
+	struct aufilt_prm prm;
+	struct le *le;
+	int err = 0;
+
+	if (!src->ac)
+		return 0;
+
+	if (!list_isempty(&src->filtl))
+		return 0;
+
+	prm.srate = src->ac->srate;
+	prm.ch = src->ac->ch;
+	prm.fmt = src->enc_fmt;
+
+	for (le = list_head(aufiltl); le; le = le->next) {
+		struct aufilt *af = le->data;
+		struct aufilt_enc_st *encst = NULL;
+		void *ctx = NULL;
+
+		if (af->encupdh) {
+			err = af->encupdh(&encst, &ctx, af, &prm, NULL);
+			if (err) {
+				warning("multicast source: erro in encoder"
+					"autio-filter '%s' (%m)\n",
+					af->name, err);
+			}
+			else {
+				encst->af = af;
+				list_append(&src->filtl, &encst->le,
+					encst);
+			}
+		}
+
+		if (err) {
+			warning("multicast source: audio-filter '%s' "
+				"update failed (%m)\n", af->name, err);
+			break;
+		}
+	}
+
+	return err;
+}
+
+
+/**
+ * @brief Start Multicast source
+ *
+ * @param srcp	Multicast source ptr
+ * @param ac	Audio codec
+ * @param sendh	Send Handler ptr
+ * @param arg	Send Hanlder Argument
+ *
+ * @return int 0 if success, errorcode otherwise
+ */
+int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
+	mcsender_send_h *sendh, void *arg)
+{
+	int err = 0;
+	struct mcsource *src = NULL;
+	struct config_audio *cfg = &conf_config()->audio;
+
+	if (!srcp || !ac)
+		return EINVAL;
+
+	src = mem_zalloc(sizeof(*src), mcsource_destructor);
+	if (!src)
+		return ENOMEM;
+
+	src->cfg = cfg;
+	src->sendh = sendh;
+	src->arg = arg;
+
+	src->src_fmt = cfg->src_fmt;
+	src->enc_fmt = cfg->enc_fmt;
+	src->mb = mbuf_alloc(STREAM_PRESZ + 4096);
+	src->sampv = mem_zalloc(
+		AUDIO_SAMPSZ * aufmt_sample_size(src->enc_fmt), NULL);
+	if (!src->mb || !src->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	auresamp_init(&src->resamp);
+	src->ptime = PTIME;
+	src->ts_ext = src->ts_base = rand_u16();
+	src->marker = true;
+
+	err = str_dup(&src->module, cfg->src_mod);
+	err |= str_dup(&src->device, cfg->src_dev);
+	if (err)
+		goto out;
+
+	src->ac = ac;
+	if (src->ac->encupdh) {
+		struct auenc_param prm;
+		prm.ptime = src->ptime;
+		prm.bitrate = 0;
+
+		err = src->ac->encupdh(&src->enc, src->ac, &prm, NULL);
+		if (err) {
+			warning ("multicast source: alloc encoder: &m\n", err);
+			goto out;
+		}
+	}
+
+	err = aufilt_setup(src, baresip_aufiltl());
+	if (err)
+		goto out;
+
+	err = start_source(src);
+	if (err)
+		goto out;
+
+  out:
+	if (err)
+		src = mem_deref(src);
+	else
+		*srcp = src;
+
+	return err;
+}


### PR DESCRIPTION
This module depends on [re#77](https://github.com/baresip/re/pull/77).

A new baresip module which allows the user to send and receive RTP streams.
Supported audio codecs: PCMU, PCMA, G722

The receiver contains a priority logic, which allows the user to decide the importance of the streams.
The core SIP-call is not affected from this module. A call has always the highest priority. Receiving a call or making a call will stop all sender and receiver of this module.