### PR TITLE
config: disables server verification if sip_verify_server is missing

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -12,7 +12,7 @@ poll_method		epoll		# poll, select, epoll ..
 #sip_certificate	cert.pem
 #sip_cafile		ca.crt
 #sip_trans_def		udp
-#sip_verify_server	yes
+sip_verify_server	yes
 
 # Call
 call_local_timeout	120

--- a/src/config.c
+++ b/src/config.c
@@ -31,7 +31,7 @@ static struct config core_config = {
 		"",
 		"",
 		SIP_TRANSP_UDP,
-		true,
+		false,
 	},
 
 	/** Call config */
@@ -619,7 +619,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			 "#sip_cafile\t\t%s\n"
 #endif
 			  "#sip_trans_def\tudp\n"
-			  "#sip_verify_server\tyes\n"
+			  "sip_verify_server\tyes\n"
 			  "\n"
 			  "# Call\n"
 			  "call_local_timeout\t%u\n"


### PR DESCRIPTION
This commit disables the server verification for old TLS configurations.

Requested by: @juha-h 

Please vote for or against this: @juha-h,  @alfredh, @sreimers , others?

I am not 100% for this commit, because we have to ensure for our products that a config line is added. If it is forgotten, then we believe that SIP TLS is safe. But it isn't.

This has to be added.
```
sip_verify_server	yes
```

Of course our testing have to do negative tests also for SIP TLS.