### PR TITLE
jack: support port pattern in config file

### DIFF
--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -180,14 +180,20 @@ static int start_jack(struct auplay_st *st)
 
 		unsigned i;
 
-		if(st->device) {
-			info("jack: connecting input ports matching regexp %s\n", st->device);
+		/* If device is specified, get the ports matching the
+		 * regexp specified in the device string. Otherwise, get all
+		 * physical ports. */
+
+		if (st->device) {
+			info("jack: connect input ports matching regexp %s\n",
+				st->device);
 			ports = jack_get_ports (st->client, st->device, NULL,
-						JackPortIsInput);
-		} else {
-			info("jack: connecting physical input ports\n");
+				JackPortIsInput);
+		}
+		else {
+			info("jack: connect physical input ports\n");
 			ports = jack_get_ports (st->client, NULL, NULL,
-						JackPortIsInput | JackPortIsPhysical);
+				JackPortIsInput | JackPortIsPhysical);
 		}
 
 		if (ports == NULL) {
@@ -195,16 +201,16 @@ static int start_jack(struct auplay_st *st)
 			return ENODEV;
 		}
 
-		/* Connect all ports. In case of for example mono
-		 * audio with 2 playback ports, connect the
-		 * single registered port to both port.
+		/* Connect all ports. In case of for example mono audio with
+		 * 2 jack input ports, connect the single registered port to
+		 * both input port.
 		 */
 		ch = 0;
 		for (i = 0; ports[i] != NULL; i++) {
 			if (jack_connect (st->client,
 					jack_port_name (st->portv[ch]),
 						ports[i])) {
-				warning("jack: cannot connect output ports\n");
+				warning("jack: cannot connect input ports\n");
 			}
 
 			++ch;

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -247,7 +247,7 @@ int jack_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	st->wh  = wh;
 	st->arg = arg;
 
-	if(device)
+	if (str_isset(device))
 		st->device = device;
 
 	st->portv = mem_reallocarray(NULL, prm->ch, sizeof(*st->portv), NULL);

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -183,21 +183,16 @@ static int start_jack(struct auplay_st *st)
 		if(st->device) {
 			info("jack: connecting input ports matching regexp %s\n", st->device);
 			ports = jack_get_ports (st->client, st->device, NULL,
-					JackPortIsInput);
-
-			if (ports == NULL) {
-				warning("jack: no input ports\n");
-				return ENODEV;
-			}
+						JackPortIsInput);
 		} else {
 			info("jack: connecting physical input ports\n");
 			ports = jack_get_ports (st->client, NULL, NULL,
-					JackPortIsInput | JackPortIsPhysical);
+						JackPortIsInput | JackPortIsPhysical);
+		}
 
-			if (ports == NULL) {
-				warning("jack: no physical playback ports\n");
-				return ENODEV;
-			}
+		if (ports == NULL) {
+			warning("jack: no input ports found\n");
+			return ENODEV;
 		}
 
 		/* Connect all ports. In case of for example mono

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -227,7 +227,7 @@ int jack_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	st->rh  = rh;
 	st->arg = arg;
 
-	if(device)
+	if (str_isset(device))
 		st->device = device;
 
 	st->portv = mem_reallocarray(NULL, prm->ch, sizeof(*st->portv), NULL);

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -169,14 +169,20 @@ static int start_jack(struct ausrc_st *st)
 	}
 
 	if (jack_connect_ports) {
-		if(st->device) {
-			info("jack: connecting output ports matching regexp %s\n", st->device);
+
+		/* If device is specified, get the ports matching the
+		 * regexp specified in the device string. Otherwise, get all
+		 * physical ports. */
+		if (st->device) {
+			info("jack: connect output ports matching regexp %s\n",
+				st->device);
 			ports = jack_get_ports (st->client, st->device, NULL,
 						JackPortIsOutput);
-		} else {
-			info("jack: connecting default output ports\n");
+		}
+		else {
+			info("jack: connect to physical output ports\n");
 			ports = jack_get_ports (st->client, NULL, NULL,
-						JackPortIsOutput | JackPortIsPhysical);
+				JackPortIsOutput | JackPortIsPhysical);
 		}
 
 		if (ports == NULL) {

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -19,6 +19,7 @@ struct ausrc_st {
 	size_t sampc;             /* includes number of channels */
 	ausrc_read_h *rh;
 	void *arg;
+	const char *device;
 
 	jack_client_t *client;
 	jack_port_t **portv;
@@ -168,17 +169,24 @@ static int start_jack(struct ausrc_st *st)
 	}
 
 	if (jack_connect_ports) {
-		info("jack: connecting default output ports\n");
-		ports = jack_get_ports (st->client, NULL, NULL,
-					JackPortIsOutput | JackPortIsPhysical);
+		if(st->device) {
+			info("jack: connecting output ports matching regexp %s\n", st->device);
+			ports = jack_get_ports (st->client, st->device, NULL,
+						JackPortIsOutput);
+		} else {
+			info("jack: connecting default output ports\n");
+			ports = jack_get_ports (st->client, NULL, NULL,
+						JackPortIsOutput | JackPortIsPhysical);
+		}
+
 		if (ports == NULL) {
-			warning("jack: no physical playback ports\n");
+			warning("jack: no output ports found\n");
 			return ENODEV;
 		}
 
 		for (ch=0; ch<st->prm.ch; ch++) {
 			if (jack_connect(st->client, ports[ch],
-					 jack_port_name(st->portv[ch]))) {
+					jack_port_name(st->portv[ch]))) {
 				warning("jack: cannot connect output ports\n");
 			}
 		}
@@ -199,7 +207,6 @@ int jack_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	int err = 0;
 
 	(void)ctx;
-	(void)device;
 	(void)errh;
 
 	if (!stp || !as || !prm || !rh)
@@ -219,6 +226,9 @@ int jack_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	st->as  = as;
 	st->rh  = rh;
 	st->arg = arg;
+
+	if(device)
+		st->device = device;
 
 	st->portv = mem_reallocarray(NULL, prm->ch, sizeof(*st->portv), NULL);
 	if (!st->portv) {


### PR DESCRIPTION
For jack_play and jack_src:
- Added support for setting port pattern (regexp) for ports to connect as device string in config file. For example:
`audio_player              jack,^system:playback_(1|2)$`
`audio_source             jack,^system:capture_(1|2)$`

- If no device is specified it works as before, connect to all physical ports



