### PR TITLE
Fix multiple resumed calls

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -831,6 +831,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 int  ua_init(const char *software, bool udp, bool tcp, bool tls);
 void ua_close(void);
 void ua_stop_all(bool forced);
+int  uag_hold_resume(struct call *call);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
 void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -111,7 +111,10 @@ static int hold_prev_call(struct re_printf *pf, void *arg)
 	const struct cmd_arg *carg = arg;
 	(void)pf;
 
-	return call_hold(ua_prev_call(menu_uacur()), 'H' == carg->key);
+	if (carg->key == 'H')
+		return call_hold(ua_prev_call(menu_uacur()), true);
+	else
+		return uag_hold_resume(ua_prev_call(menu_uacur()));
 }
 
 
@@ -131,7 +134,7 @@ static int cmd_call_resume(struct re_printf *pf, void *arg)
 	struct ua *ua = carg->data ? carg->data : menu_uacur();
 	(void)pf;
 
-	return call_hold(ua_call(ua), false);
+	return uag_hold_resume(ua_call(ua));
 }
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -496,6 +496,11 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			menu_selcall(NULL);
 		break;
 
+	case UA_EVENT_CALL_REMOTE_SDP:
+		if (!str_cmp(prm, "answer"))
+			menu_selcall(call);
+		break;
+
 	case UA_EVENT_CALL_TRANSFER:
 		/*
 		 * Create a new call to transfer target.

--- a/src/ua.c
+++ b/src/ua.c
@@ -416,6 +416,13 @@ static struct call *ua_find_active_call(struct ua *ua)
 }
 
 
+/**
+ * Put the established call on hold and resumes the given call
+ *
+ * @param call  Call to answer, or NULL for last incoming call
+ *
+ * @return 0 if success, otherwise errorcode
+ */
 int uag_hold_resume(struct call *call)
 {
 	int err = 0;


### PR DESCRIPTION
Prevent barsip from having multiple "onhold == false" calls. Resuming a call will replace the active call to the resumed one.
The handling of UA_EVENT_CALL_REMOTE_SDP is added to ensure that the menu does get the resumed call as active call.
Otherwise cmd_hangup will trigger the UA_EVENT_CALL_CLOSED and the menu.callid is removed. All commands with menu_uacur() will not work anymore.