### PR TITLE
Call resume on hangup

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -494,6 +494,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 		if (!str_cmp(call_id(call), menu.callid))
 			menu_selcall(NULL);
+
+		if (call_state(call) == CALL_STATE_ESTABLISHED &&
+				!call_is_onhold(call))
+			uag_hold_resume(NULL);
 		break;
 
 	case UA_EVENT_CALL_REMOTE_SDP:

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -497,7 +497,8 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_CALL_REMOTE_SDP:
-		if (!str_cmp(prm, "answer"))
+		if (!str_cmp(prm, "answer") &&
+				call_state(call) == CALL_STATE_ESTABLISHED)
 			menu_selcall(call);
 		break;
 

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -574,10 +574,17 @@ static int cmd_hangup(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
 	struct ua *ua = carg->data ? carg->data : menu_uacur();
+	struct call *call = ua_call(ua);
+	bool resume;
 
 	(void)pf;
 
-	ua_hangup(ua, NULL, 0, NULL);
+	resume = call_state(call) == CALL_STATE_ESTABLISHED &&
+		 !call_is_onhold(call);
+	ua_hangup(ua, call, 0, NULL);
+
+	if (resume)
+		uag_hold_resume(NULL);
 
 	return 0;
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -527,8 +527,6 @@ static void call_event_handler(struct call *call, enum call_event ev,
 	case CALL_EVENT_CLOSED:
 		ua_event(ua, UA_EVENT_CALL_CLOSED, call, str);
 		mem_deref(call);
-
-		uag_hold_resume(NULL);
 		break;
 
 	case CALL_EVENT_TRANSFER:
@@ -1183,8 +1181,6 @@ void ua_hangup(struct ua *ua, struct call *call,
 		 reason ? reason : "Connection reset by user");
 
 	mem_deref(call);
-
-	uag_hold_resume(NULL);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -430,11 +430,9 @@ int uag_hold_resume(struct call *call)
 	struct ua *ua = NULL;
 	struct call *acall = NULL, *toresume = call;
 
-	if (!toresume) {
-		for (le = list_tail(&uag.ual); le; le = le->next) {
-			ua = le->data;
-			toresume = ua_find_call_onhold(ua);
-		}
+	for (le = list_head(&uag.ual); le && !toresume; le = le->next) {
+		ua = le->data;
+		toresume = ua_find_call_onhold(ua);
 	}
 
 	if (!toresume) {

--- a/src/ua.c
+++ b/src/ua.c
@@ -440,15 +440,12 @@ int uag_hold_resume(struct call *call)
 		return 0;
 	}
 
-	for (le = list_head(&uag.ual); le; le = le->next) {
+	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
 		ua = le->data;
 		acall = ua_find_active_call(ua);
-		if (acall) {
-			err = call_hold(acall, true);
-			break;
-		}
 	}
 
+	err =  call_hold(acall, true);
 	err |= call_hold(toresume, false);
 
 	return err;

--- a/src/ua.c
+++ b/src/ua.c
@@ -436,8 +436,8 @@ int uag_hold_resume(struct call *call)
 	}
 
 	if (!toresume) {
-		warning ("ua: no call found to resume\n");
-		return EINVAL;
+		debug ("ua: no call to resume\n");
+		return 0;
 	}
 
 	for (le = list_head(&uag.ual); le; le = le->next) {


### PR DESCRIPTION
Related to (first point in) https://github.com/baresip/baresip/issues/1243.

We found that to resume a call if another call terminates is not always correct.

We  also decided that menu should invoke the resume, not UA directly. If somebody prefers to let this logic in UA, let me know and I will change this!

Note: The second point in the issue (avoid multiple established calls) will be handled in a different PR. This will be handled also in menu.