### PR TITLE
Menu ensure only one established call

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -832,6 +832,7 @@ int  ua_init(const char *software, bool udp, bool tcp, bool tls);
 void ua_close(void);
 void ua_stop_all(bool forced);
 int  uag_hold_resume(struct call *call);
+int  uag_hold_others(struct call *call);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
 void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -825,6 +825,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   enum vidmode vidmode, const struct sip_msg *msg,
 		   struct call *xcall, const char *local_uri,
 		   bool use_rtp);
+struct call *ua_find_call_state(const struct ua *ua, enum call_state st);
 
 
 /* One instance */

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -453,6 +453,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		/* We must stop the re-dialing if the call was
 		   established */
 		redial_reset();
+		uag_hold_others(call);
 		break;
 
 	case UA_EVENT_CALL_CLOSED:

--- a/src/ua.c
+++ b/src/ua.c
@@ -379,7 +379,7 @@ static struct call *ua_find_call_onhold(const struct ua *ua)
 }
 
 
-static struct call *ua_find_call_state(const struct ua *ua, enum call_state st)
+struct call *ua_find_call_state(const struct ua *ua, enum call_state st)
 {
 	struct le *le;
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1243,7 +1243,7 @@ int ua_answer(struct ua *ua, struct call *call, enum vidmode vmode)
 		return EINVAL;
 
 	if (!call) {
-		call = ua_call(ua);
+		call = ua_find_call_state(ua, CALL_STATE_INCOMING);
 		if (!call)
 			return ENOENT;
 	}


### PR DESCRIPTION
Related to https://github.com/baresip/baresip/issues/1243 (second point).

- Adds a new function uag_hold_others(call).
- For outgoing calls that become established uag_hold_others() is called in the ua_event_handler().
- For incoming calls the command accept and acceptdir have to use uag_hold_others().

@alfredh: Should we split uag from ua.c --> uag.c? Maybe in a soon next PR?