### PR TITLE
call: send CALL_EVENT_ESTABLISHED before call_stream_start

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1557,6 +1557,14 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 
 	set_state(call, CALL_STATE_ESTABLISHED);
 
+	/* the transferor will hangup this call */
+	if (call->not) {
+		(void)call_notify_sipfrag(call, 200, "OK");
+	}
+
+	/* must be done last, the handler might deref this call */
+	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);
+
 	call_stream_start(call, true);
 
 	if (call->rtp_timeout_ms) {
@@ -1569,13 +1577,6 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 		}
 	}
 
-	/* the transferor will hangup this call */
-	if (call->not) {
-		(void)call_notify_sipfrag(call, 200, "OK");
-	}
-
-	/* must be done last, the handler might deref this call */
-	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);
 }
 
 


### PR DESCRIPTION
Related to: https://github.com/baresip/baresip/issues/1261

This prevents that ALSA playback device is opened for the call before it is
closed for the ringback tone. This is only possible if dmix is enabled in the
ALSA configuration.