### PR TITLE
conf: add call_hold_other_calls config option

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -300,6 +300,7 @@ struct config_sip {
 struct config_call {
 	uint32_t local_timeout; /**< Incoming call timeout [sec] 0=off    */
 	uint32_t max_calls;     /**< Maximum number of calls, 0=unlimited */
+	bool hold_other_calls;  /**< Hold other calls */
 };
 
 /** Audio */

--- a/src/config.c
+++ b/src/config.c
@@ -37,7 +37,8 @@ static struct config core_config = {
 	/** Call config */
 	{
 		120,
-		4
+		4,
+		false
 	},
 
 	/** Audio */
@@ -301,6 +302,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   &cfg->call.local_timeout);
 	(void)conf_get_u32(conf, "call_max_calls",
 			   &cfg->call.max_calls);
+	(void)conf_get_bool(conf, "call_hold_other_calls",
+			   &cfg->call.hold_other_calls);
 
 	/* Audio */
 	(void)conf_get_str(conf, "audio_path", cfg->audio.audio_path,
@@ -430,6 +433,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "# Call\n"
 			 "call_local_timeout\t%u\n"
 			 "call_max_calls\t\t%u\n"
+			 "call_hold_other_calls\t%s\n"
 			 "\n"
 			 "# Audio\n"
 			 "audio_path\t\t%s\n"
@@ -473,6 +477,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 
 			 cfg->call.local_timeout,
 			 cfg->call.max_calls,
+			 cfg->call.hold_other_calls ? "yes" : "no",
 
 			 cfg->audio.audio_path,
 			 cfg->audio.play_mod,  cfg->audio.play_dev,
@@ -622,6 +627,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "# Call\n"
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
+			  "call_hold_other_calls\tno\n"
 			  "\n"
 			  "# Audio\n"
 #if defined (SHARE_PATH)

--- a/src/config.c
+++ b/src/config.c
@@ -38,7 +38,7 @@ static struct config core_config = {
 	{
 		120,
 		4,
-		false
+		true
 	},
 
 	/** Audio */
@@ -627,7 +627,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "# Call\n"
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
-			  "call_hold_other_calls\tno\n"
+			  "call_hold_other_calls\tyes\n"
 			  "\n"
 			  "# Audio\n"
 #if defined (SHARE_PATH)

--- a/src/ua.c
+++ b/src/ua.c
@@ -473,6 +473,10 @@ int uag_hold_others(struct call *call)
 	struct le *le = NULL;
 	struct call *acall = NULL;
 
+	if (!conf_config()->call.hold_other_calls) {
+		return 0;
+	}
+
 	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
 		struct ua *ua = le->data;
 		struct le *lec = NULL;


### PR DESCRIPTION
With the new on hold changes in `menu`, use cases like handling multiple separate calls are not possible anymore (like providing multiple test instances with `echo` or `ausine`). I think putting calls on hold should be optional.