### PR TITLE
menu: remove call resume on termination

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -496,9 +496,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		if (!str_cmp(call_id(call), menu.callid))
 			menu_selcall(NULL);
 
-		if (call_state(call) == CALL_STATE_ESTABLISHED &&
-				!call_is_onhold(call))
-			uag_hold_resume(NULL);
 		break;
 
 	case UA_EVENT_CALL_REMOTE_SDP:


### PR DESCRIPTION
Resume another call on termination of a call  does not work correctly if the
call was hangup locally. Anyway, this feature is business logic and should not
be done by baresip automatically.