### PR TITLE
Multicast call priority

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -846,6 +846,8 @@ int  uag_hold_others(struct call *call);
 void uag_set_nodial(bool nodial);
 bool uag_nodial(void);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
+void uag_set_dnd(bool dnd);
+bool uag_dnd(void);
 void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);
 void uag_set_sub_handler(sip_msg_h *subh);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -843,6 +843,8 @@ void ua_close(void);
 void ua_stop_all(bool forced);
 int  uag_hold_resume(struct call *call);
 int  uag_hold_others(struct call *call);
+void uag_set_nodial(bool nodial);
+bool uag_nodial(void);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
 void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -615,6 +615,31 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 }
 
 
+static int cmd_dnd(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	const struct cmd_arg *carg = arg;
+
+	if (!str_isset(carg->prm)) {
+		err = EINVAL;
+		goto out;
+	}
+
+	if (!str_cmp(carg->prm, "true"))
+		uag_set_dnd(true);
+	else if (!str_cmp(carg->prm, "false"))
+		uag_set_dnd(false);
+	else
+		err = EINVAL;
+
+ out:
+	if (err)
+		re_hprintf(pf, "usage: /dnd <true|false>\n");
+
+	return err;
+}
+
+
 /**
  * Hangup the active call
  *
@@ -625,6 +650,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
  *
  * @return 0 if success, otherwise errorcode
  */
+
 static int cmd_hangup(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
@@ -1125,6 +1151,7 @@ static const struct cmd cmdv[] = {
 {"dial",      'd',  CMD_PRM, "Dial",                    dial_handler         },
 {"dialdir",   0,    CMD_PRM, "Dial with audio and video"
                              "direction.",              cmd_dialdir          },
+{"dnd",       0,    CMD_PRM, "Set Do not Disturb",      cmd_dnd              },
 {"hangup",    'b',        0, "Hangup call",             cmd_hangup           },
 {"hangupall", 0,    CMD_PRM, "Hangup all calls with direction"
                                                        ,cmd_hangupall        },

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -16,6 +16,15 @@
 #include <re_dbg.h>
 
 
+struct mccfg {
+	uint32_t callprio;
+};
+
+static struct mccfg mccfg = {
+	0,
+};
+
+
 /**
  * Decode IP-address <IP>:<PORT>
  *
@@ -89,6 +98,17 @@ static int check_rtp_pt(struct aucodec *ac)
 		return EINVAL;
 
 	return ac->pt ? 0 : ENOTSUP;
+}
+
+
+/**
+ * Getter for the call priority
+ *
+ * @return uint8_t call priority
+ */
+uint8_t multicast_callprio(void)
+{
+	return mccfg.callprio;
 }
 
 
@@ -475,6 +495,8 @@ static int module_read_config(void)
 	int err = 0, prio = 1;
 	struct sa laddr;
 
+	(void)conf_get_u32(conf_cur(), "multicast_call_prio", &mccfg.callprio);
+
 	sa_init(&laddr, AF_INET);
 	err = conf_apply(conf_cur(), "multicast_listener",
 		module_read_config_handler, &prio);
@@ -511,8 +533,8 @@ static int module_init(void)
 {
 	int err = 0;
 
-	err = cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
-	err |= module_read_config();
+	err = module_read_config();
+	err |= cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
 
 	if (!err)
 		info("multicast: module init\n");

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -18,6 +18,9 @@ enum {
 };
 
 
+uint8_t multicast_callprio(void);
+
+
 /* Sender */
 typedef int (mcsender_send_h)(size_t ext_len, bool marker, uint32_t rtp_ts,
 	struct mbuf *mb, void *arg);

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -61,6 +61,9 @@ static void mcreceiver_destructor(void *arg)
 	if (mcreceiver->running)
 		mcplayer_stop();
 
+	mcreceiver->ssrc = 0;
+	mcreceiver->running = false;
+
 	mcreceiver->rtp  = mem_deref(mcreceiver->rtp);
 	mcreceiver->jbuf = mem_deref(mcreceiver->jbuf);
 
@@ -154,6 +157,31 @@ static const struct aucodec *pt2codec(const struct rtp_header *hdr)
 
 
 /**
+ * Resume to the pre-multicast uag state if no other high priority
+ * multicasts are running
+ */
+static void resume_uag_state(void)
+{
+	uint8_t h = 255;
+	struct le *le= NULL;
+	struct mcreceiver *mcreceiver = NULL;
+
+	for (le = list_head(&mcreceivl); le; le = le->next) {
+		mcreceiver = le->data;
+
+		if (mcreceiver->ssrc && mcreceiver->prio < h)
+			h = mcreceiver->prio;
+	}
+
+	if (h > multicast_callprio()) {
+		uag_set_dnd(false);
+		uag_set_nodial(false);
+		uag_hold_resume(NULL);
+	}
+}
+
+
+/**
  * Multicast Priority handling
  *
  * @param mcreceiver	Multicast receiver object
@@ -173,6 +201,11 @@ static int prio_handling(struct mcreceiver *mcreceiver, uint32_t ssrc)
 	err = lock_write_try(mcreceivl_lock);
 	if (err)
 		return err;
+
+	if (mcreceiver->prio < multicast_callprio()) {
+		uag_set_dnd(true);
+		uag_set_nodial(true);
+	}
 
 	le = list_apply(&mcreceivl, true, mcreceiver_running, NULL);
 	if (!le) {
@@ -250,6 +283,8 @@ static void timeout_handler(void *arg)
 	mcreceiver->ssrc = 0;
 	mcreceiver->ac = NULL;
 
+	resume_uag_state();
+
 	lock_rel(mcreceivl_lock);
 	return;
 }
@@ -273,36 +308,49 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 	(void) mb;
 
 	if (!mcreceiver->enable)
-		return;
+		goto out;
 
 	if (!mcreceiver->globenable)
-		return;
+		goto out;
 
-	if (uag_call_count())
-		return;
+	if (mcreceiver->prio >= multicast_callprio() && uag_call_count()) {
+		goto out;
+	}
+	else if (mcreceiver->prio < multicast_callprio() && uag_call_count()) {
+		struct le *leua;
+		struct ua *ua;
+
+		for (leua = list_head(uag_list()); leua; leua = leua->next) {
+			struct le *le;
+			ua = leua->data;
+			for (le = list_head(ua_calls(ua)); le; le = le->next) {
+				struct call *call = le->data;
+				if (!call_is_onhold(call))
+					call_hold(call, true);
+			}
+		}
+	}
 
 	mcreceiver->ac = pt2codec(hdr);
 	if (!mcreceiver->ac)
-		return;
+		goto out;
 
 	if (!mbuf_get_left(mb))
-		return;
-
-	if (err) {
-		warning ("multicast receiver: "
-			"Decoder update failed. (%m)\n", err);
-		return;
-	}
+		goto out;
 
 	err = prio_handling(mcreceiver, hdr->ssrc);
 	if (err)
-		return;
+		goto out;
 
-	tmr_start(&mcreceiver->timeout, TIMEOUT, timeout_handler, mcreceiver);
+	mcreceiver->ssrc = hdr->ssrc;
+
 
 	err = jbuf_put(mcreceiver->jbuf, hdr, mb);
 	if (err)
 		return;
+
+  out:
+	tmr_start(&mcreceiver->timeout, TIMEOUT, timeout_handler, mcreceiver);
 
 	return;
 }
@@ -398,6 +446,7 @@ void mcreceiver_unregall(void)
 {
 	lock_write_get(mcreceivl_lock);
 	list_flush(&mcreceivl);
+	resume_uag_state();
 	lock_rel(mcreceivl_lock);
 	mcreceivl_lock = mem_deref(mcreceivl_lock);
 }
@@ -421,6 +470,7 @@ void mcreceiver_unreg(struct sa *addr){
 	mcreceiver = le->data;
 	lock_write_get(mcreceivl_lock);
 	list_unlink(&mcreceiver->le);
+	resume_uag_state();
 	lock_rel(mcreceivl_lock);
 	mcreceiver = mem_deref(mcreceiver);
 

--- a/src/config.c
+++ b/src/config.c
@@ -1082,6 +1082,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f,
 			 "\n# multicast receivers (in priority order)"
 			 "- port number must be even\n"
+			 "#multicast_call_prio\t0\n"
 			 "#multicast_listener\t\t224.0.2.21:50000\n"
 			 "#multicast_listener\t\t224.0.2.21:50002\n");
 	if (f)

--- a/src/ua.c
+++ b/src/ua.c
@@ -52,6 +52,7 @@ struct uag {
 	bool delayed_close;            /**< Module will close SIP stack     */
 	sip_msg_h *subh;               /**< Subscribe handler               */
 	ua_exit_h *exith;              /**< UA Exit handler                 */
+	bool nodial;                   /**< Prevent outgoing calls          */
 	void *arg;                     /**< UA Exit handler argument        */
 	char *eprm;                    /**< Extra UA parameters             */
 #ifdef USE_TLS
@@ -72,6 +73,7 @@ static struct uag uag = {
 	false,
 	NULL,
 	NULL,
+	false,
 	NULL,
 	NULL,
 #ifdef USE_TLS
@@ -1185,6 +1187,11 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 
 	if (!ua || !str_isset(req_uri))
 		return EINVAL;
+
+	if (uag.nodial) {
+		info ("ua: currently no outgoing calls are allowed\n");
+		return EACCES;
+	}
 
 	dialbuf = mbuf_alloc(64);
 	if (!dialbuf)
@@ -2730,6 +2737,28 @@ struct tls *uag_tls(void)
 #else
 	return NULL;
 #endif
+}
+
+
+/**
+ * Setter UAG nodial flag
+ *
+ * @param nodial
+ */
+void uag_set_nodial(bool nodial)
+{
+	uag.nodial = nodial;
+}
+
+
+/**
+ * Getter UAG nodial flag
+ *
+ * @return uag.nodial
+ */
+bool uag_nodial(void)
+{
+	return uag.nodial;
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -53,6 +53,7 @@ struct uag {
 	sip_msg_h *subh;               /**< Subscribe handler               */
 	ua_exit_h *exith;              /**< UA Exit handler                 */
 	bool nodial;                   /**< Prevent outgoing calls          */
+	bool dnd;                      /**< Do not Disturb flag             */
 	void *arg;                     /**< UA Exit handler argument        */
 	char *eprm;                    /**< Extra UA parameters             */
 #ifdef USE_TLS
@@ -73,6 +74,7 @@ static struct uag uag = {
 	false,
 	NULL,
 	NULL,
+	false,
 	false,
 	NULL,
 	NULL,
@@ -1772,6 +1774,12 @@ static void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 		return;
 	}
 
+	if (uag.dnd) {
+		(void)sip_treply(NULL, uag.sip, msg,
+			480,"Temporarily Unavailable");
+		return;
+	}
+
 	/* handle multiple calls */
 	if (config->call.max_calls &&
 	    uag_call_count() + 1 > config->call.max_calls) {
@@ -2808,6 +2816,28 @@ int uag_set_extra_params(const char *eprm)
 		return str_dup(&uag.eprm, eprm);
 
 	return 0;
+}
+
+
+/**
+ * Set global Do not Disturb flag
+ *
+ * @param dnd DnD flag
+ */
+void uag_set_dnd(bool dnd)
+{
+	uag.dnd = dnd;
+}
+
+
+/**
+ * Get DnD status of uag
+ *
+ * @return True if DnD is active, False if not
+ */
+bool uag_dnd(void)
+{
+	return uag.dnd;
 }
 
 


### PR DESCRIPTION
Introduce a new config parameter "multicast_call_prio" to allow the multicast module having receivers with higher priority than a call. To prevent barsip from incoming and outgoing calls two new flags are added in the uag. On the incoming side, the DnD  reject all requests with the error 480 "Temporarily Unavailable". On the other side, the noDial flag prevents users from initiating calls.
Removing "multicast_call_prio" from the config or assigning it to 0 will ensure that a call will always be prioritized.

In cases where a multicast does have a higher priority than a call, the module takes advantage of the DnD and noDial flags. If all streams with high priority are done, the module switches back the flags. For established calls, these calls are set on_hold until the multicast is finished and resume it.