### PR TITLE
Menu fixes for play tones2

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -200,7 +200,6 @@ video_selfview		window # {window,pip}
 #zrtp_hash		no  # Disable SDP zrtp-hash (not recommended)
 
 # Menu
-#menu_bell		yes
 #redial_attempts	0 # Num or <inf>
 #redial_delay		5 # Delay in seconds
 #ringback_disabled	no

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -208,6 +208,7 @@ int  call_notify_sipfrag(struct call *call, uint16_t scode,
 			 const char *reason, ...);
 void call_set_handlers(struct call *call, call_event_h *eh,
 		       call_dtmf_h *dtmfh, void *arg);
+struct account *call_account(const struct call *call);
 uint16_t      call_scode(const struct call *call);
 enum call_state call_state(const struct call *call);
 uint32_t      call_duration(const struct call *call);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -44,7 +44,7 @@ static int cmd_find_call(struct re_printf *pf, void *arg)
 {
 	struct cmd_arg *carg = arg;
 	const char *id = carg->prm;
-	struct call *call = menu_find_call(id);
+	struct call *call = uag_call_find(id);
 
 	if (call) {
 		(void)re_hprintf(pf, "setting current call: %s\n", id);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -130,7 +130,6 @@ static void find_first_call(struct call *call, void *arg)
  *
  * @param matchh  Optional match handler. If NULL, the last call of the first
  *                  User-Agent is returned
- * @param arg     User argument
  *
  * @return  A call that matches
  */

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -595,27 +595,6 @@ struct menu *menu_get(void)
 }
 
 
-struct call *menu_find_call(const char *id)
-{
-	struct le *le;
-	struct call *call;
-
-	if (!str_isset(id))
-		return NULL;
-
-	for (le = list_head(uag_list()); le; le = le->next) {
-		struct ua *ua = le->data;
-		struct list *calls = ua_calls(ua);
-
-		call = call_find_id(calls, id);
-		if (call)
-			return call;
-	}
-
-	return NULL;
-}
-
-
 /**
  * Selects the active call.
  *
@@ -657,7 +636,7 @@ void menu_selcall(struct call *call)
  */
 struct call *menu_callcur(void)
 {
-	return menu_find_call(menu.callid);
+	return uag_call_find(menu.callid);
 }
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -426,6 +426,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 		/* set the current User-Agent to the one with the call */
 		menu_selcall(call);
+		menu_stop_play();
 
 		ardir =sdp_media_rdir(
 			stream_sdpmedia(audio_strm(call_audio(call))));

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -571,20 +571,24 @@ void menu_selcall(struct call *call)
 		CALL_STATE_ESTABLISHED,
 	};
 
+	if (!call) {
+		/* select another call */
+		for (i = ARRAY_SIZE(state)-1; i >= 0; --i) {
+			call = uag_find_call_state(state[i]);
+
+			if (!str_cmp(call_id(call), menu.callid))
+				call = NULL;
+
+			if (call)
+				break;
+		}
+	}
+
 	menu.callid = mem_deref(menu.callid);
 
 	if (call) {
 		str_dup(&menu.callid, call_id(call));
 		call_set_current(ua_calls(call_get_ua(call)), call);
-	}
-	else {
-		for (i = ARRAY_SIZE(state)-1; i >= 0; --i) {
-			call = uag_find_call_state(state[i]);
-			if (call) {
-				menu_selcall(call);
-				break;
-			}
-		}
 	}
 }
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -443,7 +443,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		if (acc && account_sip_autoanswer(acc))
 			adelay = call_answer_delay(call);
 
-		if (adelay == -1 || count > 1)
+		if (adelay == -1)
 			play_incoming(ua, count > 1);
 		else
 			start_sip_autoanswer(call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -134,6 +134,34 @@ static char *errorcode_key_aufile(uint16_t scode)
 }
 
 
+static void find_first_call(struct call *call, void *arg)
+{
+	struct call **callp = arg;
+
+	if (!*callp)
+		*callp = call;
+}
+
+
+/**
+ * Search all User-Agents for a call that matches
+ *
+ * @param matchh  Optional match handler. If NULL, the last call of the first
+ *                  User-Agent is returned
+ * @param arg     User argument
+ *
+ * @return  A call that matches
+ */
+struct call *menu_find_call(call_match_h *matchh)
+{
+	struct call *call = NULL;
+
+	uag_filter_calls(find_first_call, matchh, &call);
+
+	return call;
+}
+
+
 static void menu_play(const char *ckey, const char *fname, int repeat)
 {
 	struct config *cfg = conf_config();

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -445,10 +445,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_CALL_CLOSED:
-		menu_play_closed(call);
-
-		play_resume(call);
-
 		/* Activate the re-dialing if:
 		 *
 		 * - redial_attempts must be enabled in config
@@ -480,8 +476,11 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			}
 		}
 
-		if (!str_cmp(call_id(call), menu.callid))
+		if (!str_cmp(call_id(call), menu.callid)) {
+			menu_play_closed(call);
 			menu_selcall(NULL);
+			play_resume(call);
+		}
 
 		break;
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -134,6 +134,13 @@ static char *errorcode_key_aufile(uint16_t scode)
 }
 
 
+static bool active_call_test(const struct call* call)
+{
+	return call_state(call) == CALL_STATE_ESTABLISHED &&
+			!call_is_onhold(call);
+}
+
+
 static void find_first_call(struct call *call, void *arg)
 {
 	struct call **callp = arg;

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -13,12 +13,10 @@ enum statmode {
 
 
 struct menu{
-	struct tmr tmr_alert;         /**< Incoming call alert timer      */
 	struct tmr tmr_stat;          /**< Call status timer              */
 	struct play *play;            /**< Current audio player state     */
 	struct mbuf *dialbuf;         /**< Buffer for dialled number      */
 	char *callid;                 /**< Call-id of active call         */
-	bool bell;                    /**< ANSI Bell alert enabled        */
 	bool ringback_disabled;       /**< no ringback on sip 180 respons */
 	bool ringback;                /**< Ringback played currently      */
 	struct tmr tmr_redial;        /**< Timer for auto-reconnect       */

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -35,7 +35,6 @@ struct menu{
 struct menu *menu_get(void);
 
 /* Active call and UA */
-struct call *menu_find_call(const char *id);
 void menu_selcall(struct call *call);
 struct call *menu_callcur(void);
 struct ua   *menu_uacur(void);

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -19,7 +19,8 @@ struct menu{
 	struct mbuf *dialbuf;         /**< Buffer for dialled number      */
 	char *callid;                 /**< Call-id of active call         */
 	bool bell;                    /**< ANSI Bell alert enabled        */
-	bool ringback_disabled;	      /**< no ringback on sip 180 respons */
+	bool ringback_disabled;       /**< no ringback on sip 180 respons */
+	bool ringback;                /**< Ringback played currently      */
 	struct tmr tmr_redial;        /**< Timer for auto-reconnect       */
 	uint32_t redial_delay;        /**< Redial delay in [seconds]      */
 	uint32_t redial_attempts;     /**< Number of re-dial attempts     */

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -58,3 +58,4 @@ void dial_menu_unregister(void);
 /*Generic menu funtions*/
 void menu_update_callstatus(bool incall);
 int  menu_param_decode(const char *prm, const char *name, struct pl *val);
+struct call *menu_find_call(call_match_h *matchh);

--- a/src/config.c
+++ b/src/config.c
@@ -1024,7 +1024,6 @@ int config_write_template(const char *file, const struct config *cfg)
 
 	(void)re_fprintf(f,
 			"\n# Menu\n"
-			"#menu_bell\t\tyes\n"
 			"#redial_attempts\t0 # Num or <inf>\n"
 			"#redial_delay\t\t5 # Delay in seconds\n"
 			"#ringback_disabled\tno\n"

--- a/src/core.h
+++ b/src/core.h
@@ -140,7 +140,6 @@ int  call_info(struct re_printf *pf, const struct call *call);
 int  call_reset_transp(struct call *call, const struct sa *laddr);
 int  call_af(const struct call *call);
 void call_set_xrtpstat(struct call *call);
-struct account *call_account(const struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
 
 /*

--- a/src/ua.c
+++ b/src/ua.c
@@ -515,6 +515,9 @@ struct call *uag_call_find(const char *id)
 	struct ua *ua = NULL;
 	struct call *call = NULL;
 
+	if (!str_isset(id))
+		return NULL;
+
 	for (le = list_head(&uag.ual); le; le = le->next) {
 		ua = le->data;
 


### PR DESCRIPTION
Replaces #1273.
- ringback tone was not played
- fixes when and what to play for incoming calls
- resume right tone if a call terminates
- remove ANSI bell alert
