### PR TITLE
tls: more generic function to set cafile and capath

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -297,6 +297,7 @@ struct config_sip {
 	char local[64];         /**< Local SIP Address              */
 	char cert[256];         /**< SIP Certificate                */
 	char cafile[256];       /**< SIP CA-file                    */
+	char capath[256];       /**< SIP CA-path                    */
 	enum sip_transp transp; /**< Default outgoing SIP transport protocol */
 	bool verify_server;     /**< Enable SIP TLS verify server   */
 };

--- a/src/config.c
+++ b/src/config.c
@@ -30,6 +30,7 @@ static struct config core_config = {
 		"",
 		"",
 		"",
+		"",
 		SIP_TRANSP_UDP,
 		false,
 	},
@@ -285,10 +286,14 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   sizeof(cfg->sip.cert));
 	(void)conf_get_bool(conf, "sip_verify_server",
 			&cfg->sip.verify_server);
-	if (0 != conf_get_str(conf, "sip_cafile", cfg->sip.cafile,
-			   sizeof(cfg->sip.cafile))) {
+
+	(void)conf_get_str(conf, "sip_cafile", cfg->sip.cafile,
+			   sizeof(cfg->sip.cafile));
+	(void)conf_get_str(conf, "sip_capath", cfg->sip.capath,
+			   sizeof(cfg->sip.capath));
+	if (!str_isset(cfg->sip.cafile) && !str_isset(cfg->sip.capath)) {
 		if (cfg->sip.verify_server) {
-			warning("config: no sip_cafile defined "
+			warning("config: no sip_cafile/sip_capath defined "
 				"and sip_verify_server is enabled, "
 				"sip tls connections maybe won't work\n");
 		}
@@ -427,6 +432,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "sip_listen\t\t%s\n"
 			 "sip_certificate\t%s\n"
 			 "sip_cafile\t\t%s\n"
+			 "sip_capath\t\t%s\n"
 			 "sip_trans_def\t%s\n"
 			 "sip_verify_server\t%s\n"
 			 "\n"
@@ -473,6 +479,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 ,
 
 			 cfg->sip.local, cfg->sip.cert, cfg->sip.cafile,
+			 cfg->sip.capath,
 			 sip_transp_name(cfg->sip.transp),
 			 cfg->sip.verify_server ? "yes" : "no",
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1687,6 +1687,8 @@ static int add_transp_af(const struct sa *laddr)
 		/* Build our SSL context*/
 		if (!uag.tls) {
 			const char *cert = NULL;
+			const char *cafile = NULL;
+			const char *capath = NULL;
 
 			if (str_isset(uag.cfg->cert)) {
 				cert = uag.cfg->cert;
@@ -1700,12 +1702,17 @@ static int add_transp_af(const struct sa *laddr)
 				return err;
 			}
 
-			if (str_isset(uag.cfg->cafile)) {
-				const char *ca = uag.cfg->cafile;
+			if (str_isset(uag.cfg->cafile))
+				cafile = uag.cfg->cafile;
+			if (str_isset(uag.cfg->capath))
+				capath = uag.cfg->capath;
 
-				info("ua: adding SIP CA: %s\n", ca);
+			if (cafile || capath) {
+				info("ua: adding SIP CA file: %s\n", cafile);
+				info("ua: adding SIP CA path: %s\n", capath);
 
-				err = tls_add_ca(uag.tls, ca);
+				err = tls_add_cafile_path(uag.tls,
+					cafile, capath);
 				if (err) {
 					warning("ua: tls_add_ca() failed:"
 						" %m\n", err);


### PR DESCRIPTION
Same PR like #1295. Renaming of the branch for automated testing.

adds an config option to add capath
requires re/#84

The ca_path is does have the same meaning like in [openSSL/SSL_CTX_load_verify_locations](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_load_verify_locations.html).  The ca_file defines a file with (maybe) many certificates in one file. While the ca_path defines a directory containing (maybe) many certificates as single files.  The verification checks will check first the one defined in ca_file, then go on to the ca_path certificates.