### PR TITLE
Serreg fixes

### DIFF
--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -251,7 +251,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			break;
 
 		next_account(ua);
-		(void)ua_fallback(ua);
+		if (account_fbregint(ua_account(ua)))
+			(void)ua_fallback(ua);
+		else
+			ua_unregister(ua);
 		break;
 
 	default:


### PR DESCRIPTION
- useful reginfo printing if account prios are configured
- serreg: fixes for serial mode (accounts with fbregint=0)

### new reginfo output
accounts:
```
"chris" <sip:1004@xxx:15060>;auth_pass=xxxx;regint=10;prio=0;fbregint=4
"chris" <sip:1001@10.1.0.215:15060>;auth_pass=xxxx;regint=10;prio=1;fbregint=4
```

```
3 - sip:1004@xxx:15060                          OK   Expires 10s
24 - sip:1001@10.1.0.215:15060                  FB-OK  
```
The first with “OK” is registered and shows the expiry time.

The second shows only “FB-OK” which means fallback proxy is reachable.

```
13 - sip:1004@xxx:15060                         FB-ERR 
24 - sip:1001@10.1.0.215:15060                  OK   Expires 10s
```
Here the first one shows that the fallback proxy is not reachable. The second proxy is registered.

```
14 - sip:1001@10.1.0.215:15060                     zzz
```
Means that the registration result is pending, or the registrations stopped for this server (in “serial mode” with fbregint=0).