### PR TITLE
ua,menu: remove uag_find_call_state

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -871,7 +871,6 @@ struct tls  *uag_tls(void);
 struct sipsess_sock  *uag_sipsess_sock(void);
 struct sipevent_sock *uag_sipevent_sock(void);
 struct call *uag_call_find(const char *id);
-struct call *uag_find_call_state(enum call_state st);
 void uag_filter_calls(call_list_h *listh, call_match_h *matchh, void *arg);
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -125,6 +125,21 @@ static void find_first_call(struct call *call, void *arg)
 }
 
 
+struct call *menu_find_call_state(enum call_state st)
+{
+	struct le *le;
+
+	for (le = list_head(uag_list()); le; le = le->next) {
+		struct ua *ua = le->data;
+		struct call *call = ua_find_call_state(ua, st);
+
+		if (call)
+			return call;
+	}
+
+	return NULL;
+}
+
 /**
  * Search all User-Agents for a call that matches
  *
@@ -578,7 +593,7 @@ void menu_selcall(struct call *call)
 	if (!call) {
 		/* select another call */
 		for (i = ARRAY_SIZE(state)-1; i >= 0; --i) {
-			call = uag_find_call_state(state[i]);
+			call = menu_find_call_state(state[i]);
 
 			if (!str_cmp(call_id(call), menu.callid))
 				call = NULL;

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -58,3 +58,4 @@ void dial_menu_unregister(void);
 void menu_update_callstatus(bool incall);
 int  menu_param_decode(const char *prm, const char *name, struct pl *val);
 struct call *menu_find_call(call_match_h *matchh);
+struct call *menu_find_call_state(enum call_state st);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -103,7 +103,7 @@ static int cmd_answer(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 	else if (call_state(call) != CALL_STATE_INCOMING) {
-		call = uag_find_call_state(CALL_STATE_INCOMING);
+		call = menu_find_call_state(CALL_STATE_INCOMING);
 		ua = call_get_ua(call);
 	}
 
@@ -176,7 +176,7 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 	else if (call_state(call) != CALL_STATE_INCOMING) {
-		call = uag_find_call_state(CALL_STATE_INCOMING);
+		call = menu_find_call_state(CALL_STATE_INCOMING);
 		ua = call_get_ua(call);
 	}
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -535,29 +535,6 @@ struct call *uag_call_find(const char *id)
 
 
 /**
- * Find call with given call state
- *
- * @param st  Call-state
- *
- * @return The call if found, otherwise NULL.
- */
-struct call *uag_find_call_state(enum call_state st)
-{
-	struct le *le;
-
-	for (le = list_head(&uag.ual); le; le = le->next) {
-		struct ua *ua = le->data;
-		struct call *call = ua_find_call_state(ua, st);
-
-		if (call)
-			return call;
-	}
-
-	return NULL;
-}
-
-
-/**
  * Filters the calls of all User-Agents
  *
  * @param listh   Call list handler is called for each match


### PR DESCRIPTION
This PR should replace the uag_find_call_state() by the new uag_filter_calls(). But the uag_filter_calls() seems not to be useful for all use-cases of uag_find_call_state() in module menu.

@juha-h I couldn't find a simpler solution for the use case in menu_selcall() which selects a call when a call terminates.

It looks first for a CALL_STATE_ESTABLISHED, then CALL_STATE_EARLY, then CALL_STATE_RINGING, ...

If you like this PR anyway, you may merge it.