### PR TITLE
multicast: allow odd port number

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -43,7 +43,7 @@ static int decode_addr(struct pl *pladdr, struct sa *addr)
 
 
 	if (sa_port(addr) % 2) {
-		err = EINVAL;
+		/* err = EINVAL; -- issue warrning but allow */
 		warning("multicast: address port for RTP should be even"
 			" (%d)\n" , sa_port(addr));
 	}


### PR DESCRIPTION
Plenty of products do allow odd port numbers and in the end it is a only a strong recommendation that the multicast port number be even.