### PR TITLE
main: unload app modules in signal handler

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@ static void signal_handler(int sig)
 	static bool term = false;
 
 	if (term) {
+		module_app_unload();
 		mod_close();
 		exit(0);
 	}


### PR DESCRIPTION
Issue https://github.com/baresip/baresip/issues/1309
Fixes segfault with double Ctrl+c.