### PR TITLE
avformat: clean up ifdefs

### DIFF
--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -326,8 +326,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 		const struct AVStream *strm = st->ic->streams[i];
 		AVCodecContext *ctx;
 
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)
-
 		ctx = avcodec_alloc_context3(NULL);
 		if (!ctx) {
 			err = ENOMEM;
@@ -340,9 +338,6 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 			err = EPROTO;
 			goto out;
 		}
-#else
-		ctx = strm->codec;
-#endif
 
 		switch (ctx->codec_type) {
 


### PR DESCRIPTION
hi @sreimers

should we consider dropping ubuntu 16.04 support ?

ffmpeg version:
2.8.17-0ubuntu0.1 [security]: amd64 i386 

https://github.com/baresip/baresip/wiki/Supported-platforms#supported-version-of-ffmpeg
