### PR TITLE
Changed name and made public

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -696,6 +696,7 @@ void net_force_change(struct network *net);
 bool net_check(struct network *net);
 bool net_af_enabled(const struct network *net, int af);
 int  net_set_af(struct network *net, int af);
+void net_dns_refresh(struct network *net);
 int  net_dns_debug(struct re_printf *pf, const struct network *net);
 int  net_debug(struct re_printf *pf, const struct network *net);
 const struct sa *net_laddr_af(const struct network *net, int af);

--- a/src/net.c
+++ b/src/net.c
@@ -189,7 +189,7 @@ static int net_dns_srv_get(const struct network *net,
 /*
  * Check for DNS Server updates
  */
-static void dns_refresh(struct network *net)
+void net_dns_refresh(struct network *net)
 {
 	struct sa nsv[NET_MAX_NS];
 	uint32_t nsn;
@@ -215,7 +215,7 @@ static void ipchange_handler(void *arg)
 
 	tmr_start(&net->tmr, net->interval * 1000, ipchange_handler, net);
 
-	dns_refresh(net);
+	net_dns_refresh(net);
 
 	change = net_check(net);
 	if (change && net->ch) {
@@ -546,7 +546,7 @@ int net_use_nameserver(struct network *net, const struct sa *srvv, size_t srvc)
 		}
 	}
 
-	dns_refresh(net);
+	net_dns_refresh(net);
 
 	return 0;
 }


### PR DESCRIPTION
I changed the name 'dns_refresh' to 'net_dns_refresh' and made it public.