### PR TITLE
webrtc_aec: upgrade to more recent version

### DIFF
--- a/modules/webrtc_aec/aec.h
+++ b/modules/webrtc_aec/aec.h
@@ -4,24 +4,26 @@
  * Copyright (C) 2010 Creytiv.com
  */
 
-
 #include <pthread.h>
-#include "modules/audio_processing/aec/echo_cancellation.h"
+
+#define WEBRTC_POSIX 1
+#include <webrtc/modules/audio_processing/include/audio_processing.h>
+#include <webrtc/system_wrappers/include/trace.h>
 
 
 #define MAX_CHANNELS         1
+#define BLOCKSIZE           10  /* ms */
 
 
 using namespace webrtc;
 
 
 struct aec {
-	AecConfig config;
-	void *inst;
+	AudioProcessing *inst;
 	pthread_mutex_t mutex;
 	uint32_t srate;
-	uint32_t subframe_len;
-	int num_bands;
+	uint8_t ch;
+	uint32_t blocksize;
 };
 
 

--- a/modules/webrtc_aec/module.mk
+++ b/modules/webrtc_aec/module.mk
@@ -5,8 +5,7 @@
 #
 
 
-WEBRTC_PATH	:= ../webrtc_sdk
-
+WEBRTC_PATH	:= /usr/include/webrtc_audio_processing
 
 MOD		:= webrtc_aec
 
@@ -14,11 +13,11 @@ $(MOD)_SRCS	+= aec.cpp
 $(MOD)_SRCS	+= encode.cpp
 $(MOD)_SRCS	+= decode.cpp
 
-CPPFLAGS	+= -isystem $(WEBRTC_PATH)/include
+CPPFLAGS	+= -isystem $(WEBRTC_PATH)
 
 $(MOD)_LFLAGS	+= \
 	-L$(WEBRTC_PATH)/lib/x64/Debug \
-	-lwebrtc_full \
+	-lwebrtc_audio_processing \
 	-lstdc++
 
 


### PR DESCRIPTION
this PR upgrades the webrtc_aec module to use a more recent version of libwebrtc

the following libraries can be used:

1. native webrtc from webrtc.org (compiling it is a PITA, good luck to the brave souls :)
2. webrtc-audio-processing, a subset of libwebrtc (also in Debian 10)

https://freedesktop.org/software/pulseaudio/webrtc-audio-processing/

the new api is using the class AudioProcessing, which also includes generic audio filters like:

- Highpass filter
- Echo cancellation
- Noise reduction
- Gain control
- Voice detection

please help with building and testing