### PR TITLE
ui: fix leaking of cmd_ctx

### DIFF
--- a/src/ui.c
+++ b/src/ui.c
@@ -114,6 +114,8 @@ int ui_input_pl(struct re_printf *pf, const struct pl *pl)
 	if (pl->l > 1 && ctx)
 		err |= cmd_process(commands, &ctx, '\n', pf, NULL);
 
+	mem_deref(ctx);
+
 	return err;
 }
 


### PR DESCRIPTION
a memory leak can be triggered with this command:

```
$ ./baresip -ed
```

```
Quit
ua: stop all (forced=0)
mem: Memory leaks (3):
  0x7fbb947381f0: nrefs=1  size=24      [50 82 73 94 bb 7f 00 00 70 55 53 16 01 00 00 00 ] [P.s.....pUS.....]
  0x7fbb94738250: nrefs=1  size=32      [b0 82 73 94 bb 7f 00 00 20 00 00 00 00 00 00 00 ] [..s..... .......]
  0x7fbb947382b0: nrefs=1  size=32      [00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ] [................]
```

it will leak the ctx in ui_input_pl