### PR TITLE
Correct reverse domain name notation

### DIFF
--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -20,11 +20,11 @@
  *
  \verbatim
  # With qdbus of Qt.
- qdbus com.creytiv.Baresip /baresip com.creytiv.Baresip.invoke reginfo
+ qdbus com.github.Baresip /baresip com.github.Baresip.invoke reginfo
 
  # With gdbus of GLib.
- gdbus call -e -d com.creytiv.Baresip -o /baresip \
-	-m com.creytiv.Baresip.invoke reginfo
+ gdbus call -e -d com.github.Baresip -o /baresip \
+	-m com.github.Baresip.invoke reginfo
  \endverbatim
  *
  *

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -787,7 +787,7 @@ static void *gtk_thread(void *arg)
 	gtk_init(0, NULL);
 
 	g_set_application_name("baresip");
-	mod->app = g_application_new("com.baresip.baresip",
+	mod->app = g_application_new("com.github.baresip",
 				     G_APPLICATION_FLAGS_NONE);
 
 	g_application_register(G_APPLICATION (mod->app), NULL, &err);


### PR DESCRIPTION
Unify overlefts from `com.creytiv.*` (or similar) to `com.github.*`.

See also: https://en.wikipedia.org/wiki/Reverse_domain_name_notation