### PR TITLE
ctrl_dbus: use module_event() to send exported event

### DIFF
--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -369,8 +369,8 @@ on_name_acquired(GDBusConnection *connection, const gchar *name, gpointer arg)
 	}
 
 	info("ctrl_dbus: dbus interface %s exported\n", name);
-	ua_event(NULL, UA_EVENT_CUSTOM, NULL, "ctrl_dbus: "
-			"dbus_interface %s exported", name);
+	module_event("ctrl_dbus", "exported", NULL, NULL,
+			"dbus interface %s exported", name);
 }
 
 


### PR DESCRIPTION
Use unified format for the event sent from ctrl_dbus module.