### PR TITLE
GTK caller history

### DIFF
--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -201,7 +201,8 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 
 	if (mod->call_history_length < 20) {
 		mod->call_history_length++;
-	} else {
+	}
+	else {
 		/* Remove old call history */
 		list = gtk_container_get_children(GTK_CONTAINER(history_menu));
 		history_item = GTK_WIDGET(list->data);

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -225,7 +225,7 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 				GTK_IMAGE_MENU_ITEM(item),
 				gtk_image_new_from_icon_name(
                                         (mod->icon_call_incoming) ?
-					"call-incoming" : "go-next",
+					"call-incoming-symbolic" : "go-next",
 					GTK_ICON_SIZE_MENU));
 			break;
 		case CALL_OUTGOING:
@@ -233,15 +233,16 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 				GTK_IMAGE_MENU_ITEM(item),
 				gtk_image_new_from_icon_name(
 					(mod->icon_call_outgoing) ?
-					"call-outgoing" : "go-previous",
-					GTK_ICON_SIZE_MENU));
+					"call-outgoing-symbolic"
+						 : "go-previous",
+				GTK_ICON_SIZE_MENU));
 			break;
 		case CALL_MISSED:
 			gtk_image_menu_item_set_image(
 				GTK_IMAGE_MENU_ITEM(item),
 				gtk_image_new_from_icon_name(
 					(mod->icon_call_missed) ?
-					"call-missed" : "call-stop",
+					"call-missed-symbolic" : "call-stop",
 					GTK_ICON_SIZE_MENU));
 			break;
 		case CALL_REJECTED:
@@ -1000,17 +1001,17 @@ static void *gtk_thread(void *arg)
 	gtk_menu_shell_append(app_menu, gtk_separator_menu_item_new());
 
 	g_image = gtk_image_new_from_icon_name(
-				"call-incoming", GTK_ICON_SIZE_MENU);
+			"call-incoming-symbolic", GTK_ICON_SIZE_MENU);
 	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
 	mod->icon_call_incoming = str_cmp(strval, "image-missing");
 
 	g_image = gtk_image_new_from_icon_name(
-				"call-outgoing", GTK_ICON_SIZE_MENU);
+			"call-outgoing-symbolic", GTK_ICON_SIZE_MENU);
 	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
 	mod->icon_call_outgoing = str_cmp(strval, "image-missing");
 
 	g_image = gtk_image_new_from_icon_name(
-				"call-missed", GTK_ICON_SIZE_MENU);
+			"call-missed-symbolic", GTK_ICON_SIZE_MENU);
 	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
 	mod->icon_call_missed = str_cmp(strval, "image-missing");
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -199,7 +199,7 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 	re_snprintf(buf, sizeof buf,
 			"%s <%s>\n%04d-%02d-%02d %02d:%02d:%02d",
 			info, uri, ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday, ptm->tm_hour,
-                        ptm->tm_min, ptm->tm_sec);
+			ptm->tm_min, ptm->tm_sec);
 
 	item = gtk_image_menu_item_new_with_label(buf);
 	switch(call_type) {
@@ -207,32 +207,34 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 			gtk_image_menu_item_set_image(
 				GTK_IMAGE_MENU_ITEM(item),
 				gtk_image_new_from_icon_name(
-						"call-incoming", 32));
+//						"call-incoming", 32));
+						"go-next", 32));
 			break;
-                case CALL_OUTGOING:
-                        gtk_image_menu_item_set_image(
-                                GTK_IMAGE_MENU_ITEM(item),
-                                gtk_image_new_from_icon_name(
-                                                "call-outgoing", 32));
-                        break;
-                case CALL_MISSED:
-                        gtk_image_menu_item_set_image(
-                                GTK_IMAGE_MENU_ITEM(item),
-                                gtk_image_new_from_icon_name(
-                                                "call-missed", 32));
-                        break;
-                case CALL_REJECTED:
-                        gtk_image_menu_item_set_image(
-                                GTK_IMAGE_MENU_ITEM(item),
-                                gtk_image_new_from_icon_name(
-                                                "dialog-cancel", 32));
-                        break;
+		case CALL_OUTGOING:
+			gtk_image_menu_item_set_image(
+				GTK_IMAGE_MENU_ITEM(item),
+				gtk_image_new_from_icon_name(
+//						"call-outgoing", 32));
+						"go-previous", 32));
+			break;
+		case CALL_MISSED:
+			gtk_image_menu_item_set_image(
+				GTK_IMAGE_MENU_ITEM(item),
+				gtk_image_new_from_icon_name(
+						"call-stop", 32));
+			break;
+		case CALL_REJECTED:
+			gtk_image_menu_item_set_image(
+				GTK_IMAGE_MENU_ITEM(item),
+				gtk_image_new_from_icon_name(
+						"dialog-cancel", 32));
+			break;
 		default:
-                        gtk_image_menu_item_set_image(
-                                GTK_IMAGE_MENU_ITEM(item),
-                                gtk_image_new_from_icon_name(
-                                                "call-start", 32));
-                        break;
+			gtk_image_menu_item_set_image(
+				GTK_IMAGE_MENU_ITEM(item),
+				gtk_image_new_from_icon_name(
+						"call-start", 32));
+			break;
 	}
 	gtk_menu_shell_append(history_menu, item);
 	g_signal_connect(G_OBJECT(item), "activate",
@@ -602,7 +604,8 @@ static void ua_event_handler(struct ua *ua,
 		denotify_incoming_call(mod, call);
 		if (!call_is_outgoing(call) && call_state(call) != CALL_STATE_TERMINATED && call_state(call) != CALL_STATE_ESTABLISHED) {
 			add_history_menu_item(mod, call_peeruri(call), CALL_MISSED, call_peername(call));
-			gtk_status_icon_set_from_icon_name(mod->status_icon, "call-missed");
+//			gtk_status_icon_set_from_icon_name(mod->status_icon, "call-missed");
+			gtk_status_icon_set_from_icon_name(mod->status_icon, "call-stop");
 		}
 		break;
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -249,7 +249,7 @@ static void add_history_menu_item(struct gtk_mod *mod, const char *uri,
 			gtk_image_menu_item_set_image(
 				GTK_IMAGE_MENU_ITEM(item),
 				gtk_image_new_from_icon_name(
-					"dialog-cancel", GTK_ICON_SIZE_MENU));
+					"window-close", GTK_ICON_SIZE_MENU));
 			break;
 		default:
 			gtk_image_menu_item_set_image(

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -896,9 +896,7 @@ static void *gtk_thread(void *arg)
 	GtkWidget *item;
 	GError *err = NULL;
 	struct le *le;
-	GtkWidget *g_image;
-	GtkIconSize intval;
-	const gchar *strval;
+	GtkIconTheme *theme;
 
 
 	gdk_threads_init();
@@ -1000,20 +998,13 @@ static void *gtk_thread(void *arg)
 
 	gtk_menu_shell_append(app_menu, gtk_separator_menu_item_new());
 
-	g_image = gtk_image_new_from_icon_name(
-			"call-incoming-symbolic", GTK_ICON_SIZE_MENU);
-	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
-	mod->icon_call_incoming = str_cmp(strval, "image-missing");
-
-	g_image = gtk_image_new_from_icon_name(
-			"call-outgoing-symbolic", GTK_ICON_SIZE_MENU);
-	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
-	mod->icon_call_outgoing = str_cmp(strval, "image-missing");
-
-	g_image = gtk_image_new_from_icon_name(
-			"call-missed-symbolic", GTK_ICON_SIZE_MENU);
-	gtk_image_get_icon_name(GTK_IMAGE(g_image), &strval, &intval);
-	mod->icon_call_missed = str_cmp(strval, "image-missing");
+	theme = gtk_icon_theme_get_default();
+	mod->icon_call_incoming = gtk_icon_theme_has_icon(theme,
+						"call-incoming-symbolic");
+	mod->icon_call_outgoing = gtk_icon_theme_has_icon(theme,
+						"call-outgoing-symbolic");
+	mod->icon_call_missed = gtk_icon_theme_has_icon(theme,
+						"call-missed-symbolic");
 
 	/* About */
 	item = gtk_menu_item_new_with_mnemonic("A_bout");

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -638,7 +638,7 @@ static void ua_event_handler(struct ua *ua,
 			gtk_status_icon_set_from_icon_name(
 				mod->status_icon,
 				(mod->icon_call_missed) ?
-					"call-missed" : "call-stop");
+					"call-missed-symbolic" : "call-stop");
 		}
 		break;
 
@@ -991,7 +991,7 @@ static void *gtk_thread(void *arg)
 
 	/* Caller history */
 	mod->history_menu = gtk_menu_new();
-	item = gtk_menu_item_new_with_mnemonic("Caller _history");
+	item = gtk_menu_item_new_with_mnemonic("Call _history");
 	gtk_menu_shell_append(app_menu, item);
 	gtk_menu_item_set_submenu(GTK_MENU_ITEM(item),
 			mod->history_menu);

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -166,10 +166,12 @@ static void menu_on_dial_history(GtkMenuItem *menuItem, gpointer arg)
 
 	str_ncpy(buf, label, sizeof(buf));
 	label_1 = strchr(buf, '[');
+	if (!label_1)
+		return;
+
 	label_1[0] = ' ';
 
 	uri = strtok(label_1, "]");
-	/* Queue dial from the main thread */
 	gtk_mod_connect(mod, uri);
 }
 

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -160,11 +160,12 @@ static void menu_on_dial_history(GtkMenuItem *menuItem, gpointer arg)
 {
 	struct gtk_mod *mod = arg;
 	const char *label = gtk_menu_item_get_label(menuItem);
-	/* get the uri from the label */
 	char *label_1;
+	char buf[256];
 	char *uri;
 
-	label_1 = strchr(label, '[');
+	str_ncpy(buf, label, sizeof(buf));
+	label_1 = strchr(buf, '[');
 	label_1[0] = ' ';
 
 	uri = strtok(label_1, "]");

--- a/modules/gtk/gtk_mod.h
+++ b/modules/gtk/gtk_mod.h
@@ -7,7 +7,7 @@
 #define CALL_INCOMING  0
 #define CALL_OUTGOING  1
 #define CALL_MISSED    2
-#define CALL_REJECTED  8
+#define CALL_REJECTED  3
 
 struct gtk_mod;
 struct call_window;

--- a/modules/gtk/gtk_mod.h
+++ b/modules/gtk/gtk_mod.h
@@ -7,7 +7,7 @@
 #define CALL_INCOMING  0
 #define CALL_OUTGOING  1
 #define CALL_MISSED    2
-#define CALL_REJECTED  3
+#define CALL_REJECTED  8
 
 struct gtk_mod;
 struct call_window;

--- a/modules/gtk/gtk_mod.h
+++ b/modules/gtk/gtk_mod.h
@@ -4,6 +4,11 @@
  * Copyright (C) 2015 Charles E. Lehner
  */
 
+#define CALL_INCOMING  0
+#define CALL_OUTGOING  1
+#define CALL_MISSED    2
+#define CALL_REJECTED  3
+
 struct gtk_mod;
 struct call_window;
 struct dial_dialog;


### PR DESCRIPTION
A simple caller history on the gtk module.

Tracks up to 20 missed / outgoing / incoming calls.