### PR TITLE
call: remove tool attribute from SDP

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -785,11 +785,6 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	if (err)
 		goto out;
 
-	err = sdp_session_set_lattr(call->sdp, true,
-				    "tool", "baresip " BARESIP_VERSION);
-	if (err)
-		goto out;
-
 	/* Check for incoming SDP Offer */
 	if (msg && mbuf_get_left(msg->mb))
 		got_offer = true;

--- a/test/ua.c
+++ b/test/ua.c
@@ -730,7 +730,6 @@ static void options_resp_handler(int err, const struct sip_msg *msg, void *arg)
 	pl_set_mbuf(&content, msg->mb);
 
 	ASSERT_EQ(0, re_regex(content.p, content.l, "v=0"));
-	ASSERT_EQ(0, re_regex(content.p, content.l, "a=tool:baresip"));
 	ASSERT_EQ(0, re_regex(content.p, content.l, "m=audio"));
 
  out:


### PR DESCRIPTION
Remove the attribute "tool: baresip vx.x.xx" from the SDP, because it seems to
result in "488 SDP Parameter Error" with some SIP/PSTN gateways. This solves
issue #1351.