### PR TITLE
menu: command uafind raises UA to head

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -830,6 +830,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   struct call *xcall, const char *local_uri,
 		   bool use_rtp);
 struct call *ua_find_call_state(const struct ua *ua, enum call_state st);
+int ua_raise(struct ua *ua);
 
 
 /* One instance */

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -1012,6 +1012,7 @@ static int cmd_ua_delete_all(struct re_printf *pf, void *unused)
 static int cmd_ua_find(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
+	struct le *le;
 	struct ua *ua = NULL;
 
 	if (str_isset(carg->prm)) {
@@ -1025,6 +1026,12 @@ static int cmd_ua_find(struct re_printf *pf, void *arg)
 	}
 
 	(void)re_hprintf(pf, "ua: %s\n", account_aor(ua_account(ua)));
+
+	ua_raise(ua);
+
+	le = list_tail(ua_calls(ua));
+	if (le)
+		menu_selcall(le->data);
 
 	menu_update_callstatus(uag_call_count());
 

--- a/src/core.h
+++ b/src/core.h
@@ -377,6 +377,7 @@ struct uag {
 struct config_sip *uag_cfg(void);
 const char *uag_eprm(void);
 bool uag_delayed_close(void);
+int uag_raise(struct ua *ua, struct le *le);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -342,6 +342,41 @@ struct ua;
 void         ua_printf(const struct ua *ua, const char *fmt, ...);
 
 int ua_print_allowed(struct re_printf *pf, const struct ua *ua);
+struct call *ua_find_call_onhold(const struct ua *ua);
+struct call *ua_find_active_call(struct ua *ua);
+void ua_handle_options(struct ua *ua, const struct sip_msg *msg);
+void sipsess_conn_handler(const struct sip_msg *msg, void *arg);
+bool ua_catchall(struct ua *ua);
+
+/*
+ * User-Agent Group
+ */
+
+struct uag {
+	struct config_sip *cfg;        /**< SIP configuration               */
+	struct list ual;               /**< List of User-Agents (struct ua) */
+	struct sip *sip;               /**< SIP Stack                       */
+	struct sip_lsnr *lsnr;         /**< SIP Listener                    */
+	struct sipsess_sock *sock;     /**< SIP Session socket              */
+	struct sipevent_sock *evsock;  /**< SIP Event socket                */
+	bool use_udp;                  /**< Use UDP transport               */
+	bool use_tcp;                  /**< Use TCP transport               */
+	bool use_tls;                  /**< Use TLS transport               */
+	bool delayed_close;            /**< Module will close SIP stack     */
+	sip_msg_h *subh;               /**< Subscribe handler               */
+	ua_exit_h *exith;              /**< UA Exit handler                 */
+	bool nodial;                   /**< Prevent outgoing calls          */
+	bool dnd;                      /**< Do not Disturb flag             */
+	void *arg;                     /**< UA Exit handler argument        */
+	char *eprm;                    /**< Extra UA parameters             */
+#ifdef USE_TLS
+	struct tls *tls;               /**< TLS Context                     */
+#endif
+};
+
+struct config_sip *uag_cfg(void);
+const char *uag_eprm(void);
+bool uag_delayed_close(void);
 
 
 /*

--- a/src/srcs.mk
+++ b/src/srcs.mk
@@ -38,6 +38,7 @@ SRCS	+= stream.c
 SRCS	+= stunuri.c
 SRCS	+= timestamp.c
 SRCS	+= ua.c
+SRCS	+= uag.c
 SRCS	+= ui.c
 SRCS	+= vidcodec.c
 SRCS	+= video.c

--- a/src/ua.c
+++ b/src/ua.c
@@ -38,51 +38,6 @@ struct ua_xhdr_filter {
 };
 
 
-struct uag {
-	struct config_sip *cfg;        /**< SIP configuration               */
-	struct list ual;               /**< List of User-Agents (struct ua) */
-	struct sip *sip;               /**< SIP Stack                       */
-	struct sip_lsnr *lsnr;         /**< SIP Listener                    */
-	struct sipsess_sock *sock;     /**< SIP Session socket              */
-	struct sipevent_sock *evsock;  /**< SIP Event socket                */
-	bool use_udp;                  /**< Use UDP transport               */
-	bool use_tcp;                  /**< Use TCP transport               */
-	bool use_tls;                  /**< Use TLS transport               */
-	bool delayed_close;            /**< Module will close SIP stack     */
-	sip_msg_h *subh;               /**< Subscribe handler               */
-	ua_exit_h *exith;              /**< UA Exit handler                 */
-	bool nodial;                   /**< Prevent outgoing calls          */
-	bool dnd;                      /**< Do not Disturb flag             */
-	void *arg;                     /**< UA Exit handler argument        */
-	char *eprm;                    /**< Extra UA parameters             */
-#ifdef USE_TLS
-	struct tls *tls;               /**< TLS Context                     */
-#endif
-};
-
-static struct uag uag = {
-	NULL,
-	LIST_INIT,
-	NULL,
-	NULL,
-	NULL,
-	NULL,
-	true,
-	true,
-	true,
-	false,
-	NULL,
-	NULL,
-	false,
-	false,
-	NULL,
-	NULL,
-#ifdef USE_TLS
-	NULL,
-#endif
-};
-
-
 static void ua_destructor(void *arg)
 {
 	struct ua *ua = arg;
@@ -98,26 +53,12 @@ static void ua_destructor(void *arg)
 	mem_deref(ua->pub_gruu);
 	mem_deref(ua->acc);
 
-	if (uag.delayed_close && list_isempty(&uag.ual)) {
-		sip_close(uag.sip, false);
+	if (uag_delayed_close() && list_isempty(uag_list())) {
+		sip_close(uag_sip(), false);
 	}
 
 	list_flush(&ua->custom_hdrs);
 	list_flush(&ua->hdr_filter);
-}
-
-
-/* This function is called when all SIP transactions are done */
-static void exit_handler(void *arg)
-{
-	(void)arg;
-
-	ua_event(NULL, UA_EVENT_EXIT, NULL, NULL);
-
-	debug("ua: sip-stack exit\n");
-
-	if (uag.exith)
-		uag.exith(uag.arg);
 }
 
 
@@ -159,10 +100,10 @@ static int start_register(struct ua *ua, bool fallback)
 	if (err)
 		goto out;
 
-	if (uag.cfg && str_isset(uag.cfg->uuid)) {
+	if (uag_cfg() && str_isset(uag_cfg()->uuid)) {
 		if (re_snprintf(params, sizeof(params),
 				";+sip.instance=\"<urn:uuid:%s>\"",
-				uag.cfg->uuid) < 0) {
+				uag_cfg()->uuid) < 0) {
 			err = ENOMEM;
 			goto out;
 		}
@@ -363,7 +304,7 @@ unsigned ua_destroy(struct ua *ua)
 }
 
 
-static struct call *ua_find_call_onhold(const struct ua *ua)
+struct call *ua_find_call_onhold(const struct ua *ua)
 {
 	struct le *le;
 
@@ -409,7 +350,7 @@ struct call *ua_find_call_state(const struct ua *ua, enum call_state st)
 }
 
 
-static struct call *ua_find_active_call(struct ua *ua)
+struct call *ua_find_active_call(struct ua *ua)
 {
 	struct le *le = NULL;
 
@@ -424,140 +365,6 @@ static struct call *ua_find_active_call(struct ua *ua)
 	}
 
 	return NULL;
-}
-
-
-/**
- * Put the established call on hold and resume the given call
- *
- * @param call  Call to resume, or NULL to choose one which is on-hold
- *
- * @return 0 if success, otherwise errorcode
- */
-int uag_hold_resume(struct call *call)
-{
-	int err = 0;
-	struct le *le = NULL;
-	struct ua *ua = NULL;
-	struct call *acall = NULL, *toresume = call;
-
-	for (le = list_head(&uag.ual); le && !toresume; le = le->next) {
-		ua = le->data;
-		toresume = ua_find_call_onhold(ua);
-	}
-
-	if (!toresume) {
-		debug ("ua: no call to resume\n");
-		return 0;
-	}
-
-	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
-		ua = le->data;
-		acall = ua_find_active_call(ua);
-	}
-
-	err =  call_hold(acall, true);
-	err |= call_hold(toresume, false);
-
-	return err;
-}
-
-
-/**
- * Put all established calls on hold, except the given one
- *
- * @param call  Excluded call, or NULL
- *
- * @return 0 if success, otherwise errorcode
- */
-int uag_hold_others(struct call *call)
-{
-	int err = 0;
-	struct le *le = NULL;
-	struct call *acall = NULL;
-
-	if (!conf_config()->call.hold_other_calls) {
-		return 0;
-	}
-
-	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
-		struct ua *ua = le->data;
-		struct le *lec = NULL;
-
-		for (lec = list_head(&ua->calls); lec; lec = lec->next) {
-			struct call *ccall = lec->data;
-			if (ccall == call)
-				continue;
-
-			if (call_state(ccall) == CALL_STATE_ESTABLISHED &&
-					!call_is_onhold(ccall)) {
-				acall = ccall;
-				break;
-			}
-		}
-	}
-
-	if (!acall)
-		return 0;
-
-	err = call_hold(acall, true);
-	return err;
-}
-
-
-/**
- * Find call with given id
- *
- * @param id  Call-id string
- *
- * @return The call if found, otherwise NULL.
- */
-struct call *uag_call_find(const char *id)
-{
-	struct le *le = NULL;
-	struct ua *ua = NULL;
-	struct call *call = NULL;
-
-	if (!str_isset(id))
-		return NULL;
-
-	for (le = list_head(&uag.ual); le; le = le->next) {
-		ua = le->data;
-
-		call = call_find_id(ua_calls(ua), id);
-		if (call)
-			break;
-	}
-
-	return call;
-}
-
-
-/**
- * Filters the calls of all User-Agents
- *
- * @param listh   Call list handler is called for each match
- * @param matchh  Optional filter match handler (if NULL all calls are listed)
- * @param arg     User argument passed to listh
- */
-void uag_filter_calls(call_list_h *listh, call_match_h *matchh, void *arg)
-{
-	struct le *leu;
-
-	if (!listh)
-		return;
-
-	for (leu = list_head(uag_list()); leu; leu = leu->next) {
-		struct ua *ua = leu->data;
-		struct le *lec;
-
-		for (lec = list_tail(ua_calls(ua)); lec; lec = lec->prev) {
-			struct call *call = lec->data;
-
-			if (!matchh || matchh(call))
-				listh(call, arg);
-		}
-	}
 }
 
 
@@ -676,6 +483,172 @@ static void call_dtmf_handler(struct call *call, char key, void *arg)
 }
 
 
+static bool require_handler(const struct sip_hdr *hdr,
+			    const struct sip_msg *msg, void *arg)
+{
+	struct ua *ua = arg;
+	bool supported = false;
+	size_t i;
+	(void)msg;
+
+	for (i=0; i<ua->extensionc; i++) {
+
+		if (!pl_casecmp(&hdr->val, &ua->extensionv[i])) {
+			supported = true;
+			break;
+		}
+	}
+
+	return !supported;
+}
+
+
+static int sdp_af_hint(struct mbuf *mb)
+{
+	struct pl af;
+	int err;
+
+	err = re_regex((char *)mbuf_buf(mb), mbuf_get_left(mb),
+		       "IN IP[46]+", &af);
+	if (err)
+		return AF_UNSPEC;
+
+	switch (af.p[0]) {
+
+	case '4': return AF_INET;
+	case '6': return AF_INET6;
+	}
+
+	return AF_UNSPEC;
+}
+
+
+/* Handle incoming calls */
+void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
+{
+	struct config *config = conf_config();
+	const struct network *net = baresip_network();
+	const struct sip_hdr *hdr;
+	int af_sdp;
+	struct ua *ua;
+	struct call *call = NULL;
+	char to_uri[256];
+	int err;
+
+	(void)arg;
+
+	debug("ua: sipsess connect via %s %J --> %J\n",
+	      sip_transp_name(msg->tp),
+	      &msg->src, &msg->dst);
+
+	ua = uag_find_msg(msg);
+	if (!ua) {
+		info("ua: %r: UA not found: %r\n",
+		     &msg->from.auri, &msg->uri.user);
+		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
+		return;
+	}
+
+	if (uag_dnd()) {
+		(void)sip_treply(NULL, uag_sip(), msg,
+			480,"Temporarily Unavailable");
+		return;
+	}
+
+	/* handle multiple calls */
+	if (config->call.max_calls &&
+	    uag_call_count() + 1 > config->call.max_calls) {
+
+		info("ua: rejected call from %r (maximum %d calls)\n",
+		     &msg->from.auri, config->call.max_calls);
+		(void)sip_treply(NULL, uag_sip(), msg, 486, "Max Calls");
+		return;
+	}
+
+	/* Handle Require: header, check for any required extensions */
+	hdr = sip_msg_hdr_apply(msg, true, SIP_HDR_REQUIRE,
+				require_handler, ua);
+	if (hdr) {
+		info("ua: call from %r rejected with 420"
+			     " -- option-tag '%r' not supported\n",
+			     &msg->from.auri, &hdr->val);
+
+		(void)sip_treplyf(NULL, NULL, uag_sip(), msg, false,
+				  420, "Bad Extension",
+				  "Unsupported: %r\r\n"
+				  "Content-Length: 0\r\n\r\n",
+				  &hdr->val);
+		return;
+	}
+
+	/* Check if offered media AF is supported and available */
+	af_sdp = sdp_af_hint(msg->mb);
+	if (af_sdp) {
+		if (!net_af_enabled(net, af_sdp)) {
+			warning("ua: SDP offer AF not supported (%s)\n",
+				net_af2name(af_sdp));
+			af_sdp = 0;
+		}
+		else if (!sa_isset(net_laddr_af(net, af_sdp), SA_ADDR)) {
+			warning("ua: SDP offer AF not available (%s)\n",
+				net_af2name(af_sdp));
+			af_sdp = 0;
+		}
+		if (!af_sdp) {
+			(void)sip_treply(NULL, uag_sip(), msg, 488,
+					 "Not Acceptable Here");
+			return;
+		}
+	}
+
+	(void)pl_strcpy(&msg->to.auri, to_uri, sizeof(to_uri));
+
+	err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, to_uri, true);
+	if (err) {
+		warning("ua: call_alloc: %m\n", err);
+		goto error;
+	}
+
+	if (!list_isempty(&ua->hdr_filter)) {
+		struct list hdrs;
+		struct le *le;
+
+		list_init(&hdrs);
+
+		le = list_head(&ua->hdr_filter);
+		while (le) {
+			const struct sip_hdr *tmp_hdr;
+			const struct ua_xhdr_filter *filter = le->data;
+
+			le = le->next;
+			tmp_hdr = sip_msg_xhdr(msg, filter->hdr_name);
+
+			if (tmp_hdr) {
+				char name[256];
+
+				pl_strcpy(&tmp_hdr->name, name, sizeof(name));
+				if (custom_hdrs_add(&hdrs, name,
+						    "%r", &tmp_hdr->val))
+					goto error;
+			}
+		}
+
+		call_set_custom_hdrs(call, &hdrs);
+		list_flush(&hdrs);
+	}
+
+	err = call_accept(call, uag_sipsess_sock(), msg);
+	if (err)
+		goto error;
+
+	return;
+
+ error:
+	mem_deref(call);
+	(void)sip_treply(NULL, uag_sip(), msg, 500, "Call Error");
+}
+
+
 static int best_effort_af(struct ua *ua, const struct network *net)
 {
 	struct le *le;
@@ -694,26 +667,6 @@ static int best_effort_af(struct ua *ua, const struct network *net)
 		if (net_af_enabled(net, af) &&
 		    sa_isset(net_laddr_af(net, af), SA_ADDR))
 			return af;
-	}
-
-	return AF_UNSPEC;
-}
-
-
-static int sdp_af_hint(struct mbuf *mb)
-{
-	struct pl af;
-	int err;
-
-	err = re_regex((char *)mbuf_buf(mb), mbuf_get_left(mb),
-		       "IN IP[46]+", &af);
-	if (err)
-		return AF_UNSPEC;
-
-	switch (af.p[0]) {
-
-	case '4': return AF_INET;
-	case '6': return AF_INET6;
 	}
 
 	return AF_UNSPEC;
@@ -787,7 +740,7 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 }
 
 
-static void handle_options(struct ua *ua, const struct sip_msg *msg)
+void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 {
 	struct sip_contact contact;
 	struct call *call = NULL;
@@ -811,7 +764,7 @@ static void handle_options(struct ua *ua, const struct sip_msg *msg)
 		err = ua_call_alloc(&call, ua, VIDMODE_ON, NULL, NULL, NULL,
 				    false);
 		if (err) {
-			(void)sip_treply(NULL, uag.sip, msg,
+			(void)sip_treply(NULL, uag_sip(), msg,
 					 500, "Call Error");
 			return;
 		}
@@ -823,7 +776,7 @@ static void handle_options(struct ua *ua, const struct sip_msg *msg)
 
 	sip_contact_set(&contact, ua_cuser(ua), &msg->dst, msg->tp);
 
-	err = sip_treplyf(NULL, NULL, uag.sip,
+	err = sip_treplyf(NULL, NULL, uag_sip(),
 			  msg, true, 200, "OK",
 			  "Allow: %H\r\n"
 			  "%H"
@@ -849,27 +802,6 @@ static void handle_options(struct ua *ua, const struct sip_msg *msg)
 }
 
 
-static bool request_handler(const struct sip_msg *msg, void *arg)
-{
-	struct ua *ua;
-
-	(void)arg;
-
-	if (pl_strcmp(&msg->met, "OPTIONS"))
-		return false;
-
-	ua = uag_find_msg(msg);
-	if (!ua) {
-		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
-		return true;
-	}
-
-	handle_options(ua, msg);
-
-	return true;
-}
-
-
 static void add_extension(struct ua *ua, const char *extension)
 {
 	struct pl e;
@@ -891,7 +823,7 @@ static int create_register_clients(struct ua *ua)
 	int err = 0;
 
 	/* Register clients */
-	if (uag.cfg && str_isset(uag.cfg->uuid))
+	if (uag_cfg() && str_isset(uag_cfg()->uuid))
 		add_extension(ua, "gruu");
 
 	if (0 == str_casecmp(ua->acc->sipnat, "outbound")) {
@@ -901,7 +833,7 @@ static int create_register_clients(struct ua *ua)
 		add_extension(ua, "path");
 		add_extension(ua, "outbound");
 
-		if (!str_isset(uag.cfg->uuid)) {
+		if (!str_isset(uag_cfg()->uuid)) {
 
 			warning("ua: outbound requires valid UUID!\n");
 			err = ENOSYS;
@@ -966,8 +898,8 @@ int ua_alloc(struct ua **uap, const char *aor)
 	ua->af_media = AF_UNSPEC;
 
 	/* Decode SIP address */
-	if (uag.eprm) {
-		err = re_sdprintf(&buf, "%s;%s", aor, uag.eprm);
+	if (uag_eprm()) {
+		err = re_sdprintf(&buf, "%s;%s", aor, uag_eprm());
 		if (err)
 			goto out;
 		aor = buf;
@@ -1004,7 +936,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (err)
 		goto out;
 
-	list_append(&uag.ual, &ua->le, ua);
+	list_append(uag_list(), &ua->le, ua);
 
  out:
 	mem_deref(buf);
@@ -1037,77 +969,6 @@ int ua_update_account(struct ua *ua)
 }
 
 
-static bool uri_only_user(const struct uri *uri)
-{
-	bool ret;
-	struct sa sa;
-
-	/* Note:
-	 * If only user is given then uri_decode sets uri->host instead of
-	 * uri->user. We don't know if this is a bug. But if somebody changes
-	 * this behavior then the following line has to be adapted.          */
-	ret = pl_isset(&uri->host) && !pl_isset(&uri->user);
-
-	/* exclude IP addresses */
-	if (!sa_set(&sa, &uri->host, 0))
-		ret = false;
-
-	return ret;
-}
-
-
-static bool uri_user_and_host(const struct uri *uri)
-{
-	bool ret;
-
-	ret = pl_isset(&uri->host) && pl_isset(&uri->user);
-
-	return ret;
-}
-
-
-static bool uri_host_local(const struct uri *uri)
-{
-
-	const char *hostv[] = {
-		"localhost",
-		"127.0.0.1",
-		"::1"
-	};
-	int afv[2] = {AF_INET, AF_INET6};
-	const struct sa *sal;
-	struct sa sap;
-	size_t i;
-	int err;
-
-	if (!uri)
-		return false;
-
-	for (i=0; i<ARRAY_SIZE(hostv); i++) {
-
-		if (!pl_strcmp(&uri->host, hostv[i]))
-			return true;
-	}
-
-	for (i=0; i<ARRAY_SIZE(afv); i++) {
-
-		sal = net_laddr_af(baresip_network(), afv[i]);
-
-		err = sa_set(&sap, &uri->host, 0);
-		if (err)
-			continue;
-
-		if (sa_cmp(sal, &sap, SA_ADDR))
-			return true;
-	}
-
-	return false;
-}
-
-
-static bool uri_match_af(const struct uri *accu, const struct uri *peeru);
-
-
 /**
  * Connect an outgoing call to a given SIP uri with audio and video direction
  *
@@ -1133,7 +994,7 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 	if (!ua || !str_isset(req_uri))
 		return EINVAL;
 
-	if (uag.nodial) {
+	if (uag_nodial()) {
 		info ("ua: currently no outgoing calls are allowed\n");
 		return EACCES;
 	}
@@ -1505,284 +1366,6 @@ int ua_state_json_api(struct odict *od, const struct ua *ua)
 }
 
 
-/* One instance */
-
-
-static int add_transp_af(const struct sa *laddr)
-{
-	struct sa local;
-	int err = 0;
-
-	if (str_isset(uag.cfg->local)) {
-		err = sa_decode(&local, uag.cfg->local,
-				str_len(uag.cfg->local));
-		if (err) {
-			err = sa_set_str(&local, uag.cfg->local, 0);
-			if (err) {
-				warning("ua: decode failed: '%s'\n",
-					uag.cfg->local);
-				return err;
-			}
-		}
-
-		if (!sa_isset(&local, SA_ADDR)) {
-			uint16_t port = sa_port(&local);
-			(void)sa_set_sa(&local, &laddr->u.sa);
-			sa_set_port(&local, port);
-		}
-
-		if (sa_af(laddr) != sa_af(&local))
-			return 0;
-	}
-	else {
-		sa_cpy(&local, laddr);
-		sa_set_port(&local, 0);
-	}
-
-	if (uag.use_udp)
-		err |= sip_transp_add(uag.sip, SIP_TRANSP_UDP, &local);
-	if (uag.use_tcp)
-		err |= sip_transp_add(uag.sip, SIP_TRANSP_TCP, &local);
-	if (err) {
-		warning("ua: SIP Transport failed: %m\n", err);
-		return err;
-	}
-
-#ifdef USE_TLS
-	if (uag.use_tls) {
-		/* Build our SSL context*/
-		if (!uag.tls) {
-			const char *cert = NULL;
-			const char *cafile = NULL;
-			const char *capath = NULL;
-
-			if (str_isset(uag.cfg->cert)) {
-				cert = uag.cfg->cert;
-				info("SIP Certificate: %s\n", cert);
-			}
-
-			err = tls_alloc(&uag.tls, TLS_METHOD_SSLV23,
-					cert, NULL);
-			if (err) {
-				warning("ua: tls_alloc() failed: %m\n", err);
-				return err;
-			}
-
-			if (str_isset(uag.cfg->cafile))
-				cafile = uag.cfg->cafile;
-			if (str_isset(uag.cfg->capath))
-				capath = uag.cfg->capath;
-
-			if (cafile || capath) {
-				info("ua: adding SIP CA file: %s\n", cafile);
-				info("ua: adding SIP CA path: %s\n", capath);
-
-				err = tls_add_cafile_path(uag.tls,
-					cafile, capath);
-				if (err) {
-					warning("ua: tls_add_ca() failed:"
-						" %m\n", err);
-				}
-			}
-
-			if (!uag.cfg->verify_server)
-				tls_disable_verify_server(uag.tls);
-		}
-
-		if (sa_isset(&local, SA_PORT))
-			sa_set_port(&local, sa_port(&local) + 1);
-
-		err = sip_transp_add(uag.sip, SIP_TRANSP_TLS, &local, uag.tls);
-		if (err) {
-			warning("ua: SIP/TLS transport failed: %m\n", err);
-			return err;
-		}
-	}
-#endif
-
-	err = sip_transp_add_websock(uag.sip, SIP_TRANSP_WS, &local,
-				     false, NULL);
-	if (err) {
-		warning("ua: could not add Websock transport (%m)\n", err);
-		return err;
-	}
-
-#ifdef USE_TLS
-	err = sip_transp_add_websock(uag.sip, SIP_TRANSP_WSS, &local,
-				     false, uag.cfg->cert);
-	if (err) {
-		warning("ua: could not add secure Websock transport (%m)\n",
-			err);
-		return err;
-	}
-#endif
-
-	return err;
-}
-
-
-static int ua_add_transp(struct network *net)
-{
-	int err = 0;
-
-	if (sa_isset(net_laddr_af(net, AF_INET), SA_ADDR))
-		err |= add_transp_af(net_laddr_af(net, AF_INET));
-
-#if HAVE_INET6
-	if (sa_isset(net_laddr_af(net, AF_INET6), SA_ADDR))
-		err |= add_transp_af(net_laddr_af(net, AF_INET6));
-#endif
-
-	return err;
-}
-
-
-static bool require_handler(const struct sip_hdr *hdr,
-			    const struct sip_msg *msg, void *arg)
-{
-	struct ua *ua = arg;
-	bool supported = false;
-	size_t i;
-	(void)msg;
-
-	for (i=0; i<ua->extensionc; i++) {
-
-		if (!pl_casecmp(&hdr->val, &ua->extensionv[i])) {
-			supported = true;
-			break;
-		}
-	}
-
-	return !supported;
-}
-
-
-/* Handle incoming calls */
-static void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
-{
-	struct config *config = conf_config();
-	const struct network *net = baresip_network();
-	const struct sip_hdr *hdr;
-	int af_sdp;
-	struct ua *ua;
-	struct call *call = NULL;
-	char to_uri[256];
-	int err;
-
-	(void)arg;
-
-	debug("ua: sipsess connect via %s %J --> %J\n",
-	      sip_transp_name(msg->tp),
-	      &msg->src, &msg->dst);
-
-	ua = uag_find_msg(msg);
-	if (!ua) {
-		info("ua: %r: UA not found: %r\n",
-		     &msg->from.auri, &msg->uri.user);
-		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
-		return;
-	}
-
-	if (uag.dnd) {
-		(void)sip_treply(NULL, uag.sip, msg,
-			480,"Temporarily Unavailable");
-		return;
-	}
-
-	/* handle multiple calls */
-	if (config->call.max_calls &&
-	    uag_call_count() + 1 > config->call.max_calls) {
-
-		info("ua: rejected call from %r (maximum %d calls)\n",
-		     &msg->from.auri, config->call.max_calls);
-		(void)sip_treply(NULL, uag.sip, msg, 486, "Max Calls");
-		return;
-	}
-
-	/* Handle Require: header, check for any required extensions */
-	hdr = sip_msg_hdr_apply(msg, true, SIP_HDR_REQUIRE,
-				require_handler, ua);
-	if (hdr) {
-		info("ua: call from %r rejected with 420"
-			     " -- option-tag '%r' not supported\n",
-			     &msg->from.auri, &hdr->val);
-
-		(void)sip_treplyf(NULL, NULL, uag.sip, msg, false,
-				  420, "Bad Extension",
-				  "Unsupported: %r\r\n"
-				  "Content-Length: 0\r\n\r\n",
-				  &hdr->val);
-		return;
-	}
-
-	/* Check if offered media AF is supported and available */
-	af_sdp = sdp_af_hint(msg->mb);
-	if (af_sdp) {
-		if (!net_af_enabled(net, af_sdp)) {
-			warning("ua: SDP offer AF not supported (%s)\n",
-				net_af2name(af_sdp));
-			af_sdp = 0;
-		}
-		else if (!sa_isset(net_laddr_af(net, af_sdp), SA_ADDR)) {
-			warning("ua: SDP offer AF not available (%s)\n",
-				net_af2name(af_sdp));
-			af_sdp = 0;
-		}
-		if (!af_sdp) {
-			(void)sip_treply(NULL, uag_sip(), msg, 488,
-					 "Not Acceptable Here");
-			return;
-		}
-	}
-
-	(void)pl_strcpy(&msg->to.auri, to_uri, sizeof(to_uri));
-
-	err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, to_uri, true);
-	if (err) {
-		warning("ua: call_alloc: %m\n", err);
-		goto error;
-	}
-
-	if (!list_isempty(&ua->hdr_filter)) {
-		struct list hdrs;
-		struct le *le;
-
-		list_init(&hdrs);
-
-		le = list_head(&ua->hdr_filter);
-		while (le) {
-			const struct sip_hdr *tmp_hdr;
-			const struct ua_xhdr_filter *filter = le->data;
-
-			le = le->next;
-			tmp_hdr = sip_msg_xhdr(msg, filter->hdr_name);
-
-			if (tmp_hdr) {
-				char name[256];
-
-				pl_strcpy(&tmp_hdr->name, name, sizeof(name));
-				if (custom_hdrs_add(&hdrs, name,
-						    "%r", &tmp_hdr->val))
-					goto error;
-			}
-		}
-
-		call_set_custom_hdrs(call, &hdrs);
-		list_flush(&hdrs);
-	}
-
-	err = call_accept(call, uag.sock, msg);
-	if (err)
-		goto error;
-
-	return;
-
- error:
-	mem_deref(call);
-	(void)sip_treply(NULL, uag.sip, msg, 500, "Call Error");
-}
-
-
 static void ua_xhdr_filter_destructor(void *arg)
 {
 	struct ua_xhdr_filter *filter = arg;
@@ -1817,241 +1400,6 @@ int ua_add_xhdr_filter(struct ua *ua, const char *hdr_name)
 	list_append(&ua->hdr_filter, &filter->le, filter);
 
 	return 0;
-}
-
-
-static bool sub_handler(const struct sip_msg *msg, void *arg)
-{
-	struct ua *ua;
-
-	(void)arg;
-
-	ua = uag_find_msg(msg);
-	if (!ua) {
-		warning("subscribe: no UA found for %r\n", &msg->uri.user);
-		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
-		return true;
-	}
-
-	if (uag.subh)
-		uag.subh(msg, ua);
-
-	return true;
-}
-
-
-static void sip_trace_handler(bool tx, enum sip_transp tp,
-			      const struct sa *src, const struct sa *dst,
-			      const uint8_t *pkt, size_t len, void *arg)
-{
-	(void)tx;
-	(void)arg;
-
-	re_printf("\x1b[36;1m"
-		  "#\n"
-		  "%s %J -> %J\n"
-		  "%b"
-		  "\x1b[;m\n"
-		  ,
-		  sip_transp_name(tp), src, dst, pkt, len);
-}
-
-
-/**
- * Initialise the User-Agents
- *
- * @param software    SIP User-Agent string
- * @param udp         Enable UDP transport
- * @param tcp         Enable TCP transport
- * @param tls         Enable TLS transport
- *
- * @return 0 if success, otherwise errorcode
- */
-int ua_init(const char *software, bool udp, bool tcp, bool tls)
-{
-	struct config *cfg = conf_config();
-	struct network *net = baresip_network();
-	uint32_t bsize;
-	int err;
-
-	if (!net) {
-		warning("ua: no network\n");
-		return EINVAL;
-	}
-
-	uag.cfg = &cfg->sip;
-	bsize = 16;
-
-	uag.use_udp = udp;
-	uag.use_tcp = tcp;
-	uag.use_tls = tls;
-
-	list_init(&uag.ual);
-
-	err = sip_alloc(&uag.sip, net_dnsc(net), bsize, bsize, bsize,
-			software, exit_handler, NULL);
-	if (err) {
-		warning("ua: sip stack failed: %m\n", err);
-		goto out;
-	}
-
-	err = ua_add_transp(net);
-	if (err)
-		goto out;
-
-	err = sip_listen(&uag.lsnr, uag.sip, true, request_handler, NULL);
-	if (err)
-		goto out;
-
-	err = sipsess_listen(&uag.sock, uag.sip, bsize,
-			     sipsess_conn_handler, NULL);
-	if (err)
-		goto out;
-
-	err = sipevent_listen(&uag.evsock, uag.sip, bsize, bsize,
-			      sub_handler, NULL);
-	if (err)
-		goto out;
-
- out:
-	if (err) {
-		warning("ua: init failed (%m)\n", err);
-		ua_close();
-	}
-	return err;
-}
-
-
-/**
- * Close all active User-Agents
- */
-void ua_close(void)
-{
-	uag.evsock   = mem_deref(uag.evsock);
-	uag.sock     = mem_deref(uag.sock);
-	uag.lsnr     = mem_deref(uag.lsnr);
-	uag.sip      = mem_deref(uag.sip);
-	uag.eprm     = mem_deref(uag.eprm);
-
-#ifdef USE_TLS
-	uag.tls = mem_deref(uag.tls);
-#endif
-
-	list_flush(&uag.ual);
-}
-
-
-/**
- * Stop all User-Agents
- *
- * @param forced True to force, otherwise false
- */
-void ua_stop_all(bool forced)
-{
-	struct le *le;
-	unsigned ext_ref = 0;
-
-	info("ua: stop all (forced=%d)\n", forced);
-
-	/* check if someone else has grabbed a ref to ua */
-	le = uag.ual.head;
-	while (le) {
-
-		struct ua *ua = le->data;
-		le = le->next;
-
-		if (ua_destroy(ua) != 0) {
-			++ext_ref;
-		}
-	}
-
-	if (ext_ref) {
-		info("ua: in use (%u) by app module\n", ext_ref);
-		uag.delayed_close = true;
-		return;
-	}
-
-	if (forced)
-		sipsess_close_all(uag.sock);
-
-	sip_close(uag.sip, forced);
-}
-
-
-/**
- * Set the global UA exit handler. The exit handler will be called
- * asyncronously when the SIP stack has exited.
- *
- * @param exith Exit handler
- * @param arg   Handler argument
- */
-void uag_set_exit_handler(ua_exit_h *exith, void *arg)
-{
-	uag.exith = exith;
-	uag.arg = arg;
-}
-
-
-/**
- * Enable SIP message tracing
- *
- * @param enable True to enable, false to disable
- */
-void uag_enable_sip_trace(bool enable)
-{
-	sip_set_trace_handler(uag.sip, enable ? sip_trace_handler : NULL);
-}
-
-
-/**
- * Reset the SIP transports for all User-Agents
- *
- * @param reg      True to reset registration
- * @param reinvite True to update active calls
- *
- * @return 0 if success, otherwise errorcode
- */
-int uag_reset_transp(bool reg, bool reinvite)
-{
-	struct network *net = baresip_network();
-	struct le *le;
-	int err;
-
-	/* Update SIP transports */
-	sip_transp_flush(uag.sip);
-
-	(void)net_check(net);
-	err = ua_add_transp(net);
-	if (err)
-		return err;
-
-	/* Re-REGISTER all User-Agents */
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (reg && ua->acc->regint && !ua->acc->prio) {
-			err |= ua_register(ua);
-		}
-		else if (reg && ua->acc->regint) {
-			err |= ua_fallback(ua);
-		}
-
-		/* update all active calls */
-		if (reinvite) {
-			struct le *lec;
-
-			for (lec = ua->calls.head; lec; lec = lec->next) {
-				struct call *call = lec->data;
-				const struct sa *laddr;
-
-				laddr = net_laddr_af(net, call_af(call));
-
-				err |= call_reset_transp(call, laddr);
-			}
-		}
-	}
-
-	return err;
 }
 
 
@@ -2101,372 +1449,6 @@ int ua_print_calls(struct re_printf *pf, const struct ua *ua)
 	err |= re_hprintf(pf, "\n");
 
 	return err;
-}
-
-
-/**
- * Get the global SIP Stack
- *
- * @return SIP Stack
- */
-struct sip *uag_sip(void)
-{
-	return uag.sip;
-}
-
-
-/**
- * Get the global SIP Session socket
- *
- * @return SIP Session socket
- */
-struct sipsess_sock *uag_sipsess_sock(void)
-{
-	return uag.sock;
-}
-
-
-/**
- * Get the global SIP Event socket
- *
- * @return SIP Event socket
- */
-struct sipevent_sock *uag_sipevent_sock(void)
-{
-	return uag.evsock;
-}
-
-
-static bool uri_match_transport(const struct uri *accu,
-		const struct uri *peeru, enum sip_transp tp)
-{
-	struct pl pl;
-	enum sip_transp tpa;
-	int err;
-
-	err = msg_param_decode(&accu->params, "transport", &pl);
-	if (err)
-		return true;
-
-	tpa = sip_transp_decode(&pl);
-	if (peeru) {
-		/* outgoing calls */
-		tp = uag.cfg->transp;
-		if (!msg_param_decode(&peeru->params, "transport", &pl))
-			tp = sip_transp_decode(&pl);
-	}
-
-	return tpa == tp;
-}
-
-
-static bool uri_match_af(const struct uri *accu, const struct uri *peeru)
-{
-#ifdef HAVE_INET6
-	struct sa sa1;
-	struct sa sa2;
-	int err;
-#endif
-
-	/* we list cases where we know there is a mismatch in af */
-#ifdef HAVE_INET6
-	if (peeru->af == AF_UNSPEC || accu->af == AF_UNSPEC)
-		return true;
-
-	if (accu->af != peeru->af)
-		return false;
-
-	if (accu->af == AF_INET6 && peeru->af == AF_INET6) {
-		err =  sa_set(&sa1, &accu->host, 0);
-		err |= sa_set(&sa2, &peeru->host, 0);
-
-		if (err) {
-			warning("ua: No valid IPv6 URI %r, %r (%m)\n",
-					&accu->host,
-					&peeru->host, err);
-			return false;
-		}
-
-		return sa_is_linklocal(&sa1) == sa_is_linklocal(&sa2);
-	}
-#endif
-
-	/* both IPv4 or we can't decide if af will match */
-	return true;
-}
-
-
-/**
- * Find the correct UA from the contact user
- *
- * @param cuser Contact username
- *
- * @return Matching UA if found, NULL if not found
- */
-struct ua *uag_find(const struct pl *cuser)
-{
-	struct le *le;
-
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (0 == pl_strcasecmp(cuser, ua->cuser))
-			return ua;
-	}
-
-	/* Try also matching by AOR, for better interop */
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (0 == pl_casecmp(cuser, &ua->acc->luri.user))
-			return ua;
-	}
-
-	/* Last resort, try any catchall UAs */
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (ua->catchall)
-			return ua;
-	}
-
-	return NULL;
-}
-
-
-/**
- * Find the correct UA from SIP message
- *
- * @param msg SIP message
- *
- * @return Matching UA if found, NULL if not found
- */
-struct ua *uag_find_msg(const struct sip_msg *msg)
-{
-	struct le *le;
-	const struct pl *cuser;
-	struct ua *uaf = NULL;  /* fallback ua */
-
-	if (!msg)
-		return NULL;
-
-	cuser = &msg->uri.user;
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (0 == pl_strcasecmp(cuser, ua->cuser)) {
-			ua_printf(ua, "selected for %r\n", cuser);
-			return ua;
-		}
-	}
-
-	/* Try also matching by AOR, for better interop and for peer-to-peer
-	 * calls */
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-		struct account *acc = ua->acc;
-
-		if (!acc->regint) {
-			if (!uri_match_transport(&acc->luri, NULL, msg->tp))
-				continue;
-
-			if (!uri_match_af(&acc->luri, &msg->uri))
-				continue;
-
-			if (!uri_host_local(&msg->uri))
-				continue;
-
-			if (!uaf)
-				uaf = ua;
-		}
-
-		if (0 == pl_casecmp(cuser, &ua->acc->luri.user)) {
-			ua_printf(ua, "account match for %r\n", cuser);
-			return ua;
-		}
-	}
-
-	/* Last resort, try any catchall UAs */
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (ua->catchall) {
-			ua_printf(ua, "use catch-all account for %r\n", cuser);
-			return ua;
-		}
-	}
-
-	if (uaf)
-		ua_printf(uaf, "selected\n");
-
-	return uaf;
-}
-
-
-/**
- * Find a User-Agent (UA) from an Address-of-Record (AOR)
- *
- * @param aor Address-of-Record string
- *
- * @return User-Agent (UA) if found, otherwise NULL
- */
-struct ua *uag_find_aor(const char *aor)
-{
-	struct le *le;
-
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		if (str_isset(aor) && str_cmp(ua->acc->aor, aor))
-			continue;
-
-		return ua;
-	}
-
-	return NULL;
-}
-
-
-/**
- * Find a User-Agent (UA) which has certain address parameter and/or value
- *
- * @param name  SIP Address parameter name
- * @param value SIP Address parameter value (optional)
- *
- * @return User-Agent (UA) if found, otherwise NULL
- */
-struct ua *uag_find_param(const char *name, const char *value)
-{
-	struct le *le;
-
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-		struct sip_addr *laddr = account_laddr(ua->acc);
-		struct pl val;
-
-		if (value) {
-
-			if (0 == msg_param_decode(&laddr->params, name, &val)
-			    &&
-			    0 == pl_strcasecmp(&val, value)) {
-				return ua;
-			}
-		}
-		else {
-			if (0 == msg_param_exists(&laddr->params, name, &val))
-				return ua;
-		}
-	}
-
-	return NULL;
-}
-
-
-/**
- * Find a User-Agent (UA) best fitting for an SIP request
- *
- * @param requri The SIP uri for the request
- *
- * @return User-Agent (UA) if found, otherwise NULL
- */
-struct ua *uag_find_requri(const char *requri)
-{
-	struct mbuf *mb;
-	struct pl pl;
-	struct uri *uri;
-	struct le *le;
-	struct ua *ret = NULL;
-	struct sip_addr addr;
-	struct sa sa;
-	int err;
-
-	if (!requri)
-		return NULL;
-
-	if (!uag.ual.head)
-		return NULL;
-
-	mb = mbuf_alloc(16);
-	if (!mb)
-		return NULL;
-
-	err = account_uri_complete(NULL, mb, requri);
-	if (err) {
-		warning("ua: failed to complete uri: %s\n", requri);
-		goto out;
-	}
-
-	mbuf_set_pos(mb, 0);
-	pl_set_mbuf(&pl, mb);
-	err = sip_addr_decode(&addr, &pl);
-	if (err) {
-		warning("ua: address %r could not be parsed: %m\n",
-			&pl, err);
-		goto out;
-	}
-
-	uri = &addr.uri;
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-		struct account *acc = ua->acc;
-
-		/* not registered */
-		if (acc->regint && !ua_isregistered(ua))
-			continue;
-
-		if (uri_only_user(uri)) {
-			if (acc->regint) {
-				ret = ua;
-				break;
-			}
-		}
-
-		if (uri_user_and_host(uri) && acc->regint) {
-			if (0 != pl_cmp(&uri->host, &acc->luri.host)) {
-				continue;
-			}
-			else {
-				ret = ua;
-				break;
-			}
-		}
-
-		/* Now we select a local account for peer-to-peer calls.
-		 * uri = user@IP | user@domain | IP. */
-		if (!acc->regint) {
-			if (!uri_match_transport(&acc->luri, uri,
-						 SIP_TRANSP_NONE))
-				continue;
-
-			if (!uri_match_af(&acc->luri, uri))
-				continue;
-
-			if (!uri_only_user(uri) ||
-					!sa_set(&sa, &uri->host, 0)) {
-				/* Remember local account.
-				 * But we prefer registered UA. */
-				if (!ret)
-					ret = ua;
-			}
-		}
-	}
-
-	if (ret) {
-		ua_printf(ret, "selected for request\n");
-	}
-	else {
-		/* Ok, seems that matching account is missing. */
-		if (uri_only_user(uri)) {
-			goto out;
-		}
-
-		ret = uag.ual.head->data;
-		ua_printf(ret, "fallback selection\n");
-	}
-
-out:
-	mem_deref(mb);
-	return ret;
 }
 
 
@@ -2531,37 +1513,6 @@ void ua_pub_gruu_set(struct ua *ua, const struct pl *pval)
 
 	ua->pub_gruu = mem_deref(ua->pub_gruu);
 	(void)pl_strdup(&ua->pub_gruu, pval);
-}
-
-
-/**
- * Get the list of User-Agents
- *
- * @return List of User-Agents (struct ua)
- */
-struct list *uag_list(void)
-{
-	return &uag.ual;
-}
-
-
-/**
- * Counts the calls from all user agents.
- *
- * @return the number of calls over all user agents.
- */
-uint32_t uag_call_count(void)
-{
-	struct le *le;
-	uint32_t c = 0;
-
-	for (le = uag.ual.head; le; le = le->next) {
-		struct ua *ua = le->data;
-
-		c += list_count(&ua->calls);
-	}
-
-	return c;
 }
 
 
@@ -2634,54 +1585,6 @@ struct list *ua_calls(const struct ua *ua)
 
 
 /**
- * Set the handler to receive incoming SIP SUBSCRIBE messages
- *
- * @param subh Subscribe handler
- */
-void uag_set_sub_handler(sip_msg_h *subh)
-{
-	uag.subh = subh;
-}
-
-
-/**
- * Get UAG-TLS Context
- *
- * @return TLS Context if used, NULL otherwise
- */
-struct tls *uag_tls(void)
-{
-#ifdef USE_TLS
-	return uag.tls ? uag.tls : NULL;
-#else
-	return NULL;
-#endif
-}
-
-
-/**
- * Setter UAG nodial flag
- *
- * @param nodial
- */
-void uag_set_nodial(bool nodial)
-{
-	uag.nodial = nodial;
-}
-
-
-/**
- * Getter UAG nodial flag
- *
- * @return uag.nodial
- */
-bool uag_nodial(void)
-{
-	return uag.nodial;
-}
-
-
-/**
  * Set the preferred address family for media
  *
  * @param ua       User-Agent
@@ -2712,43 +1615,9 @@ void ua_set_catchall(struct ua *ua, bool enabled)
 }
 
 
-/**
- * Set extra parameters to use for all SIP Accounts
- *
- * @param eprm Extra parameters
- *
- * @return 0 if success, otherwise errorcode
- */
-int uag_set_extra_params(const char *eprm)
+bool ua_catchall(struct ua *ua)
 {
-	uag.eprm = mem_deref(uag.eprm);
-
-	if (eprm)
-		return str_dup(&uag.eprm, eprm);
-
-	return 0;
-}
-
-
-/**
- * Set global Do not Disturb flag
- *
- * @param dnd DnD flag
- */
-void uag_set_dnd(bool dnd)
-{
-	uag.dnd = dnd;
-}
-
-
-/**
- * Get DnD status of uag
- *
- * @return True if DnD is active, False if not
- */
-bool uag_dnd(void)
-{
-	return uag.dnd;
+	return ua ? ua->catchall : false;
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1795,3 +1795,12 @@ int  ua_disable_autoanswer(struct ua *ua, enum answer_method met)
 	pl_set_str(&n, name);
 	return ua_rm_custom_hdr(ua, &n);
 }
+
+
+int ua_raise(struct ua *ua)
+{
+	if (!ua)
+		return EINVAL;
+
+	return uag_raise(ua, &ua->le);
+}

--- a/src/uag.c
+++ b/src/uag.c
@@ -1,0 +1,1157 @@
+/**
+ * @file src/uag.c  User-Agent Group
+ *
+ * Copyright (C) 2010 Alfred E. Heggestad
+ */
+#include <string.h>
+#include <re.h>
+#include <baresip.h>
+#include "core.h"
+
+/* One instance */
+
+static struct uag uag = {
+	NULL,
+	LIST_INIT,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	true,
+	true,
+	true,
+	false,
+	NULL,
+	NULL,
+	false,
+	false,
+	NULL,
+	NULL,
+#ifdef USE_TLS
+	NULL,
+#endif
+};
+
+
+/* This function is called when all SIP transactions are done */
+static void exit_handler(void *arg)
+{
+	(void)arg;
+
+	ua_event(NULL, UA_EVENT_EXIT, NULL, NULL);
+
+	debug("ua: sip-stack exit\n");
+
+	if (uag.exith)
+		uag.exith(uag.arg);
+}
+
+
+/**
+ * Put the established call on hold and resume the given call
+ *
+ * @param call  Call to resume, or NULL to choose one which is on-hold
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int uag_hold_resume(struct call *call)
+{
+	int err = 0;
+	struct le *le = NULL;
+	struct ua *ua = NULL;
+	struct call *acall = NULL, *toresume = call;
+
+	for (le = list_head(&uag.ual); le && !toresume; le = le->next) {
+		ua = le->data;
+		toresume = ua_find_call_onhold(ua);
+	}
+
+	if (!toresume) {
+		debug ("ua: no call to resume\n");
+		return 0;
+	}
+
+	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
+		ua = le->data;
+		acall = ua_find_active_call(ua);
+	}
+
+	err =  call_hold(acall, true);
+	err |= call_hold(toresume, false);
+
+	return err;
+}
+
+
+/**
+ * Put all established calls on hold, except the given one
+ *
+ * @param call  Excluded call, or NULL
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int uag_hold_others(struct call *call)
+{
+	int err = 0;
+	struct le *le = NULL;
+	struct call *acall = NULL;
+
+	if (!conf_config()->call.hold_other_calls) {
+		return 0;
+	}
+
+	for (le = list_head(&uag.ual); le && !acall; le = le->next) {
+		struct ua *ua = le->data;
+		struct le *lec = NULL;
+
+		for (lec = list_head(ua_calls(ua)); lec; lec = lec->next) {
+			struct call *ccall = lec->data;
+			if (ccall == call)
+				continue;
+
+			if (call_state(ccall) == CALL_STATE_ESTABLISHED &&
+					!call_is_onhold(ccall)) {
+				acall = ccall;
+				break;
+			}
+		}
+	}
+
+	if (!acall)
+		return 0;
+
+	err = call_hold(acall, true);
+	return err;
+}
+
+
+/**
+ * Find call with given id
+ *
+ * @param id  Call-id string
+ *
+ * @return The call if found, otherwise NULL.
+ */
+struct call *uag_call_find(const char *id)
+{
+	struct le *le = NULL;
+	struct ua *ua = NULL;
+	struct call *call = NULL;
+
+	if (!str_isset(id))
+		return NULL;
+
+	for (le = list_head(&uag.ual); le; le = le->next) {
+		ua = le->data;
+
+		call = call_find_id(ua_calls(ua), id);
+		if (call)
+			break;
+	}
+
+	return call;
+}
+
+
+/**
+ * Filters the calls of all User-Agents
+ *
+ * @param listh   Call list handler is called for each match
+ * @param matchh  Optional filter match handler (if NULL all calls are listed)
+ * @param arg     User argument passed to listh
+ */
+void uag_filter_calls(call_list_h *listh, call_match_h *matchh, void *arg)
+{
+	struct le *leu;
+
+	if (!listh)
+		return;
+
+	for (leu = list_head(uag_list()); leu; leu = leu->next) {
+		struct ua *ua = leu->data;
+		struct le *lec;
+
+		for (lec = list_tail(ua_calls(ua)); lec; lec = lec->prev) {
+			struct call *call = lec->data;
+
+			if (!matchh || matchh(call))
+				listh(call, arg);
+		}
+	}
+}
+
+
+static bool request_handler(const struct sip_msg *msg, void *arg)
+{
+	struct ua *ua;
+
+	(void)arg;
+
+	if (pl_strcmp(&msg->met, "OPTIONS"))
+		return false;
+
+	ua = uag_find_msg(msg);
+	if (!ua) {
+		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
+		return true;
+	}
+
+	ua_handle_options(ua, msg);
+
+	return true;
+}
+
+
+static bool uri_only_user(const struct uri *uri)
+{
+	bool ret;
+	struct sa sa;
+
+	/* Note:
+	 * If only user is given then uri_decode sets uri->host instead of
+	 * uri->user. We don't know if this is a bug. But if somebody changes
+	 * this behavior then the following line has to be adapted.          */
+	ret = pl_isset(&uri->host) && !pl_isset(&uri->user);
+
+	/* exclude IP addresses */
+	if (!sa_set(&sa, &uri->host, 0))
+		ret = false;
+
+	return ret;
+}
+
+
+static bool uri_user_and_host(const struct uri *uri)
+{
+	bool ret;
+
+	ret = pl_isset(&uri->host) && pl_isset(&uri->user);
+
+	return ret;
+}
+
+
+static bool uri_host_local(const struct uri *uri)
+{
+
+	const char *hostv[] = {
+		"localhost",
+		"127.0.0.1",
+		"::1"
+	};
+	int afv[2] = {AF_INET, AF_INET6};
+	const struct sa *sal;
+	struct sa sap;
+	size_t i;
+	int err;
+
+	if (!uri)
+		return false;
+
+	for (i=0; i<ARRAY_SIZE(hostv); i++) {
+
+		if (!pl_strcmp(&uri->host, hostv[i]))
+			return true;
+	}
+
+	for (i=0; i<ARRAY_SIZE(afv); i++) {
+
+		sal = net_laddr_af(baresip_network(), afv[i]);
+
+		err = sa_set(&sap, &uri->host, 0);
+		if (err)
+			continue;
+
+		if (sa_cmp(sal, &sap, SA_ADDR))
+			return true;
+	}
+
+	return false;
+}
+
+
+static int add_transp_af(const struct sa *laddr)
+{
+	struct sa local;
+	int err = 0;
+
+	if (str_isset(uag.cfg->local)) {
+		err = sa_decode(&local, uag.cfg->local,
+				str_len(uag.cfg->local));
+		if (err) {
+			err = sa_set_str(&local, uag.cfg->local, 0);
+			if (err) {
+				warning("ua: decode failed: '%s'\n",
+					uag.cfg->local);
+				return err;
+			}
+		}
+
+		if (!sa_isset(&local, SA_ADDR)) {
+			uint16_t port = sa_port(&local);
+			(void)sa_set_sa(&local, &laddr->u.sa);
+			sa_set_port(&local, port);
+		}
+
+		if (sa_af(laddr) != sa_af(&local))
+			return 0;
+	}
+	else {
+		sa_cpy(&local, laddr);
+		sa_set_port(&local, 0);
+	}
+
+	if (uag.use_udp)
+		err |= sip_transp_add(uag.sip, SIP_TRANSP_UDP, &local);
+	if (uag.use_tcp)
+		err |= sip_transp_add(uag.sip, SIP_TRANSP_TCP, &local);
+	if (err) {
+		warning("ua: SIP Transport failed: %m\n", err);
+		return err;
+	}
+
+#ifdef USE_TLS
+	if (uag.use_tls) {
+		/* Build our SSL context*/
+		if (!uag.tls) {
+			const char *cert = NULL;
+			const char *cafile = NULL;
+			const char *capath = NULL;
+
+			if (str_isset(uag.cfg->cert)) {
+				cert = uag.cfg->cert;
+				info("SIP Certificate: %s\n", cert);
+			}
+
+			err = tls_alloc(&uag.tls, TLS_METHOD_SSLV23,
+					cert, NULL);
+			if (err) {
+				warning("ua: tls_alloc() failed: %m\n", err);
+				return err;
+			}
+
+			if (str_isset(uag.cfg->cafile))
+				cafile = uag.cfg->cafile;
+			if (str_isset(uag.cfg->capath))
+				capath = uag.cfg->capath;
+
+			if (cafile || capath) {
+				info("ua: adding SIP CA file: %s\n", cafile);
+				info("ua: adding SIP CA path: %s\n", capath);
+
+				err = tls_add_cafile_path(uag.tls,
+					cafile, capath);
+				if (err) {
+					warning("ua: tls_add_ca() failed:"
+						" %m\n", err);
+				}
+			}
+
+			if (!uag.cfg->verify_server)
+				tls_disable_verify_server(uag.tls);
+		}
+
+		if (sa_isset(&local, SA_PORT))
+			sa_set_port(&local, sa_port(&local) + 1);
+
+		err = sip_transp_add(uag.sip, SIP_TRANSP_TLS, &local, uag.tls);
+		if (err) {
+			warning("ua: SIP/TLS transport failed: %m\n", err);
+			return err;
+		}
+	}
+#endif
+
+	err = sip_transp_add_websock(uag.sip, SIP_TRANSP_WS, &local,
+				     false, NULL);
+	if (err) {
+		warning("ua: could not add Websock transport (%m)\n", err);
+		return err;
+	}
+
+#ifdef USE_TLS
+	err = sip_transp_add_websock(uag.sip, SIP_TRANSP_WSS, &local,
+				     false, uag.cfg->cert);
+	if (err) {
+		warning("ua: could not add secure Websock transport (%m)\n",
+			err);
+		return err;
+	}
+#endif
+
+	return err;
+}
+
+
+static int ua_add_transp(struct network *net)
+{
+	int err = 0;
+
+	if (sa_isset(net_laddr_af(net, AF_INET), SA_ADDR))
+		err |= add_transp_af(net_laddr_af(net, AF_INET));
+
+#if HAVE_INET6
+	if (sa_isset(net_laddr_af(net, AF_INET6), SA_ADDR))
+		err |= add_transp_af(net_laddr_af(net, AF_INET6));
+#endif
+
+	return err;
+}
+
+
+static bool sub_handler(const struct sip_msg *msg, void *arg)
+{
+	struct ua *ua;
+
+	(void)arg;
+
+	ua = uag_find_msg(msg);
+	if (!ua) {
+		warning("subscribe: no UA found for %r\n", &msg->uri.user);
+		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
+		return true;
+	}
+
+	if (uag.subh)
+		uag.subh(msg, ua);
+
+	return true;
+}
+
+
+static void sip_trace_handler(bool tx, enum sip_transp tp,
+			      const struct sa *src, const struct sa *dst,
+			      const uint8_t *pkt, size_t len, void *arg)
+{
+	(void)tx;
+	(void)arg;
+
+	re_printf("\x1b[36;1m"
+		  "#\n"
+		  "%s %J -> %J\n"
+		  "%b"
+		  "\x1b[;m\n"
+		  ,
+		  sip_transp_name(tp), src, dst, pkt, len);
+}
+
+
+/**
+ * Initialise the User-Agent Group
+ *
+ * @param software    SIP User-Agent string
+ * @param udp         Enable UDP transport
+ * @param tcp         Enable TCP transport
+ * @param tls         Enable TLS transport
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int ua_init(const char *software, bool udp, bool tcp, bool tls)
+{
+	struct config *cfg = conf_config();
+	struct network *net = baresip_network();
+	uint32_t bsize;
+	int err;
+
+	if (!net) {
+		warning("ua: no network\n");
+		return EINVAL;
+	}
+
+	uag.cfg = &cfg->sip;
+	bsize = 16;
+
+	uag.use_udp = udp;
+	uag.use_tcp = tcp;
+	uag.use_tls = tls;
+
+	list_init(&uag.ual);
+
+	err = sip_alloc(&uag.sip, net_dnsc(net), bsize, bsize, bsize,
+			software, exit_handler, NULL);
+	if (err) {
+		warning("ua: sip stack failed: %m\n", err);
+		goto out;
+	}
+
+	err = ua_add_transp(net);
+	if (err)
+		goto out;
+
+	err = sip_listen(&uag.lsnr, uag.sip, true, request_handler, NULL);
+	if (err)
+		goto out;
+
+	err = sipsess_listen(&uag.sock, uag.sip, bsize,
+			     sipsess_conn_handler, NULL);
+	if (err)
+		goto out;
+
+	err = sipevent_listen(&uag.evsock, uag.sip, bsize, bsize,
+			      sub_handler, NULL);
+	if (err)
+		goto out;
+
+ out:
+	if (err) {
+		warning("ua: init failed (%m)\n", err);
+		ua_close();
+	}
+	return err;
+}
+
+
+/**
+ * Close all active User-Agents
+ */
+void ua_close(void)
+{
+	uag.evsock   = mem_deref(uag.evsock);
+	uag.sock     = mem_deref(uag.sock);
+	uag.lsnr     = mem_deref(uag.lsnr);
+	uag.sip      = mem_deref(uag.sip);
+	uag.eprm     = mem_deref(uag.eprm);
+
+#ifdef USE_TLS
+	uag.tls = mem_deref(uag.tls);
+#endif
+
+	list_flush(&uag.ual);
+}
+
+
+/**
+ * Stop all User-Agents
+ *
+ * @param forced True to force, otherwise false
+ */
+void ua_stop_all(bool forced)
+{
+	struct le *le;
+	unsigned ext_ref = 0;
+
+	info("ua: stop all (forced=%d)\n", forced);
+
+	/* check if someone else has grabbed a ref to ua */
+	le = uag.ual.head;
+	while (le) {
+
+		struct ua *ua = le->data;
+		le = le->next;
+
+		if (ua_destroy(ua) != 0) {
+			++ext_ref;
+		}
+	}
+
+	if (ext_ref) {
+		info("ua: in use (%u) by app module\n", ext_ref);
+		uag.delayed_close = true;
+		return;
+	}
+
+	if (forced)
+		sipsess_close_all(uag.sock);
+
+	sip_close(uag.sip, forced);
+}
+
+
+/**
+ * Set the global UA exit handler. The exit handler will be called
+ * asyncronously when the SIP stack has exited.
+ *
+ * @param exith Exit handler
+ * @param arg   Handler argument
+ */
+void uag_set_exit_handler(ua_exit_h *exith, void *arg)
+{
+	uag.exith = exith;
+	uag.arg = arg;
+}
+
+
+/**
+ * Enable SIP message tracing
+ *
+ * @param enable True to enable, false to disable
+ */
+void uag_enable_sip_trace(bool enable)
+{
+	sip_set_trace_handler(uag.sip, enable ? sip_trace_handler : NULL);
+}
+
+
+/**
+ * Reset the SIP transports for all User-Agents
+ *
+ * @param reg      True to reset registration
+ * @param reinvite True to update active calls
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int uag_reset_transp(bool reg, bool reinvite)
+{
+	struct network *net = baresip_network();
+	struct le *le;
+	int err;
+
+	/* Update SIP transports */
+	sip_transp_flush(uag.sip);
+
+	(void)net_check(net);
+	err = ua_add_transp(net);
+	if (err)
+		return err;
+
+	/* Re-REGISTER all User-Agents */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		if (reg && account_regint(acc) && !account_prio(acc)) {
+			err |= ua_register(ua);
+		}
+		else if (reg && account_regint(acc)) {
+			err |= ua_fallback(ua);
+		}
+
+		/* update all active calls */
+		if (reinvite) {
+			struct le *lec;
+
+			for (lec = ua_calls(ua)->head; lec; lec = lec->next) {
+				struct call *call = lec->data;
+				const struct sa *laddr;
+
+				laddr = net_laddr_af(net, call_af(call));
+
+				err |= call_reset_transp(call, laddr);
+			}
+		}
+	}
+
+	return err;
+}
+
+
+/**
+ * Get the global SIP configuration
+ *
+ * @return SIP Stack
+ */
+struct config_sip *uag_cfg(void)
+{
+	return uag.cfg;
+}
+
+
+/**
+ * Get the global SIP Stack
+ *
+ * @return SIP Stack
+ */
+struct sip *uag_sip(void)
+{
+	return uag.sip;
+}
+
+
+/**
+ * Get the global SIP Session socket
+ *
+ * @return SIP Session socket
+ */
+struct sipsess_sock *uag_sipsess_sock(void)
+{
+	return uag.sock;
+}
+
+
+/**
+ * Get the global SIP Event socket
+ *
+ * @return SIP Event socket
+ */
+struct sipevent_sock *uag_sipevent_sock(void)
+{
+	return uag.evsock;
+}
+
+
+static bool uri_match_transport(const struct uri *accu,
+		const struct uri *peeru, enum sip_transp tp)
+{
+	struct pl pl;
+	enum sip_transp tpa;
+	int err;
+
+	err = msg_param_decode(&accu->params, "transport", &pl);
+	if (err)
+		return true;
+
+	tpa = sip_transp_decode(&pl);
+	if (peeru) {
+		/* outgoing calls */
+		tp = uag.cfg->transp;
+		if (!msg_param_decode(&peeru->params, "transport", &pl))
+			tp = sip_transp_decode(&pl);
+	}
+
+	return tpa == tp;
+}
+
+
+static bool uri_match_af(const struct uri *accu, const struct uri *peeru)
+{
+#ifdef HAVE_INET6
+	struct sa sa1;
+	struct sa sa2;
+	int err;
+#endif
+
+	/* we list cases where we know there is a mismatch in af */
+#ifdef HAVE_INET6
+	if (peeru->af == AF_UNSPEC || accu->af == AF_UNSPEC)
+		return true;
+
+	if (accu->af != peeru->af)
+		return false;
+
+	if (accu->af == AF_INET6 && peeru->af == AF_INET6) {
+		err =  sa_set(&sa1, &accu->host, 0);
+		err |= sa_set(&sa2, &peeru->host, 0);
+
+		if (err) {
+			warning("ua: No valid IPv6 URI %r, %r (%m)\n",
+					&accu->host,
+					&peeru->host, err);
+			return false;
+		}
+
+		return sa_is_linklocal(&sa1) == sa_is_linklocal(&sa2);
+	}
+#endif
+
+	/* both IPv4 or we can't decide if af will match */
+	return true;
+}
+
+
+/**
+ * Find the correct UA from the contact user
+ *
+ * @param cuser Contact username
+ *
+ * @return Matching UA if found, NULL if not found
+ */
+struct ua *uag_find(const struct pl *cuser)
+{
+	struct le *le;
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (0 == pl_strcasecmp(cuser, ua_cuser(ua)))
+			return ua;
+	}
+
+	/* Try also matching by AOR, for better interop */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		if (0 == pl_casecmp(cuser, &acc->luri.user))
+			return ua;
+	}
+
+	/* Last resort, try any catchall UAs */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (ua_catchall(ua))
+			return ua;
+	}
+
+	return NULL;
+}
+
+
+/**
+ * Find the correct UA from SIP message
+ *
+ * @param msg SIP message
+ *
+ * @return Matching UA if found, NULL if not found
+ */
+struct ua *uag_find_msg(const struct sip_msg *msg)
+{
+	struct le *le;
+	const struct pl *cuser;
+	struct ua *uaf = NULL;  /* fallback ua */
+
+	if (!msg)
+		return NULL;
+
+	cuser = &msg->uri.user;
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (0 == pl_strcasecmp(cuser, ua_cuser(ua))) {
+			ua_printf(ua, "selected for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	/* Try also matching by AOR, for better interop and for peer-to-peer
+	 * calls */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		if (!acc->regint) {
+			if (!uri_match_transport(&acc->luri, NULL, msg->tp))
+				continue;
+
+			if (!uri_match_af(&acc->luri, &msg->uri))
+				continue;
+
+			if (!uri_host_local(&msg->uri))
+				continue;
+
+			if (!uaf)
+				uaf = ua;
+		}
+
+		if (0 == pl_casecmp(cuser, &acc->luri.user)) {
+			ua_printf(ua, "account match for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	/* Last resort, try any catchall UAs */
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		if (ua_catchall(ua)) {
+			ua_printf(ua, "use catch-all account for %r\n", cuser);
+			return ua;
+		}
+	}
+
+	if (uaf)
+		ua_printf(uaf, "selected\n");
+
+	return uaf;
+}
+
+
+/**
+ * Find a User-Agent (UA) from an Address-of-Record (AOR)
+ *
+ * @param aor Address-of-Record string
+ *
+ * @return User-Agent (UA) if found, otherwise NULL
+ */
+struct ua *uag_find_aor(const char *aor)
+{
+	struct le *le;
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		if (str_isset(aor) && str_cmp(acc->aor, aor))
+			continue;
+
+		return ua;
+	}
+
+	return NULL;
+}
+
+
+/**
+ * Find a User-Agent (UA) which has certain address parameter and/or value
+ *
+ * @param name  SIP Address parameter name
+ * @param value SIP Address parameter value (optional)
+ *
+ * @return User-Agent (UA) if found, otherwise NULL
+ */
+struct ua *uag_find_param(const char *name, const char *value)
+{
+	struct le *le;
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+		struct sip_addr *laddr = account_laddr(acc);
+		struct pl val;
+
+		if (value) {
+
+			if (0 == msg_param_decode(&laddr->params, name, &val)
+			    &&
+			    0 == pl_strcasecmp(&val, value)) {
+				return ua;
+			}
+		}
+		else {
+			if (0 == msg_param_exists(&laddr->params, name, &val))
+				return ua;
+		}
+	}
+
+	return NULL;
+}
+
+
+/**
+ * Find a User-Agent (UA) best fitting for an SIP request
+ *
+ * @param requri The SIP uri for the request
+ *
+ * @return User-Agent (UA) if found, otherwise NULL
+ */
+struct ua *uag_find_requri(const char *requri)
+{
+	struct mbuf *mb;
+	struct pl pl;
+	struct uri *uri;
+	struct le *le;
+	struct ua *ret = NULL;
+	struct sip_addr addr;
+	struct sa sa;
+	int err;
+
+	if (!requri)
+		return NULL;
+
+	if (!uag.ual.head)
+		return NULL;
+
+	mb = mbuf_alloc(16);
+	if (!mb)
+		return NULL;
+
+	err = account_uri_complete(NULL, mb, requri);
+	if (err) {
+		warning("ua: failed to complete uri: %s\n", requri);
+		goto out;
+	}
+
+	mbuf_set_pos(mb, 0);
+	pl_set_mbuf(&pl, mb);
+	err = sip_addr_decode(&addr, &pl);
+	if (err) {
+		warning("ua: address %r could not be parsed: %m\n",
+			&pl, err);
+		goto out;
+	}
+
+	uri = &addr.uri;
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		/* not registered */
+		if (acc->regint && !ua_isregistered(ua))
+			continue;
+
+		if (uri_only_user(uri)) {
+			if (acc->regint) {
+				ret = ua;
+				break;
+			}
+		}
+
+		if (uri_user_and_host(uri) && acc->regint) {
+			if (0 != pl_cmp(&uri->host, &acc->luri.host)) {
+				continue;
+			}
+			else {
+				ret = ua;
+				break;
+			}
+		}
+
+		/* Now we select a local account for peer-to-peer calls.
+		 * uri = user@IP | user@domain | IP. */
+		if (!acc->regint) {
+			if (!uri_match_transport(&acc->luri, uri,
+						 SIP_TRANSP_NONE))
+				continue;
+
+			if (!uri_match_af(&acc->luri, uri))
+				continue;
+
+			if (!uri_only_user(uri) ||
+					!sa_set(&sa, &uri->host, 0)) {
+				/* Remember local account.
+				 * But we prefer registered UA. */
+				if (!ret)
+					ret = ua;
+			}
+		}
+	}
+
+	if (ret) {
+		ua_printf(ret, "selected for request\n");
+	}
+	else {
+		/* Ok, seems that matching account is missing. */
+		if (uri_only_user(uri)) {
+			goto out;
+		}
+
+		ret = uag.ual.head->data;
+		ua_printf(ret, "fallback selection\n");
+	}
+
+out:
+	mem_deref(mb);
+	return ret;
+}
+
+
+/**
+ * Get the list of User-Agents
+ *
+ * @return List of User-Agents (struct ua)
+ */
+struct list *uag_list(void)
+{
+	return &uag.ual;
+}
+
+
+/**
+ * Counts the calls from all user agents.
+ *
+ * @return the number of calls over all user agents.
+ */
+uint32_t uag_call_count(void)
+{
+	struct le *le;
+	uint32_t c = 0;
+
+	for (le = uag.ual.head; le; le = le->next) {
+		struct ua *ua = le->data;
+
+		c += list_count(ua_calls(ua));
+	}
+
+	return c;
+}
+
+
+/**
+ * Set the handler to receive incoming SIP SUBSCRIBE messages
+ *
+ * @param subh Subscribe handler
+ */
+void uag_set_sub_handler(sip_msg_h *subh)
+{
+	uag.subh = subh;
+}
+
+
+/**
+ * Get UAG-TLS Context
+ *
+ * @return TLS Context if used, NULL otherwise
+ */
+struct tls *uag_tls(void)
+{
+#ifdef USE_TLS
+	return uag.tls ? uag.tls : NULL;
+#else
+	return NULL;
+#endif
+}
+
+
+/**
+ * Setter UAG nodial flag
+ *
+ * @param nodial
+ */
+void uag_set_nodial(bool nodial)
+{
+	uag.nodial = nodial;
+}
+
+
+/**
+ * Getter UAG nodial flag
+ *
+ * @return uag.nodial
+ */
+bool uag_nodial(void)
+{
+	return uag.nodial;
+}
+
+
+/**
+ * Set extra parameters to use for all SIP Accounts
+ *
+ * @param eprm Extra parameters
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int uag_set_extra_params(const char *eprm)
+{
+	uag.eprm = mem_deref(uag.eprm);
+
+	if (eprm)
+		return str_dup(&uag.eprm, eprm);
+
+	return 0;
+}
+
+
+/**
+ * Get extra parameters to use for all SIP Accounts
+ *
+ * @return Extra parameters
+ */
+const char *uag_eprm(void)
+{
+	return uag.eprm;
+}
+
+
+/**
+ * Set global Do not Disturb flag
+ *
+ * @param dnd DnD flag
+ */
+void uag_set_dnd(bool dnd)
+{
+	uag.dnd = dnd;
+}
+
+
+/**
+ * Get DnD status of uag
+ *
+ * @return True if DnD is active, False if not
+ */
+bool uag_dnd(void)
+{
+	return uag.dnd;
+}
+
+
+/**
+ * Get the global delayed close flag
+ *
+ * @return Delayed close flag
+ */
+bool uag_delayed_close(void)
+{
+	return uag.delayed_close;
+}
+

--- a/src/uag.c
+++ b/src/uag.c
@@ -1046,6 +1046,17 @@ uint32_t uag_call_count(void)
 }
 
 
+int uag_raise(struct ua *ua, struct le *le)
+{
+	if (!ua || !le)
+		return EINVAL;
+
+	list_unlink(le);
+	list_prepend(&uag.ual, le, ua);
+	return 0;
+}
+
+
 /**
  * Set the handler to receive incoming SIP SUBSCRIBE messages
  *


### PR DESCRIPTION
- The UA at head will be used for a dial to a user only URI.
- Command `uafind` also switches the active call if there is one at this UA.

This PR is based on https://github.com/baresip/baresip/pull/1349 and has to be rebased after #1349 was merged.

This solution replaces the already removed `uanext` ("current UA") solution. The benefit is that `uag_find_requri()` selects an adequate UA regarding these rules: If URI looks like
- user --> selects the head UA
- user@domain --> selects the UA whose account host matches domain