### PR TITLE
multicast: remove clang static analyzer warnings

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -64,7 +64,7 @@ static int decode_codec(struct pl *plcodec, struct aucodec **codecptr)
 {
 	int err = 0;
 	struct list *acodeclist = baresip_aucodecl();
-	struct aucodec *codec;
+	struct aucodec *codec = NULL;
 	struct le *le;
 
 	LIST_FOREACH(acodeclist, le) {

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -442,6 +442,9 @@ int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac)
 
 	err = str_dup(&player->module, cfg->play_mod);
 	err |= str_dup(&player->device, cfg->play_dev);
+	if (err)
+		goto out;
+
 	player->sampv = mem_zalloc(AUDIO_SAMPSZ *
 		aufmt_sample_size(player->dec_fmt), NULL);
 	if (!player->sampv) {

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -474,7 +474,7 @@ void mcreceiver_unreg(struct sa *addr){
 	list_unlink(&mcreceiver->le);
 	resume_uag_state();
 	lock_rel(mcreceivl_lock);
-	mcreceiver = mem_deref(mcreceiver);
+	mem_deref(mcreceiver);
 
 	if (list_isempty(&mcreceivl))
 		mcreceivl_lock = mem_deref(mcreceivl_lock);
@@ -552,7 +552,7 @@ int mcreceiver_alloc(struct sa *addr, uint8_t prio)
 
   out:
 	if (err)
-		mcreceiver = mem_deref(mcreceiver);
+		mem_deref(mcreceiver);
 
 	return err;
 }

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -146,7 +146,7 @@ void mcsender_stop(struct sa *addr)
 
 	mcsender = le->data;
 	list_unlink(&mcsender->le);
-	mcsender = mem_deref(mcsender);
+	mem_deref(mcsender);
 }
 
 
@@ -189,7 +189,7 @@ int mcsender_alloc(struct sa *addr, const struct aucodec *codec)
 
  out:
 	if (err)
-		mcsender = mem_deref(mcsender);
+		mem_deref(mcsender);
 
 	return err;
 }

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -565,7 +565,7 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 
   out:
 	if (err)
-		src = mem_deref(src);
+		mem_deref(src);
 	else
 		*srcp = src;
 


### PR DESCRIPTION
Removes the warnings for the module/multicast listed in #1368 