### PR TITLE
Tls sipcert per acc

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -15,6 +15,7 @@
 #    ;auth_user=username
 #    ;auth_pass=password
 #    ;call_transfer=no
+#    ;cert=cert.pem
 #    ;mediaenc={srtp,srtp-mand,srtp-mandf,dtls_srtp,zrtp}
 #    ;medianat={stun,turn,ice}
 #    ;mwi=no

--- a/src/core.h
+++ b/src/core.h
@@ -70,6 +70,7 @@ struct account {
 	struct list vidcodecl;       /**< List of preferred video-codecs     */
 	bool mwi;                    /**< MWI on/off                         */
 	bool refer;                  /**< REFER method on/off                */
+	char *cert;                  /**< SIP TLS client certificate+keyfile */
 	char *ausrc_mod;
 	char *ausrc_dev;
 	char *auplay_mod;

--- a/src/ua.c
+++ b/src/ua.c
@@ -977,6 +977,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (err)
 		goto out;
 
+
 	/* generate a unique contact-user, this is needed to route
 	   incoming requests when using multiple useragents */
 	err = re_sdprintf(&ua->cuser, "%r-%p", &ua->acc->luri.user, ua);
@@ -998,6 +999,18 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (ua->acc->menc) {
 		ua_printf(ua, "Using media encryption '%s'\n",
 			  ua->acc->menc->id);
+	}
+
+	if (ua->acc->cert) {
+		err = sip_transp_add_ccert(uag.sip,
+			&ua->acc->laddr.uri, ua->acc->cert);
+		if (err) {
+			warning("ua: SIP/TLS add client "
+				"certificate %s failed: %m\n",
+				ua->acc->cert, err);
+			return err;
+		}
+
 	}
 
 	err = create_register_clients(ua);
@@ -1508,6 +1521,33 @@ int ua_state_json_api(struct odict *od, const struct ua *ua)
 /* One instance */
 
 
+#ifdef USE_TLS
+static int add_transp_clientcert(void)
+{
+	struct le *le;
+	struct ua *ua;
+	int err = 0;
+
+	for (le = list_head(&uag.ual); le; le = le->next) {
+		ua = le->data;
+		if (ua->acc->cert) {
+			err = sip_transp_add_ccert(uag.sip,
+				&ua->acc->laddr.uri, ua->acc->cert);
+			if (err) {
+				warning("ua: SIP/TLS add client "
+					"certificate %s failed: %m\n",
+					ua->acc->cert, err);
+				return err;
+			}
+
+		}
+	}
+
+	return err;
+}
+#endif
+
+
 static int add_transp_af(const struct sa *laddr)
 {
 	struct sa local;
@@ -1597,6 +1637,11 @@ static int add_transp_af(const struct sa *laddr)
 			warning("ua: SIP/TLS transport failed: %m\n", err);
 			return err;
 		}
+
+		err = add_transp_clientcert();
+		if (err)
+			return err;
+
 	}
 #endif
 


### PR DESCRIPTION
This PR depends on [#96](https://github.com/baresip/re/pull/96)

It allows the user to specify different client certificates for different
accounts in the accounts file.

SIP proxies environments may not allow installing new trusted certificates. In 
the same time they may have a certificate installed which is used to issue
new SIP certificates. For a single server it is no problem, since a user could
configure the server generated certificate as the SIP_certificate in the
config file. Having multiple such servers (maybe as fallback servers)
leads to a problem where baresip is currently not able to handle a variety of
client certificates.

This PR overcomes exactly the described problem.
In case a user has more than one account on the same SIP proxy. The connection
TLS handshake is done once. Therefore the client certificate check of the
server is done once. Configuring different client certificates for the same 
server configuration makes no sense and should be avoided.

Since the certificate option in the accounts file is optional, baresip uses
the SIP_certificate of the config file as fallback.