### PR TITLE
account: allow also ip;transport=tcp as valid dial URI

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -1438,6 +1438,7 @@ int account_uri_complete(const struct account *acc, struct mbuf *buf,
 	bool uri_is_ip;
 	char *uridup;
 	char *host;
+	char *param;
 	int err = 0;
 
 	if (!buf || !uri)
@@ -1469,6 +1470,10 @@ int account_uri_complete(const struct account *acc, struct mbuf *buf,
 		host = uridup + 4;
 	else
 		host = uridup;
+
+	param = strchr(host, ';');
+	if (param)
+		*param = 0;
 
 	uri_is_ip =
 		!sa_decode(&sa_addr, host, strlen(host)) ||


### PR DESCRIPTION
This adds support for dialing IP-address with given transport protocol.

Function `account_uri_complete()` should make a from a user-input dial URI that might not be fully RFC conform a fully RFC conform SIP URI.

But dial URIs like:
```
10.1.0.215;transport=tcp
```
result in an nonsense URI
```
sip:10.1.0.215;transport=tcp@localhost
```

@alfredh If you like it, we maybe should put it into 1.1.0.