### PR TITLE
dtls_srtp: use elliptic curve cryptography

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -185,6 +185,8 @@ module_app		ctrl_dbus.so
 #------------------------------------------------------------------------------
 # Module parameters
 
+# DTLS SRTP parameters
+#dtls_srtp_use_ec	prime256v1
 
 # UI Modules parameters
 cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets

--- a/src/config.c
+++ b/src/config.c
@@ -983,6 +983,10 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "# Module parameters\n");
 	(void)re_fprintf(f, "\n");
 
+	(void)re_fprintf(f, "# DTLS SRTP parameters\n");
+	(void)re_fprintf(f, "#dtls_srtp_use_ec\tprime256v1\n");
+	(void)re_fprintf(f, "\n");
+
 	(void)re_fprintf(f, "\n# UI Modules parameters\n");
 	(void)re_fprintf(f, "cons_listen\t\t0.0.0.0:5555 # cons - "
 				"Console UI UDP/TCP sockets\n");


### PR DESCRIPTION
The used curve is configured in the config file via "dtls_srtp_use_ec".