### PR TITLE
Video passthrough

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -269,6 +269,13 @@ video_selfview		window # {window,pip}
 # ctrl_dbus
 #ctrl_dbus_use	system		# system, session
 
+# avformat
+#pass_through		yes
+#profile_level_id	42002a
+
+# rtsp
+#rtsp_transport		udp
+
 # mqtt
 #mqtt_broker_host	sollentuna.example.com
 #mqtt_broker_port	1883

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -972,9 +972,8 @@ struct vidpacket {
 };
 
 /* Declare function pointer */
-typedef void (vidsrc_packet_h)(struct vidpacket *packet, uint64_t timestamp,
-			      void *arg);
-
+typedef void (vidsrc_packet_h)(struct vidpacket *packet,
+					uint64_t timestamp, void *arg);
 
 /**
  * Provides video frames to the core

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -42,6 +42,7 @@ struct ua;
 struct vidframe;
 struct vidrect;
 struct vidsz;
+struct vidpacket;
 
 
 /*
@@ -971,7 +972,8 @@ struct vidpacket {
 };
 
 /* Declare function pointer */
-typedef void (vidsrc_packet_h)(struct vidpacket *packet, void *arg);
+typedef void (vidsrc_packet_h)(struct vidpacket *packet, uint64_t timestamp,
+			      void *arg);
 
 /**
  * Provides video frames to the core
@@ -1145,6 +1147,10 @@ typedef int (videnc_encode_h)(struct videnc_state *ves, bool update,
 			      const struct vidframe *frame,
 			      uint64_t timestamp);
 
+typedef int (videnc_copy_h)(struct videnc_state *ves, bool update,
+			      const struct vidpacket *packet,
+			      uint64_t timestamp);
+
 typedef int (viddec_update_h)(struct viddec_state **vdsp,
 			      const struct vidcodec *vc, const char *fmtp);
 typedef int (viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
@@ -1163,6 +1169,7 @@ struct vidcodec {
 	viddec_decode_h *dech;
 	sdp_fmtp_enc_h *fmtp_ench;
 	sdp_fmtp_cmp_h *fmtp_cmph;
+	videnc_copy_h *copyh;
 };
 
 void vidcodec_register(struct list *vidcodecl, struct vidcodec *vc);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -975,6 +975,7 @@ struct vidpacket {
 typedef void (vidsrc_packet_h)(struct vidpacket *packet, uint64_t timestamp,
 			      void *arg);
 
+
 /**
  * Provides video frames to the core
  *

--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -89,6 +89,7 @@ static struct vidcodec h264 = {
 	.dech      = avcodec_decode_h264,
 	.fmtp_ench = avcodec_h264_fmtp_enc,
 	.fmtp_cmph = avcodec_h264_fmtp_cmp,
+	.copyh     = avcodec_copy,
 };
 
 static struct vidcodec h264_1 = {

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -56,6 +56,8 @@ int avcodec_encode_update(struct videnc_state **vesp,
 			  videnc_packet_h *pkth, void *arg);
 int avcodec_encode(struct videnc_state *st, bool update,
 		   const struct vidframe *frame, uint64_t timestamp);
+int avcodec_copy(struct videnc_state *st, bool update,
+		   const struct vidpacket *packet, uint64_t timestamp);
 
 
 /*

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -3,7 +3,9 @@
  *
  * Copyright (C) 2010 - 2013 Alfred E. Heggestad
  * Copyright (C) 2010 - 2013 Creytiv.com
- * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
+ * Copyright (C) 2021 by:
+ *     Media Magic Technologies <developer@mediamagictechnologies.com>
+ *     and Divus GmbH <developer@divus.eu>
  */
 #include <re.h>
 #include <rem.h>
@@ -687,13 +689,13 @@ int avcodec_copy(struct videnc_state *st, bool update,
 
 		case AV_CODEC_ID_H264:
 			err = h264_packetize(ts, packet->buf, packet->size,
-								 st->encprm.pktsize,
-								 st->pkth, st->arg);
+							st->encprm.pktsize,
+							st->pkth, st->arg);
 			break;
 
 		case AV_CODEC_ID_MPEG4:
 			err = general_packetize(ts, &mb, st->encprm.pktsize,
-									st->pkth, st->arg);
+							st->pkth, st->arg);
 			break;
 
 #ifdef AV_CODEC_ID_H265

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -2,6 +2,8 @@
  * @file avcodec/encode.c  Video codecs using libavcodec -- encoder
  *
  * Copyright (C) 2010 - 2013 Alfred E. Heggestad
+ * Copyright (C) 2010 - 2013 Creytiv.com
+ * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
  */
 #include <re.h>
 #include <rem.h>

--- a/modules/avcodec/sdp.c
+++ b/modules/avcodec/sdp.c
@@ -3,7 +3,9 @@
  *
  * Copyright (C) 2010 Alfred E. Heggestad
  * Copyright (C) 2010 Creytiv.com
- * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
+ * Copyright (C) 2021 by:
+ *     Media Magic Technologies <developer@mediamagictechnologies.com>
+ *     and Divus GmbH <developer@divus.eu>
  */
 
 #include <re.h>
@@ -49,13 +51,15 @@ int avcodec_h264_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 
 	if (*pass_through != '\0' && 0==strcmp(pass_through, "yes")) {
 		conf_get_str(conf_cur(), "profile_level_id",
-					 profile_level_id, sizeof(profile_level_id));
+					 profile_level_id,
+					 sizeof(profile_level_id));
 
 		if (*profile_level_id != '\0') {
 			struct pl prof;
 			pl_set_str(&prof, profile_level_id);
 			if (prof.l != 6) {
-				warning("avcodec: invalid profile_level_id (%r) using default\n",
+				warning("avcodec: invalid profile_level_id"
+						" (%r) using default\n",
 						profile_level_id);
 				goto out;
 			}

--- a/modules/avcodec/sdp.c
+++ b/modules/avcodec/sdp.c
@@ -2,6 +2,8 @@
  * @file avcodec/sdp.c  Video codecs using libavcodec -- SDP functions
  *
  * Copyright (C) 2010 Alfred E. Heggestad
+ * Copyright (C) 2010 Creytiv.com
+ * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
  */
 
 #include <re.h>

--- a/modules/avcodec/sdp.c
+++ b/modules/avcodec/sdp.c
@@ -10,7 +10,8 @@
 #include "avcodec.h"
 
 
-static const uint8_t h264_level_idc = 0x1f;
+static char pass_through[256] = "";
+static char profile_level_id[256] = "";
 
 
 uint32_t h264_packetization_mode(const char *fmtp)
@@ -33,13 +34,38 @@ int avcodec_h264_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 			  bool offer, void *arg)
 {
 	struct vidcodec *vc = arg;
-	const uint8_t profile_idc = 0x42; /* baseline profile */
-	const uint8_t profile_iop = 0xe0;
+	uint8_t profile_idc = 0x42; /* baseline profile */
+	uint8_t profile_iop = 0xe0;
+	uint8_t h264_level_idc = 0x1f;
 	(void)offer;
 
 	if (!mb || !fmt || !vc)
 		return 0;
 
+	conf_get_str(conf_cur(), "avformat_pass_through",
+				 pass_through, sizeof(pass_through));
+
+	if (*pass_through != '\0' && 0==strcmp(pass_through, "yes")) {
+		conf_get_str(conf_cur(), "profile_level_id",
+					 profile_level_id, sizeof(profile_level_id));
+
+		if (*profile_level_id != '\0') {
+			struct pl prof;
+			pl_set_str(&prof, profile_level_id);
+			if (prof.l != 6) {
+				warning("avcodec: invalid profile_level_id (%r) using default\n",
+						profile_level_id);
+				goto out;
+			}
+
+			prof.l = 2;
+			profile_idc = pl_x32(&prof); prof.p += 2;
+			profile_iop = pl_x32(&prof); prof.p += 2;
+			h264_level_idc   = pl_x32(&prof);
+
+		}
+	}
+ out:
 	return mbuf_printf(mb, "a=fmtp:%s"
 			   " %s"
 			   ";profile-level-id=%02x%02x%02x"

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -2,6 +2,7 @@
  * @file avformat.c  libavformat media-source
  *
  * Copyright (C) 2010 - 2020 Alfred E. Heggestad
+ * Copyright (C) 2010 - 2020 Creytiv.com
  * Copyright (C) 2021 by:
  *     Media Magic Technologies <developer@mediamagictechnologies.com>
  *     and Divus GmbH <developer@divus.eu>
@@ -162,7 +163,8 @@ static void *read_thread(void *data)
 				avformat_video_decode(st, pkt);
 				if (st->is_pass_through) {
 					avformat_video_copy(st, &pkt);
-				} else {
+				}
+				else {
 					avformat_video_decode(st, &pkt);
 				}
 			}
@@ -335,10 +337,13 @@ int avformat_shared_alloc(struct shared **shp, const char *dev,
 
 	if (*rtsp_transport != '\0') {
 		ret = -1;
-		if ((0==strcmp(rtsp_transport, "tcp")) || (0==strcmp(rtsp_transport, "udp")) ||
-			(0==strcmp(rtsp_transport, "udp_multicast")) || (0==strcmp(rtsp_transport, "http")) ||
+		if ((0==strcmp(rtsp_transport, "tcp")) ||
+			(0==strcmp(rtsp_transport, "udp")) ||
+			(0==strcmp(rtsp_transport, "udp_multicast")) ||
+			(0==strcmp(rtsp_transport, "http")) ||
 			(0==strcmp(rtsp_transport, "https"))) {
-			ret = av_dict_set(&format_opts, "rtsp_transport", rtsp_transport, 0);
+			ret = av_dict_set(&format_opts, "rtsp_transport",
+						rtsp_transport, 0);
 		}
 
 		if (ret != 0) {

--- a/modules/avformat/mod_avformat.h
+++ b/modules/avformat/mod_avformat.h
@@ -15,6 +15,7 @@ struct shared {
 	pthread_t thread;
 	bool is_realtime;
 	bool run;
+	bool is_pass_through;
 
 	struct stream {
 		AVRational time_base;
@@ -45,3 +46,6 @@ int  avformat_video_alloc(struct vidsrc_st **stp, const struct vidsrc *vs,
 			  vidsrc_packet_h *packeth,
 			  vidsrc_error_h *errorh, void *arg);
 void avformat_video_decode(struct shared *st, AVPacket *pkt);
+
+/*add avformat_video_copy function which passes packets to packet handler*/
+void avformat_video_copy(struct shared *st, AVPacket *pkt);

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -3,7 +3,9 @@
  *
  * Copyright (C) 2010 - 2020 Alfred E. Heggestad
  * Copyright (C) 2010 - 2020 Creytiv.com
- * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
+ * Copyright (C) 2021 by:
+ *     Media Magic Technologies <developer@mediamagictechnologies.com>
+ *     and Divus GmbH <developer@divus.eu>
  */
 
 #include <re.h>

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -2,6 +2,8 @@
  * @file avformat/video.c  libavformat media-source -- video
  *
  * Copyright (C) 2010 - 2020 Alfred E. Heggestad
+ * Copyright (C) 2010 - 2020 Creytiv.com
+ * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
  */
 
 #include <re.h>

--- a/modules/v4l2_codec/v4l2_codec.c
+++ b/modules/v4l2_codec/v4l2_codec.c
@@ -284,7 +284,7 @@ static void read_frame(struct vidsrc_st *st)
 #endif
 
 	if (st->packeth)
-		st->packeth(&vp, st->arg);
+		st->packeth(&vp, timestamp, st->arg);
 	else {
 		warning("v4l2_codec: no packet handler\n");
 	}

--- a/modules/vidloop/vidloop.c
+++ b/modules/vidloop/vidloop.c
@@ -372,11 +372,14 @@ static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
 }
 
 
-static void vidsrc_packet_handler(struct vidpacket *packet, void *arg)
+static void vidsrc_packet_handler(struct vidpacket *packet,
+		uint64_t timestamp, void *arg)
 {
 	struct video_loop *vl = arg;
 	uint64_t rtp_ts;
 
+	/* todo: not sure if here we need to use packet->timestamp
+	or the received timestamp */
 	rtp_ts = video_calc_rtp_timestamp_fix(packet->timestamp);
 
 	/* todo: hardcoded codecid, get from packet */

--- a/src/config.c
+++ b/src/config.c
@@ -1128,6 +1128,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "#avformat_hwaccel\tvaapi\n"
 			 "#avformat_inputformat\tmjpeg\n"
 			 "#avformat_decoder\tmjpeg\n"
+			 "#avformat_pass_through\tyes\n"
 			 "#avformat_rtsp_transport\tudp\n");
 
 	if (f)

--- a/src/video.c
+++ b/src/video.c
@@ -3,7 +3,9 @@
  *
  * Copyright (C) 2010 Alfred E. Heggestad
  * Copyright (C) 2010 Creytiv.com
- * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
+ * Copyright (C) 2021 by:
+ *     Media Magic Technologies <developer@mediamagictechnologies.com>
+ *     and Divus GmbH <developer@divus.eu>
  *
  * \ref GenericVideoStream
  */
@@ -395,13 +397,16 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 		lock_write_get(vtx->lock_enc);
 
 		if (vtx->vc && vtx->vc->copyh) {
-			err = vtx->vc->copyh(vtx->enc, vtx->picup, packet, timestamp);
+			err = vtx->vc->copyh(vtx->enc, vtx->picup,
+							packet, timestamp);
 			if (err)
 				goto out;
 
 			vtx->picup = false;
-		} else {
-			warning("video: Skipping Packet as Copy Handler not initialized ..\n");
+		}
+		else {
+			warning("video: Skipping Packet as"
+				" Copy Handler not initialized ..\n");
 		}
 		goto out;
 	}

--- a/src/video.c
+++ b/src/video.c
@@ -2,6 +2,8 @@
  * @file src/video.c  Video stream
  *
  * Copyright (C) 2010 Alfred E. Heggestad
+ * Copyright (C) 2010 Creytiv.com
+ * Copyright (C) 2021 Media Magic Technologies <developer@mediamagictechnologies.com> and Divus GmbH <developer@divus.eu>
  *
  * \ref GenericVideoStream
  */


### PR DESCRIPTION
In this PR we introduce the possibility to passthrough the video received by the avformat module without the need to decode and re-encode it. The feature was discussed in #296

To achieve this goal, three new settings were introduced:

* **pass_through**: when set to **yes** video passthrough is enabled
* **rtsp_transport**: it can be set to **tcp**, **udp**, **udp_multicast**, **http** or **https** to force the kind of transport used to communicate with the camera (when RTSP is used)
* **profile_level_id**: to set the profile level of the output stream, for example **42002a** to set profile_idc to 42, profile_iop to 00 and h264_level_idc to 2a, so that it can be aligned to the one served by the camera

The copyright of this work is shared by Media Magic Technologies <developer@mediamagictechnologies.com> ( @mediamagic-dev ) and Divus GmbH <developer@divus.eu> ( @divusgmbh ) and it's released under the same licence used by Baresip.

The development was done on tag v1.0.0 and then rebased on master; we tested it on a very low-power system, and can confirm a huge benefit in terms of CPU usage.