### PR TITLE
config: enable sip_verify_server if sip_cafile or sip_capath is set

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -284,20 +284,17 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   sizeof(cfg->sip.local));
 	(void)conf_get_str(conf, "sip_certificate", cfg->sip.cert,
 			   sizeof(cfg->sip.cert));
-	(void)conf_get_bool(conf, "sip_verify_server",
-			&cfg->sip.verify_server);
 
+	cfg->sip.verify_server = true;
 	(void)conf_get_str(conf, "sip_cafile", cfg->sip.cafile,
 			   sizeof(cfg->sip.cafile));
 	(void)conf_get_str(conf, "sip_capath", cfg->sip.capath,
 			   sizeof(cfg->sip.capath));
-	if (!str_isset(cfg->sip.cafile) && !str_isset(cfg->sip.capath)) {
-		if (cfg->sip.verify_server) {
-			warning("config: no sip_cafile/sip_capath defined "
-				"and sip_verify_server is enabled, "
-				"sip tls connections maybe won't work\n");
-		}
-	}
+	if (!str_isset(cfg->sip.cafile) && !str_isset(cfg->sip.capath))
+		cfg->sip.verify_server = false;
+
+	(void)conf_get_bool(conf, "sip_verify_server",
+			&cfg->sip.verify_server);
 
 	if (!conf_get(conf, "sip_trans_def", &tr))
 		cfg->sip.transp = sip_transp_decode(&tr);
@@ -631,7 +628,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			 "#sip_cafile\t\t%s\n"
 #endif
 			  "#sip_trans_def\t\tudp\n"
-			  "sip_verify_server\tyes\n"
+			  "#sip_verify_server\tyes\n"
 			  "\n"
 			  "# Call\n"
 			  "call_local_timeout\t%u\n"


### PR DESCRIPTION
- In case no sip_cafile or sip_capath is configured. sip_verify_server is false.
- The sip_verify_server option in the config file overrules the decision via sip_cafile and sip_capath.
- The standard config template shows the possibility of a sip_verify_server option. But it is not active.