### PR TITLE
account: add accounts parameter to force media address family

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -65,7 +65,7 @@
 <sip:user@example.com>;audio_codecs=opus/48000/2;video_codecs=vp8;auth_pass=pass
 
 #
-# Force IPv6 for media
+# Prefer IPv6 for media
 #
 <sip:user@example.com>;mediaaf=ipv6
 

--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -16,6 +16,7 @@
 #    ;auth_pass=password
 #    ;call_transfer=no
 #    ;cert=cert.pem
+#    ;mediaaf={ipv4,ipv6}
 #    ;mediaenc={srtp,srtp-mand,srtp-mandf,dtls_srtp,zrtp}
 #    ;medianat={stun,turn,ice}
 #    ;mwi=no
@@ -62,6 +63,11 @@
 # Force audio-codec 'opus' and video-codec 'vp8'
 #
 <sip:user@example.com>;audio_codecs=opus/48000/2;video_codecs=vp8;auth_pass=pass
+
+#
+# Force IPv6 for media
+#
+<sip:user@example.com>;mediaaf=ipv6
 
 
 # ... more examples can be added here ...

--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -16,7 +16,7 @@
 #    ;auth_pass=password
 #    ;call_transfer=no
 #    ;cert=cert.pem
-#    ;mediaaf={ipv4,ipv6}
+#    ;mediaaf={ipv4,ipv6,auto}
 #    ;mediaenc={srtp,srtp-mand,srtp-mandf,dtls_srtp,zrtp}
 #    ;medianat={stun,turn,ice}
 #    ;mwi=no
@@ -68,6 +68,12 @@
 # Prefer IPv6 for media
 #
 <sip:user@example.com>;mediaaf=ipv6
+
+#
+# Use same address family as SIP registration. This is the default for
+# registered accounts
+#
+<sip:user@example.com>;regint=3600;mediaaf=auto
 
 
 # ... more examples can be added here ...

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -110,6 +110,7 @@ const char *account_stun_pass(const struct account *acc);
 const char *account_stun_host(const struct account *acc);
 const struct stun_uri *account_stun_uri(const struct account *acc);
 uint16_t account_stun_port(const struct account *acc);
+int         account_mediaaf(const struct account *acc);
 const char *account_mediaenc(const struct account *acc);
 const char *account_medianat(const struct account *acc);
 const char *account_mwi(const struct account *acc);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -80,6 +80,7 @@ int account_set_stun_host(struct account *acc, const char *host);
 int account_set_stun_port(struct account *acc, uint16_t port);
 int account_set_stun_user(struct account *acc, const char *user);
 int account_set_stun_pass(struct account *acc, const char *pass);
+int account_set_mediaaf(struct account *acc, int mediaaf);
 int account_set_mediaenc(struct account *acc, const char *mediaenc);
 int account_set_medianat(struct account *acc, const char *medianat);
 int account_set_audio_codecs(struct account *acc, const char *codecs);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -80,7 +80,7 @@ int account_set_stun_host(struct account *acc, const char *host);
 int account_set_stun_port(struct account *acc, uint16_t port);
 int account_set_stun_user(struct account *acc, const char *user);
 int account_set_stun_pass(struct account *acc, const char *pass);
-int account_set_mediaaf(struct account *acc, int mediaaf);
+void account_set_mediaaf(struct account *acc, int mediaaf);
 int account_set_mediaenc(struct account *acc, const char *mediaenc);
 int account_set_medianat(struct account *acc, const char *medianat);
 int account_set_audio_codecs(struct account *acc, const char *codecs);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -819,7 +819,6 @@ struct call    *ua_call(const struct ua *ua);
 struct list    *ua_calls(const struct ua *ua);
 enum presence_status ua_presence_status(const struct ua *ua);
 void ua_presence_status_set(struct ua *ua, const enum presence_status status);
-void ua_set_media_af(struct ua *ua, int af_media);
 void ua_set_catchall(struct ua *ua, bool enabled);
 int ua_add_xhdr_filter(struct ua *ua, const char *hdr_name);
 int  ua_set_custom_hdrs(struct ua *ua, struct list *custom_hdrs);

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -56,6 +56,7 @@ static int account_write_template(const char *file)
 			 "#    ;auth_user=username\n"
 			 "#    ;auth_pass=password\n"
 			 "#    ;call_transfer=no\n"
+			 "#    ;mediaaf={ipv4,ipv6}\n"
 			 "#    ;mediaenc={srtp,srtp-mand,srtp-mandf"
 			 ",dtls_srtp,zrtp}\n"
 			 "#    ;medianat={stun,turn,ice}\n"

--- a/src/account.c
+++ b/src/account.c
@@ -177,6 +177,11 @@ static int af_decode(struct account *acc, const struct pl *prm)
 	acc->maf = !pl_strcasecmp(&pl, "ipv6") ? AF_INET6 :
 		   !pl_strcasecmp(&pl, "ipv4") ? AF_INET : AF_UNSPEC;
 
+	if (acc->maf == AF_UNSPEC) {
+		warning("account: invalid address family '%r'\n", &pl);
+		return EINVAL;
+	}
+
 	return 0;
 }
 

--- a/src/account.c
+++ b/src/account.c
@@ -483,6 +483,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	if (!acc)
 		return ENOMEM;
 
+	acc->maf = AF_UNSPEC;
 	err = str_dup(&acc->buf, sipaddr);
 	if (err)
 		goto out;

--- a/src/account.c
+++ b/src/account.c
@@ -791,16 +791,13 @@ int account_set_stun_pass(struct account *acc, const char *pass)
  *
  * @param acc      User-Agent account
  * @param mediaaf  Media address family
- *
- * @return 0 if success, otherwise errorcode
  */
-int account_set_mediaaf(struct account *acc, int mediaaf)
+void account_set_mediaaf(struct account *acc, int mediaaf)
 {
 	if (!acc)
-		return EINVAL;
+		return;
 
 	acc->maf = mediaaf;
-	return 0;
 }
 
 

--- a/src/account.c
+++ b/src/account.c
@@ -1430,7 +1430,7 @@ static const char *dtmfmode_str(enum dtmfmode mode)
  *
  * @param acc User-Agent account
  *
- * @return The address family
+ * @return Address family
  */
 int account_mediaaf(const struct account *acc)
 {

--- a/src/account.c
+++ b/src/account.c
@@ -167,6 +167,7 @@ static int extra_decode(struct account *acc, const struct pl *prm)
 static int af_decode(struct account *acc, const struct pl *prm)
 {
 	struct pl pl;
+	int maf;
 
 	if (!acc || !prm)
 		return EINVAL;
@@ -174,14 +175,16 @@ static int af_decode(struct account *acc, const struct pl *prm)
 	if (msg_param_decode(prm, "mediaaf", &pl))
 		return 0;
 
-	acc->maf = !pl_strcasecmp(&pl, "ipv6") ? AF_INET6 :
-		   !pl_strcasecmp(&pl, "ipv4") ? AF_INET : AF_UNSPEC;
+	maf = !pl_strcasecmp(&pl, "ipv6") ? AF_INET6 :
+	      !pl_strcasecmp(&pl, "ipv4") ? AF_INET :
+	      !pl_strcasecmp(&pl, "auto") ? AF_UNSPEC : -1;
 
-	if (acc->maf == AF_UNSPEC) {
+	if (maf == -1) {
 		warning("account: invalid address family '%r'\n", &pl);
 		return EINVAL;
 	}
 
+	acc->maf = maf;
 	return 0;
 }
 

--- a/src/account.c
+++ b/src/account.c
@@ -163,6 +163,24 @@ static int extra_decode(struct account *acc, const struct pl *prm)
 }
 
 
+/* Decode address family parameter */
+static int af_decode(struct account *acc, const struct pl *prm)
+{
+	struct pl pl;
+
+	if (!acc || !prm)
+		return EINVAL;
+
+	if (msg_param_decode(prm, "mediaaf", &pl))
+		return 0;
+
+	acc->maf = !pl_strcasecmp(&pl, "ipv6") ? AF_INET6 :
+		   !pl_strcasecmp(&pl, "ipv4") ? AF_INET : AF_UNSPEC;
+
+	return 0;
+}
+
+
 static int decode_pair(char **val1, char **val2,
 		       const struct pl *params, const char *name)
 {
@@ -525,6 +543,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 
 	err |= cert_decode(acc, &acc->laddr.params);
 	err |= extra_decode(acc, &acc->laddr.params);
+	err |= af_decode(acc,  &acc->laddr.params);
 
  out:
 	if (err)
@@ -1456,6 +1475,19 @@ const char *account_call_transfer(const struct account *acc)
 const char *account_extra(const struct account *acc)
 {
 	return acc ? acc->extra : NULL;
+}
+
+
+/**
+ * Get the preferred address for media of an account
+ *
+ * @param acc User-Agent account
+ *
+ * @return The address family
+ */
+int account_mediaaf(const struct account *acc)
+{
+	return acc ? acc->maf : 0;
 }
 
 

--- a/src/account.c
+++ b/src/account.c
@@ -787,6 +787,24 @@ int account_set_stun_pass(struct account *acc, const char *pass)
 
 
 /**
+ * Set the preferred media address family of a SIP account
+ *
+ * @param acc      User-Agent account
+ * @param mediaaf  Media address family
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int account_set_mediaaf(struct account *acc, int mediaaf)
+{
+	if (!acc)
+		return EINVAL;
+
+	acc->maf = mediaaf;
+	return 0;
+}
+
+
+/**
  * Set the media encryption for a SIP account
  *
  * @param acc     User-Agent account
@@ -1408,6 +1426,19 @@ static const char *dtmfmode_str(enum dtmfmode mode)
 
 
 /**
+ * Get the preferred address family for media of an account
+ *
+ * @param acc User-Agent account
+ *
+ * @return The address family
+ */
+int account_mediaaf(const struct account *acc)
+{
+	return acc ? acc->maf : 0;
+}
+
+
+/**
  * Get the media encryption of an account
  *
  * @param acc User-Agent account
@@ -1475,19 +1506,6 @@ const char *account_call_transfer(const struct account *acc)
 const char *account_extra(const struct account *acc)
 {
 	return acc ? acc->extra : NULL;
-}
-
-
-/**
- * Get the preferred address for media of an account
- *
- * @param acc User-Agent account
- *
- * @return The address family
- */
-int account_mediaaf(const struct account *acc)
-{
-	return acc ? acc->maf : 0;
 }
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -50,6 +50,7 @@ struct account {
 	struct list aucodecl;        /**< List of preferred audio-codecs     */
 	char *auth_user;             /**< Authentication username            */
 	char *auth_pass;             /**< Authentication password            */
+	int maf;                     /**< Media address family to force      */
 	char *mnatid;                /**< Media NAT handling                 */
 	char *mencid;                /**< Media encryption type              */
 	const struct mnat *mnat;     /**< MNAT module                        */

--- a/src/ua.c
+++ b/src/ua.c
@@ -988,6 +988,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (err)
 		goto out;
 
+	ua_set_media_af(ua, ua->acc->maf);
 	if (ua->acc->sipnat) {
 		ua_printf(ua, "Using sipnat: '%s'\n", ua->acc->sipnat);
 	}

--- a/src/ua.c
+++ b/src/ua.c
@@ -25,7 +25,6 @@ struct ua {
 	size_t    extensionc;        /**< Number of SIP extensions           */
 	char *cuser;                 /**< SIP Contact username               */
 	char *pub_gruu;              /**< SIP Public GRUU                    */
-	int af_media;                /**< Preferred Address Family for media */
 	enum presence_status pstat;  /**< Presence Status                    */
 	bool catchall;               /**< Catch all inbound requests         */
 	struct list hdr_filter;      /**< Filter for incoming headers        */
@@ -756,11 +755,11 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 		     net_af2name(af_sdp));
 		af = af_sdp;
 	}
-	else if (ua->af_media &&
-		   sa_isset(net_laddr_af(net, ua->af_media), SA_ADDR)) {
+	else if (ua->acc->maf &&
+		   sa_isset(net_laddr_af(net, ua->acc->maf), SA_ADDR)) {
 		info("ua: using ua's preferred AF: af=%s\n",
-		     net_af2name(ua->af_media));
-		af = ua->af_media;
+		     net_af2name(ua->acc->maf));
+		af = ua->acc->maf;
 	}
 	else {
 		af = best_effort_af(ua, net);
@@ -967,8 +966,6 @@ int ua_alloc(struct ua **uap, const char *aor)
 
 	list_init(&ua->calls);
 
-	ua->af_media = AF_UNSPEC;
-
 	/* Decode SIP address */
 	if (uag.eprm) {
 		err = re_sdprintf(&buf, "%s;%s", aor, uag.eprm);
@@ -988,7 +985,6 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (err)
 		goto out;
 
-	ua_set_media_af(ua, ua->acc->maf);
 	if (ua->acc->sipnat) {
 		ua_printf(ua, "Using sipnat: '%s'\n", ua->acc->sipnat);
 	}
@@ -1453,7 +1449,6 @@ int ua_debug(struct re_printf *pf, const struct ua *ua)
 	err |= re_hprintf(pf, " nrefs:     %u\n", mem_nrefs(ua));
 	err |= re_hprintf(pf, " cuser:     %s\n", ua->cuser);
 	err |= re_hprintf(pf, " pub-gruu:  %s\n", ua->pub_gruu);
-	err |= re_hprintf(pf, " af_media:  %s\n", net_af2name(ua->af_media));
 	err |= re_hprintf(pf, " %H", ua_print_supported, ua);
 
 	err |= account_debug(pf, ua->acc);
@@ -2727,21 +2722,6 @@ void uag_set_nodial(bool nodial)
 bool uag_nodial(void)
 {
 	return uag.nodial;
-}
-
-
-/**
- * Set the preferred address family for media
- *
- * @param ua       User-Agent
- * @param af_media Address family (e.g. AF_INET, AF_INET6)
- */
-void ua_set_media_af(struct ua *ua, int af_media)
-{
-	if (!ua)
-		return;
-
-	ua->af_media = af_media;
 }
 
 


### PR DESCRIPTION
```diff
+#    ;mediaaf={ipv4,ipv6}
```

This makes most sense for local accounts (regint=0). The logic is already in ua.c. This PR adds only the setting in accounts file.