### PR TITLE
menu: play ringtone on audio_alert device

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -182,8 +182,8 @@ static void menu_play(const char *ckey, const char *fname, int repeat)
 	pl_strdup(&file, &pl);
 	menu_stop_play();
 	(void)play_file(&menu.play, player, file, repeat,
-			cfg->audio.play_mod,
-			cfg->audio.play_dev);
+			cfg->audio.alert_mod,
+			cfg->audio.alert_dev);
 	mem_deref(file);
 }
 


### PR DESCRIPTION
The ringtone has to be played on separate audio device. Differently from audio speech.

I don't think that anybody has a problem that the ring and other signal tones are played on `audio_alert` where currently only the message.wav is played.

An option would be to add a new setting. But in order to keep the config as simple as possible, we prefer this solution.