### PR TITLE
menu: use str_isset() for command parameter

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -77,7 +77,7 @@ static int cmd_call_hold(struct re_printf *pf, void *arg)
 
 	(void)pf;
 
-	if (carg->prm) {
+	if (str_isset(carg->prm)) {
 		call = uag_call_find(carg->prm);
 		if (!call) {
 			re_hprintf(pf, "call %s not found\n", carg->prm);
@@ -158,7 +158,7 @@ static int cmd_call_resume(struct re_printf *pf, void *arg)
 	struct call *call = ua_call(ua);
 	(void)pf;
 
-	if (carg->prm) {
+	if (str_isset(carg->prm)) {
 		call = uag_call_find(carg->prm);
 		if (!call) {
 			re_hprintf(pf, "call %s not found\n", carg->prm);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -93,7 +93,7 @@ static int cmd_answer(struct re_printf *pf, void *arg)
 	struct call *call = ua_call(ua);
 	int err;
 
-	if (carg->prm) {
+	if (str_isset(carg->prm)) {
 		call = uag_call_find(carg->prm);
 		if (!call) {
 			re_hprintf(pf, "call %s not found\n", carg->prm);
@@ -699,7 +699,7 @@ static int cmd_hangup(struct re_printf *pf, void *arg)
 
 	(void)pf;
 
-	if (carg->prm) {
+	if (str_isset(carg->prm)) {
 		call = uag_call_find(carg->prm);
 		if (!call) {
 			re_hprintf(pf, "call %s not found\n", carg->prm);
@@ -952,7 +952,7 @@ static int cmd_set_adelay(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
 
-	if (!carg->prm) {
+	if (!str_isset(carg->prm)) {
 		menu_get()->adelay = -1;
 		return 0;
 	}


### PR DESCRIPTION
Fixes the commands in combination with module ctrl_tcp where the carg->prm
are empty strings if not specified.