### PR TITLE
multicast: add source and player API calls

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -533,6 +533,9 @@ static int module_init(void)
 	err = module_read_config();
 	err |= cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
 
+	mcsource_init();
+	mcplayer_init();
+
 	if (!err)
 		info("multicast: module init\n");
 
@@ -546,6 +549,9 @@ static int module_close(void)
 	mcreceiver_unregall();
 
 	cmd_unregister(baresip_commands(), cmdv);
+
+	mcsource_terminate();
+	mcplayer_terminate();
 
 	return 0;
 }

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -533,8 +533,8 @@ static int module_init(void)
 	err = module_read_config();
 	err |= cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
 
-	mcsource_init();
-	mcplayer_init();
+	err |= mcsource_init();
+	err |= mcplayer_init();
 
 	if (!err)
 		info("multicast: module init\n");

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -46,7 +46,7 @@ void mcreceiver_print(struct re_printf *pf);
 int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac);
 void mcplayer_stop(void);
 
-void mcplayer_init(void);
+int  mcplayer_init(void);
 void mcplayer_terminate(void);
 
 /* Source <exchangable source> */
@@ -55,5 +55,5 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 	mcsender_send_h *sendh, void *arg);
 void mcsource_stop(struct mcsource *src);
 
-void mcsource_init(void);
+int  mcsource_init(void);
 void mcsource_terminate(void);

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -46,7 +46,14 @@ void mcreceiver_print(struct re_printf *pf);
 int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac);
 void mcplayer_stop(void);
 
+void mcplayer_init(void);
+void mcplayer_terminate(void);
+
 /* Source <exchangable source> */
 struct mcsource;
 int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 	mcsender_send_h *sendh, void *arg);
+void mcsource_stop(struct mcsource *src);
+
+void mcsource_init(void);
+void mcsource_terminate(void);

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -565,10 +565,11 @@ void mcplayer_stop(void)
 /**
  * Initialize everything needed for the player beforhand
  *
+ * @return 0 if success, otherwise errorcode
  */
-void mcplayer_init(void)
+int mcplayer_init(void)
 {
-	return;
+	return 0;
 }
 
 /**

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -560,3 +560,22 @@ void mcplayer_stop(void)
 {
 	player = mem_deref(player);
 }
+
+
+/**
+ * Initialize everything needed for the player beforhand
+ *
+ */
+void mcplayer_init(void)
+{
+	return;
+}
+
+/**
+ * Terminate everything needed for the player afterwards
+ *
+ */
+void mcplayer_terminate(void)
+{
+	return;
+}

--- a/modules/multicast/sender.c
+++ b/modules/multicast/sender.c
@@ -46,6 +46,7 @@ static void mcsender_destructor(void *arg)
 {
 	struct mcsender *mcsender = arg;
 
+	mcsource_stop(mcsender->src);
 	mcsender->src = mem_deref(mcsender->src);
 	mcsender->rtp = mem_deref(mcsender->rtp);
 }

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -587,10 +587,11 @@ void mcsource_stop(struct mcsource *unused)
 /**
  * Initialize everything needed for the source beforhand
  *
+ * @return 0 if success, otherwise errorcode
  */
-void mcsource_init(void)
+int mcsource_init(void)
 {
-	return;
+	return 0;
 }
 
 

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -571,3 +571,34 @@ int mcsource_start(struct mcsource **srcp, const struct aucodec *ac,
 
 	return err;
 }
+
+
+/**
+ * Stop one multicast source.
+ *
+ * @param src Multicast audio source object
+ */
+void mcsource_stop(struct mcsource *unused)
+{
+	(void) unused;
+}
+
+
+/**
+ * Initialize everything needed for the source beforhand
+ *
+ */
+void mcsource_init(void)
+{
+	return;
+}
+
+
+/**
+ * Terminate everything needed for the source afterwards
+ *
+ */
+void mcsource_terminate(void)
+{
+	return;
+}


### PR DESCRIPTION
This adds some API calls which are useful for the exchangeable multicast source/player.