### PR TITLE
menu: command uafind raises UA to head

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -837,6 +837,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   struct call *xcall, const char *local_uri,
 		   bool use_rtp);
 struct call *ua_find_call_state(const struct ua *ua, enum call_state st);
+int ua_raise(struct ua *ua);
 
 
 /* One instance */

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -1010,6 +1010,7 @@ static int cmd_ua_delete_all(struct re_printf *pf, void *unused)
 static int cmd_ua_find(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
+	struct le *le;
 	struct ua *ua = NULL;
 
 	if (str_isset(carg->prm)) {
@@ -1023,6 +1024,12 @@ static int cmd_ua_find(struct re_printf *pf, void *arg)
 	}
 
 	(void)re_hprintf(pf, "ua: %s\n", account_aor(ua_account(ua)));
+
+	ua_raise(ua);
+
+	le = list_tail(ua_calls(ua));
+	if (le)
+		menu_selcall(le->data);
 
 	menu_update_callstatus(uag_call_count());
 

--- a/src/core.h
+++ b/src/core.h
@@ -380,6 +380,7 @@ struct uag {
 struct config_sip *uag_cfg(void);
 const char *uag_eprm(void);
 bool uag_delayed_close(void);
+int uag_raise(struct ua *ua, struct le *le);
 
 
 /*

--- a/src/ua.c
+++ b/src/ua.c
@@ -1797,3 +1797,12 @@ int  ua_disable_autoanswer(struct ua *ua, enum answer_method met)
 	pl_set_str(&n, name);
 	return ua_rm_custom_hdr(ua, &n);
 }
+
+
+int ua_raise(struct ua *ua)
+{
+	if (!ua)
+		return EINVAL;
+
+	return uag_raise(ua, &ua->le);
+}

--- a/src/uag.c
+++ b/src/uag.c
@@ -1075,6 +1075,17 @@ uint32_t uag_call_count(void)
 }
 
 
+int uag_raise(struct ua *ua, struct le *le)
+{
+	if (!ua || !le)
+		return EINVAL;
+
+	list_unlink(le);
+	list_prepend(&uag.ual, le, ua);
+	return 0;
+}
+
+
 /**
  * Set the handler to receive incoming SIP SUBSCRIBE messages
  *


### PR DESCRIPTION
- The UA at head will be used for a dial to a user only URI.
- Command uafind also switches the active call if there is one at this UA.

This solution replaces the already removed `uanext` ("current UA") solution. The benefit is that `uag_find_requri()` selects an adequate UA regarding these rules: If URI looks like
- user --> selects the head UA
- user@domain --> selects the UA whose account host matches domain

@juha-h This might be useful for baresip-studio.