### PR TITLE
menu: add command for settings media local direction

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -711,6 +711,29 @@ int menu_param_decode(const char *prm, const char *name, struct pl *val)
 }
 
 
+/**
+ * Decode an SDP direction
+ *
+ * @param pl  SDP direction as string
+ *
+ * @return sdp_dir SDP direction, SDP_SENDRECV as fallback
+ */
+enum sdp_dir decode_sdp_enum(const struct pl *pl)
+{
+	if (!pl_strcmp(pl, "inactive")) {
+		return SDP_INACTIVE;
+	}
+	else if (!pl_strcmp(pl, "sendonly")) {
+		return  SDP_SENDONLY;
+	}
+	else if (!pl_strcmp(pl, "recvonly")) {
+		return SDP_RECVONLY;
+	}
+
+	return SDP_SENDRECV;
+}
+
+
 static int module_init(void)
 {
 	struct pl val;

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -59,3 +59,4 @@ void menu_update_callstatus(bool incall);
 int  menu_param_decode(const char *prm, const char *name, struct pl *val);
 struct call *menu_find_call(call_match_h *matchh);
 struct call *menu_find_call_state(enum call_state st);
+enum sdp_dir decode_sdp_enum(const struct pl *pl);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -10,29 +10,6 @@
 #include "menu.h"
 
 
-/**
- * Decode a SDP direction
- *
- * @param pl  SDP direction as string
- *
- * @return sdp_dir SDP direction, SDP_SENDRECV as fallback
- */
-static enum sdp_dir decode_sdp_enum(const struct pl *pl)
-{
-	if (!pl_strcmp(pl, "inactive")) {
-		return SDP_INACTIVE;
-	}
-	else if (!pl_strcmp(pl, "sendonly")) {
-		return  SDP_SENDONLY;
-	}
-	else if (!pl_strcmp(pl, "recvonly")) {
-		return SDP_RECVONLY;
-	}
-
-	return SDP_SENDRECV;
-}
-
-
 static const char about_fmt[] =
 	".------------------------------------------------------------.\n"
 	"|                      "


### PR DESCRIPTION
Intercom feature: Force Privacy Interruption

- Talk ( + video ) in one direction from A to B
- B wants to switch to audio ( + video ) to bi-directional with a re-INVITE

This PR lets A change its local audio + video directions per menu command. Otherwise the re-INVITE from B to A will not have an effect.