### PR TITLE
Accounts example cleanup

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -35,17 +35,13 @@
 #
 # Examples:
 #
-#  <sip:user:secret@domain.com;transport=tcp>
-#  <sip:user:secret@1.2.3.4;transport=tcp>
-#  <sip:user:secret@[2001:df8:0:16:216:6fff:fe91:614c]:5070;transport=tcp>
+#  <sip:user@domain.com>;auth_pass=secret;regint=3600
+#  <sip:user@domain.com;transport=tcp>;auth_pass=secret;regint=3600
+#  <sip:user@1.2.3.4;transport=tcp>;auth_pass=secret;regint=3600
+#  <sip:user@[2001:df8:0:16:216:6fff:fe91:614c]:5070;transport=tcp>;auth_pass=secret;regint=3600
 #
-
-
-#
-# A very basic example
-#
-<sip:user@iptel.org>
-
+# A registrar-less account
+<sip:alice@office>
 
 #
 # Use SIP Outbound over TCP, with ICE for Media NAT Traversal, and DTLS-SRTP for encryption

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -79,16 +79,19 @@ static int account_write_template(const char *file)
 			 "#\n"
 			 "# Examples:\n"
 			 "#\n"
+			 "#  <sip:user@domain.com>"
+		         ";auth_pass=secret;regint=3600\n"
 			 "#  <sip:user@domain.com;transport=tcp>"
-		         ";auth_pass=secret\n"
+		         ";auth_pass=secret;regint=3600\n"
 			 "#  <sip:user@1.2.3.4;transport=tcp>"
-		         ";auth_pass=secret\n"
+		         ";auth_pass=secret;regint=3600\n"
 			 "#  <sip:user@"
 			 "[2001:df8:0:16:216:6fff:fe91:614c]:5070"
-			 ";transport=tcp>;auth_pass=secret\n"
+			 ";transport=tcp>;auth_pass=secret;regint=3600\n"
 			 "#\n"
 		       "\n"
-		       "#<sip:user@domain>;auth_pass=PASSWORD\n");
+		       "# A registrar-less account"
+		       "#<sip:alice@office>\n");
 	if (r < 0)
 		err = ENOMEM;
 


### PR DESCRIPTION
Some cleanup for the accounts examples in template and docs.

- regint has to be specified for SIP registrar accounts
- user:password is not supported. Instead auth_pass.