### PR TITLE
menu,call: fix hangup for outgoing call

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -410,6 +410,11 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 		break;
 
+	case UA_EVENT_CALL_LOCAL_SDP:
+		if (call_state(call) == CALL_STATE_OUTGOING)
+			menu_selcall(call);
+		break;
+
 	case UA_EVENT_CALL_RINGING:
 		menu_selcall(call);
 		if (!menu.ringback && !menu_find_call(active_call_test))

--- a/src/call.c
+++ b/src/call.c
@@ -1966,8 +1966,6 @@ static int send_invite(struct call *call)
 
 	routev[0] = account_outbound(call->acc, 0);
 
-	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call, "offer");
-
 	err = call_sdp_get(call, &desc, true);
 	if (err)
 		return err;
@@ -2007,6 +2005,8 @@ static int send_invite(struct call *call)
 
 	/* save call setup timer */
 	call->time_conn = time(NULL);
+
+	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call, "offer");
 
  out:
 	mem_deref(desc);


### PR DESCRIPTION
If a call is in state CALL_STATE_OUTGOING and the remote does not answer, e.g.
if the remote is not available, then the call can not be canceled by command
"hangup" without specifying the call-id.

Fixes: #1416

Not solved: `dial_handler()` returns the call-id. This gives only a useful result if no media-nat is configured.

A solution would mean to generate the call-id in baresip core, pass it to libre as optional call-id where it is used in sip_dialog. `sip_dialog_alloc()` will generate a random call-id if is not given as parameter (like it does now). --> This needs a change in the libre API function `sip_dialog_alloc()` and `sipsess_connect()`.