### PR TITLE
AMR Bandwidth Efficient mode support

### DIFF
--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -204,7 +204,7 @@ static int decode_update(struct audec_state **adsp,
 
 static void pack_be(uint8_t *buf, size_t len)
 {
-	/* basic bandwidth effiecient pack and unpack. see
+	/* basic bandwidth efficient pack and unpack. see
 	https://github.com/traud/asterisk-amr/blob/master/codecs/codec_amr.c */
 
 	const int another = ((buf[1] >> 7) & 0x01);

--- a/modules/amr/amr.h
+++ b/modules/amr/amr.h
@@ -4,6 +4,12 @@
  * Copyright (C) 2010 - 2015 Alfred E. Heggestad
  */
 
+struct amr_aucodec {
+	struct aucodec ac;
+	bool aligned;
+};
+
 bool amr_octet_align(const char *fmtp);
 int  amr_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 		  bool offer, void *arg);
+bool amr_fmtp_cmp(const char *lfmtp, const char *rfmtp, void *arg);

--- a/modules/amr/amr.h
+++ b/modules/amr/amr.h
@@ -12,4 +12,3 @@ struct amr_aucodec {
 bool amr_octet_align(const char *fmtp);
 int  amr_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 		  bool offer, void *arg);
-bool amr_fmtp_cmp(const char *lfmtp, const char *rfmtp, void *arg);

--- a/modules/amr/amr.h
+++ b/modules/amr/amr.h
@@ -7,6 +7,7 @@
 struct amr_aucodec {
 	struct aucodec ac;
 	bool aligned;
+	uint8_t *be_dec_arr;
 };
 
 bool amr_octet_align(const char *fmtp);

--- a/modules/amr/amr.h
+++ b/modules/amr/amr.h
@@ -4,7 +4,6 @@
  * Copyright (C) 2010 - 2015 Alfred E. Heggestad
  */
 
-
+bool amr_octet_align(const char *fmtp);
 int  amr_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 		  bool offer, void *arg);
-bool amr_fmtp_cmp(const char *lfmtp, const char *rfmtp, void *arg);

--- a/modules/amr/sdp.c
+++ b/modules/amr/sdp.c
@@ -9,7 +9,7 @@
 #include "amr.h"
 
 
-static bool amr_octet_align(const char *fmtp)
+bool amr_octet_align(const char *fmtp)
 {
 	struct pl pl, oa;
 
@@ -34,23 +34,9 @@ int amr_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 	if (!mb || !fmt || !ac)
 		return 0;
 
-	return mbuf_printf(mb, "a=fmtp:%s octet-align=1\r\n",
+	return 0;
+
+	/* return mbuf_printf(mb, "a=fmtp:%s octet-align=0\r\n",
 			   fmt->id);
-}
-
-
-bool amr_fmtp_cmp(const char *lfmtp, const char *rfmtp, void *arg)
-{
-	const struct aucodec *ac = arg;
-	(void)lfmtp;
-
-	if (!ac)
-		return false;
-
-	if (!amr_octet_align(rfmtp)) {
-		info("amr: octet-align mode is required\n");
-		return false;
-	}
-
-	return true;
+	*/
 }

--- a/modules/amr/sdp.c
+++ b/modules/amr/sdp.c
@@ -28,15 +28,16 @@ bool amr_octet_align(const char *fmtp)
 int amr_fmtp_enc(struct mbuf *mb, const struct sdp_format *fmt,
 		 bool offer, void *arg)
 {
-	const struct aucodec *ac = arg;
+	const struct amr_aucodec *amr_ac = arg;
 	(void)offer;
 
-	if (!mb || !fmt || !ac)
+	if (!mb || !fmt || !amr_ac)
 		return 0;
 
-	return 0;
-
-	/* return mbuf_printf(mb, "a=fmtp:%s octet-align=0\r\n",
+	if (amr_ac->aligned) {
+		return mbuf_printf(mb, "a=fmtp:%s octet-align=1\r\n",
 			   fmt->id);
-	*/
+	}
+
+	return 0;
 }


### PR DESCRIPTION
Basic support for AMR Bandwidth Efficient mode. Original code hade support for 'octet aligned' mode only; with this code added both modes are supported. This code changes the default proposed mode from Baresip from octet aligned to bandwidth efficient.

Interop testing is OK with:
1. MicroSIP client (which seems to run only octet-aligned') 
2. PSTN carrier supporting both modes with bandwidth efficient being default
3. Mitel hardware SIP phone
4. MX-ONE PBX