### PR TITLE
menu: in command dialdir call uag_find_requri() with uri

### DIFF
--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -595,7 +595,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 		goto out;
 
 	if (!ua)
-		ua = uag_find_requri(carg->prm);
+		ua = uag_find_requri(uri);
 
 	if (!ua) {
 		(void)re_hprintf(pf, "could not find UA for %s\n", carg->prm);


### PR DESCRIPTION
Instead of
```
 ua = uag_find_requri("sip:alice@sipproxy.org audio=sendrecv video=sendrecv")
```
it should be:
```
 ua = uag_find_requri("sip:alice@sipproxy.org")
```
