### PR TITLE
Work on Intercom module

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -222,6 +222,7 @@ bool          call_is_outgoing(const struct call *call);
 void          call_enable_rtp_timeout(struct call *call, uint32_t timeout_ms);
 uint32_t      call_linenum(const struct call *call);
 int32_t       call_answer_delay(const struct call *call);
+void          call_set_answer_delay(struct call *call, int32_t adelay);
 struct call  *call_find_linenum(const struct list *calls, uint32_t linenum);
 struct call  *call_find_id(const struct list *calls, const char *id);
 void call_set_current(struct list *calls, struct call *call);

--- a/src/call.c
+++ b/src/call.c
@@ -2430,6 +2430,24 @@ int32_t call_answer_delay(const struct call *call)
 
 
 /**
+ * Set/override the answer delay of call
+ *
+ * @param call    Call object
+ * @param adelay  Answer delay in ms. A value of -1 means auto answer is
+ *                disabled
+ *
+ * @return answer delay in ms
+ */
+void call_set_answer_delay(struct call *call, int32_t adelay)
+{
+	if (!call)
+		return;
+
+	call->adelay = adelay;
+}
+
+
+/**
  * Find the call with a given line number
  *
  * @param calls   List of calls


### PR DESCRIPTION
call: add a setter function for answer delay

Can be used to override the SIP auto answer delay from an external application/module. E.g. Set it back to -1, which suppresses the auto answer.

The baresip-apps PR https://github.com/baresip/baresip-apps/pull/2 introduces an intercom module with privacy mode. If privacy is on, the SIP auto answer is suppressed.

TODO: override ringtones for module menu, or prevent menu from ringing for intercom calls