### PR TITLE
Working on intercom (ringtone override)

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -411,6 +411,19 @@ static void start_sip_autoanswer(struct call *call)
 }
 
 
+static bool ovaufile_del(struct le *le, void *arg)
+{
+	struct odict_entry *oe = le->data;
+	struct call *call = arg;
+	const char *id = call_id(call);
+
+	if (!strncmp(oe->key, id, str_len(id)))
+		mem_deref(oe);
+
+	return false;
+}
+
+
 static void process_module_event(struct call *call, const char *prm)
 {
 	int err;
@@ -558,6 +571,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			play_resume();
 		}
 
+		hash_apply(menu.ovaufile->ht, ovaufile_del, call);
 		break;
 
 	case UA_EVENT_CALL_REMOTE_SDP:

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -28,6 +28,7 @@ struct menu{
 	bool clean_number;            /**< Remove -/() from diald numbers */
 	char redial_aor[128];
 	int32_t adelay;               /**< Outgoing auto answer delay     */
+	struct odict *ovaufile;       /**< Override aufile dictionary     */
 };
 
 /*Get menu object*/


### PR DESCRIPTION
Allow other modules loaded before menu to override played ring-, ringback and other signal tones.

E.g. module intercom in baresip-apps is able to replace the aufile configuration keys of menu by its own configuration keys
in order to specify separate audio files.

The overrides are call related and can be set via module events.

Example: https://github.com/baresip/baresip-apps/tree/main/modules/intercom