### PR TITLE
audio: add pre filter (baresip_au_pre_filtl)

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1530,6 +1530,7 @@ struct list   *baresip_mencl(void);
 struct list   *baresip_aucodecl(void);
 struct list   *baresip_ausrcl(void);
 struct list   *baresip_auplayl(void);
+struct list   *baresip_au_pre_filtl(void);
 struct list   *baresip_aufiltl(void);
 struct list   *baresip_vidcodecl(void);
 struct list   *baresip_vidsrcl(void);

--- a/src/audio.c
+++ b/src/audio.c
@@ -298,6 +298,7 @@ static void stop_tx(struct autx *tx, struct audio *a)
 	tx->ausrc = mem_deref(tx->ausrc);
 	tx->aubuf = mem_deref(tx->aubuf);
 
+	list_flush(&tx->pre_filtl);
 	list_flush(&tx->filtl);
 }
 
@@ -322,6 +323,7 @@ static void stop_rx(struct aurx *rx)
 
 	rx->auplay = mem_deref(rx->auplay);
 	rx->aubuf  = mem_deref(rx->aubuf);
+	list_flush(&rx->pre_filtl);
 	list_flush(&rx->filtl);
 }
 
@@ -353,6 +355,9 @@ static void audio_destructor(void *arg)
 	pthread_mutex_destroy(&a->rx.thr.mutex);
 	pthread_cond_destroy(&a->rx.thr.cond);
 #endif
+
+	list_flush(&a->tx.pre_filtl);
+	list_flush(&a->rx.pre_filtl);
 
 	list_flush(&a->tx.filtl);
 	list_flush(&a->rx.filtl);

--- a/src/audio.c
+++ b/src/audio.c
@@ -1572,15 +1572,24 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl, bool pre)
 		if (!list_isempty(&tx->pre_filtl) ||
 		    !list_isempty(&rx->pre_filtl))
 			return 0;
+
+		encprm.srate = a->cfg.srate_src;
+		encprm.ch = a->cfg.channels_src;
+		encprm.fmt = a->cfg.src_fmt;
+
+		decprm.srate = a->cfg.srate_play;
+		decprm.ch = a->cfg.channels_play;
+		decprm.fmt = a->cfg.play_fmt;
 	}
 	else {
 		if (!list_isempty(&tx->filtl) ||
 		    !list_isempty(&rx->filtl))
 			return 0;
+
+		aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
+		aufilt_param_set(&decprm, rx->ac, rx->dec_fmt);
 	}
 
-	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&decprm, rx->ac, rx->dec_fmt);
 
 	/* Audio filters */
 	for (le = list_head(aufiltl); le; le = le->next) {

--- a/src/baresip.c
+++ b/src/baresip.c
@@ -24,6 +24,7 @@ static struct baresip {
 	struct list ausrcl;
 	struct list auplayl;
 	struct list aufiltl;
+	struct list au_pre_filtl;
 	struct list vidcodecl;
 	struct list vidsrcl;
 	struct list vidispl;
@@ -267,6 +268,17 @@ struct list *baresip_ausrcl(void)
 struct list *baresip_auplayl(void)
 {
 	return &baresip.auplayl;
+}
+
+
+/**
+ * Get the list of Audio Pre-Filters
+ *
+ * @return List of audio-pre-filters
+ */
+struct list *baresip_au_pre_filtl(void)
+{
+	return &baresip.au_pre_filtl;
 }
 
 


### PR DESCRIPTION
Needed for #1411

 Processing encoder pipeline:
```
 .   .-------.  .--------.  .-------.  .--------.  .--------.  .--------.
 |   |       |  |        |  |       |  |        |  |        |  |        |
 |O->| ausrc |->|pre_filt|->| aubuf |->| resamp |->| aufilt |->| encode |->RTP
 |   |       |  |        |  |       |  |        |  |        |  |        |
 '   '-------'  '--------'  '-------'  '--------'  '--------'  '--------'
```


Processing decoder pipeline:
```
     .--------.  .--------.  .-------.  .--------.  .--------.  .--------.
|\   |        |  |        |  |       |  |        |  |        |  |        |
| |<-| auplay |<-|pre_filt|<-| aubuf |<-| resamp |<-| aufilt |<-| decode |<-RTP
|/   |        |  |        |  |       |  |        |  |        |  |        |
     '--------'  '--------'  '-------'  '--------'  '--------'  '--------'
```