### PR TITLE
ua selection checks for UDP transport

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -194,6 +194,7 @@ int  reg_debug(struct re_printf *pf, const struct reg *reg);
 int  reg_json_api(struct odict *od, const struct reg *reg);
 int  reg_status(struct re_printf *pf, const struct reg *reg);
 int  reg_af(const struct reg *reg);
+struct sipreg *reg_sipreg(const struct reg *reg);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -351,6 +351,7 @@ struct call *ua_find_active_call(struct ua *ua);
 void ua_handle_options(struct ua *ua, const struct sip_msg *msg);
 void sipsess_conn_handler(const struct sip_msg *msg, void *arg);
 bool ua_catchall(struct ua *ua);
+struct ua *ua_p2p_check(struct ua *ua, const struct sip_msg *msg);
 
 /*
  * User-Agent Group

--- a/src/reg.c
+++ b/src/reg.c
@@ -365,3 +365,16 @@ int reg_af(const struct reg *reg)
 
 	return reg->af;
 }
+
+
+/**
+ * Get the SIP register client of the register client
+ *
+ * @param reg register client object
+ *
+ * @return sip register client object
+ */
+struct sipreg *reg_sipreg(const struct reg *reg)
+{
+	return reg ? reg->sipreg : NULL;
+}

--- a/src/uag.c
+++ b/src/uag.c
@@ -832,7 +832,7 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 
 		if (0 == pl_strcasecmp(cuser, ua_local_cuser(ua))) {
 			ua_printf(ua, "selected for %r\n", cuser);
-			return ua;
+			return ua_p2p_check(ua, msg);
 		}
 	}
 
@@ -858,7 +858,7 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 
 		if (0 == pl_casecmp(cuser, &acc->luri.user)) {
 			ua_printf(ua, "account match for %r\n", cuser);
-			return ua;
+			return ua_p2p_check(ua, msg);
 		}
 	}
 
@@ -868,14 +868,14 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 
 		if (ua_catchall(ua)) {
 			ua_printf(ua, "use catch-all account for %r\n", cuser);
-			return ua;
+			return ua_p2p_check(ua, msg);
 		}
 	}
 
 	if (uaf)
 		ua_printf(uaf, "selected\n");
 
-	return uaf;
+	return ua_p2p_check(uaf, msg);
 }
 
 


### PR DESCRIPTION
Depends on [re/#102](https://github.com/baresip/re/pull/102)
Followup to #1429

We do not allow peer-to-peer connections via UDP for registered UAs neither for registrar-less accounts which does have authentication properties configured.

For any other transport protocol nothing changes.