### PR TITLE
call answer media dir

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -273,6 +273,10 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 
 	adir = decode_sdp_enum(&argdir[0]);
 	vdir = decode_sdp_enum(&argdir[1]);
+	if (adir == SDP_INACTIVE && vdir == SDP_INACTIVE) {
+		(void) re_hprintf(pf, "%s", usage);
+		return EINVAL;
+	}
 
 	(void)pl_strdup(&cid, &callid);
 	if (str_isset(cid))

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -582,7 +582,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 		err = re_regex(carg->prm, str_len(carg->prm),
 			"[^ ]* [^ ]*",&pluri, &argdir[0]);
 
-	if (err) {
+	if (err || !re_regex(argdir[0].p, argdir[0].l, "=")) {
 		(void)re_hprintf(pf, "%s", usage);
 		return EINVAL;
 	}

--- a/src/stream.c
+++ b/src/stream.c
@@ -140,7 +140,8 @@ static void check_rtp_handler(void *arg)
 		}
 	}
 	else {
-		re_printf("check_rtp: not checking (dir=%s)\n",
+		debug("check_rtp: not checking \"%s\" RTP (dir=%s)\n",
+			  sdp_media_name(strm->sdp),
 			  sdp_dir_name(sdp_media_dir(strm->sdp)));
 	}
 }


### PR DESCRIPTION
- In combination with re PR https://github.com/baresip/re/pull/103 fixes audio only calls. There was an RTP timeout for the video stream.
- Fixes also one-directional `acceptdir` for incoming early-video calls.