### PR TITLE
Account auto answer beep

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -13,6 +13,7 @@
 #    ;audio_source=alsa,default
 #    ;audio_player=alsa,default
 #    ;sip_autoanswer={yes, no}
+#    ;sip_autoanswer_beep={off, on, local}
 #    ;dtmfmode={rtpevent, info}
 #    ;auth_user=username
 #    ;auth_pass=password

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -246,7 +246,6 @@ video_selfview		window # {window,pip}
 #ringback_disabled	no
 #statmode_default	off
 #menu_clean_number	no
-#sip_autoanswer_beep	yes
 #sip_autoanswer_method	rfc5373 # {rfc5373,call-info,alert-info}
 #ring_aufile		ring.wav
 #callwaiting_aufile	callwaiting.wav

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -129,6 +129,7 @@ const char *account_extra(const struct account *acc);
 int account_uri_complete(const struct account *acc, struct mbuf *buf,
 			 const char *uri);
 bool account_sip_autoanswer(const struct account *acc);
+void account_set_sip_autoanswer(struct account *acc, bool allow);
 enum sipansbeep account_sipansbeep(const struct account *acc);
 void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -63,6 +63,13 @@ enum dtmfmode {
 	DTMFMODE_SIP_INFO
 };
 
+/** SIP auto answer beep modes */
+enum sipansbeep {
+	SIPANSBEEP_OFF,
+	SIPANSBEEP_ON,
+	SIPANSBEEP_LOCAL,
+};
+
 struct account;
 
 int account_alloc(struct account **accp, const char *sipaddr);
@@ -122,6 +129,8 @@ const char *account_extra(const struct account *acc);
 int account_uri_complete(const struct account *acc, struct mbuf *buf,
 			 const char *uri);
 bool account_sip_autoanswer(const struct account *acc);
+enum sipansbeep account_sipansbeep(const struct account *acc);
+void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
 
 
 /*

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -56,6 +56,7 @@ static int account_write_template(const char *file)
 			 "#    ;audio_source=alsa,default\n"
 			 "#    ;audio_player=alsa,default\n"
 			 "#    ;sip_autoanswer={yes, no}\n"
+			 "#    ;sip_autoanswer_beep={off, on, local}\n"
 			 "#    ;dtmfmode={rtpevent, info}\n"
 			 "#    ;auth_user=username\n"
 			 "#    ;auth_pass=password\n"

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -388,6 +388,7 @@ static void auans_play_finished(struct play *play, void *arg)
 
 static void start_sip_autoanswer(struct call *call)
 {
+	struct account *acc = call_account(call);
 	int32_t adelay = call_answer_delay(call);
 	bool beep = true;
 
@@ -395,6 +396,7 @@ static void start_sip_autoanswer(struct call *call)
 		return;
 
 	conf_get_bool(conf_cur(), "sip_autoanswer_beep", &beep);
+	beep = account_sipansbeep(acc) != SIPANSBEEP_OFF;
 	if (beep) {
 		beep = menu_play(call,
 				 "sip_autoanswer_aufile", "autoanswer.wav", 1);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -395,7 +395,6 @@ static void start_sip_autoanswer(struct call *call)
 	if (adelay == -1)
 		return;
 
-	conf_get_bool(conf_cur(), "sip_autoanswer_beep", &beep);
 	beep = account_sipansbeep(acc) != SIPANSBEEP_OFF;
 	if (beep) {
 		beep = menu_play(call,

--- a/src/account.c
+++ b/src/account.c
@@ -1434,6 +1434,15 @@ bool account_sip_autoanswer(const struct account *acc)
 }
 
 
+void account_set_sip_autoanswer(struct account *acc, bool allow)
+{
+	if (!acc)
+		return;
+
+	acc->sipans = allow;
+}
+
+
 /**
  * Returns the beep mode for a SIP auto answer call
  *

--- a/src/account.c
+++ b/src/account.c
@@ -246,13 +246,25 @@ static void answermode_decode(struct account *prm, const struct pl *pl)
 }
 
 
-static void autoanswer_allow_decode(struct account *prm, const struct pl *pl)
+static void autoanswer_decode(struct account *prm, const struct pl *pl)
 {
 	struct pl v;
 
 	if (0 == msg_param_decode(pl, "sip_autoanswer", &v)) {
 		if (0 == pl_strcasecmp(&v, "yes")) {
 			prm->sipans = true;
+		}
+	}
+
+	if (0 == msg_param_decode(pl, "sip_autoanswer_beep", &v)) {
+		if (0 == pl_strcasecmp(&v, "on")) {
+			prm->sipansbeep = SIPANSBEEP_ON;
+		}
+		else if (0 == pl_strcasecmp(&v, "off")) {
+			prm->sipansbeep = SIPANSBEEP_OFF;
+		}
+		else if (0 == pl_strcasecmp(&v, "local")) {
+			prm->sipansbeep = SIPANSBEEP_LOCAL;
 		}
 	}
 }
@@ -490,6 +502,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 		return ENOMEM;
 
 	acc->maf = AF_UNSPEC;
+	acc->sipansbeep = SIPANSBEEP_ON;
 	err = str_dup(&acc->buf, sipaddr);
 	if (err)
 		goto out;
@@ -512,7 +525,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	acc->ptime = 20;
 	err |= sip_params_decode(acc, &acc->laddr);
 	       answermode_decode(acc, &acc->laddr.params);
-	       autoanswer_allow_decode(acc, &acc->laddr.params);
+	       autoanswer_decode(acc, &acc->laddr.params);
 	       dtmfmode_decode(acc,&acc->laddr.params);
 	err |= audio_codecs_decode(acc, &acc->laddr.params);
 	err |= video_codecs_decode(acc, &acc->laddr.params);
@@ -1421,6 +1434,36 @@ bool account_sip_autoanswer(const struct account *acc)
 }
 
 
+/**
+ * Returns the beep mode for a SIP auto answer call
+ *
+ * - SIPANSBEEP_ON    ... The beep is played before the call is answered
+ *                         automatically. The locally configured audio file can
+ *                         be overwritten with the Alert-Info header URL.
+ *                         This is the default value.
+ *
+ * - SIPANSBEEP_OFF   ... No beep is played.
+ *
+ * - SIPANSBEEP_LOCAL ... The local configured beep tone is played.
+ *
+ * @param acc User-Agent account
+ * @return Beep mode
+ */
+enum sipansbeep account_sipansbeep(const struct account *acc)
+{
+	return acc ? acc->sipansbeep : SIPANSBEEP_ON;
+}
+
+
+void account_set_sipansbeep(struct account *acc, enum sipansbeep beep)
+{
+	if (!acc)
+		return;
+
+	acc->sipansbeep = beep;
+}
+
+
 static const char *answermode_str(enum answermode mode)
 {
 	switch (mode) {
@@ -1441,6 +1484,18 @@ static const char *dtmfmode_str(enum dtmfmode mode)
 
 	case DTMFMODE_RTP_EVENT: return "rtpevent";
 	case DTMFMODE_SIP_INFO:  return "info";
+	default: return "???";
+	}
+}
+
+
+static const char *sipansbeep_str(enum sipansbeep beep)
+{
+	switch (beep) {
+
+	case SIPANSBEEP_OFF:   return "off";
+	case SIPANSBEEP_ON:    return "on";
+	case SIPANSBEEP_LOCAL: return "local";
 	default: return "???";
 	}
 }
@@ -1645,6 +1700,8 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 			  answermode_str(acc->answermode));
 	err |= re_hprintf(pf, " sipans:       %s\n",
 			  acc->sipans ? "yes" : "no");
+	err |= re_hprintf(pf, " sipansbeep:  %s\n",
+			  sipansbeep_str(acc->sipansbeep));
 	err |= re_hprintf(pf, " dtmfmode:     %s\n",
 			  dtmfmode_str(acc->dtmfmode));
 	if (!list_isempty(&acc->aucodecl)) {

--- a/src/config.c
+++ b/src/config.c
@@ -1057,7 +1057,6 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#ringback_disabled\tno\n"
 			"#statmode_default\toff\n"
 			"#menu_clean_number\tno\n"
-			"#sip_autoanswer_beep\tyes\n"
 			"#sip_autoanswer_method\trfc5373 "
 			"# {rfc5373,call-info,alert-info}\n"
 			"#ring_aufile\t\tring.wav\n"

--- a/src/core.h
+++ b/src/core.h
@@ -43,6 +43,7 @@ struct account {
 
 	/* parameters: */
 	bool sipans;                 /**< Allow SIP header auto answer mode  */
+	enum sipansbeep sipansbeep;  /**< Beep mode for SIP auto answer      */
 	enum answermode answermode;  /**< Answermode for incoming calls      */
 	uint32_t adelay;             /**< Delay for delayed auto answer [ms] */
 	enum dtmfmode dtmfmode;      /**< Send type for DTMF tones           */


### PR DESCRIPTION
The flag `sip_autoanswer_beep` is moved from config to account because there might be SIP servers that stream the beep tone at the beginning of an intercom call. For peer-to-peer intercom calls the beep tone should be played locally.

Instead of a bool we use an enum. Reason:

**Following PR** will support also Beep tone specified in the Alert-Info headers URI.
```
Alert-Info: <file:///usr/local/share/baresip/autoanswer.wav>;info=alert-autoanswer;delay=0
```
Thus the enum has the values:
- SIPANSBEEP_ON    ... The beep is played before the call is answered automatically. The locally configured audio file can
                         be overwritten with the Alert-Info header URL. This is the default value.

- SIPANSBEEP_OFF   ... No beep is played.

- SIPANSBEEP_LOCAL ... The local configured beep tone is played.

