### PR TITLE
stream: check if media is present before enabling the RTP timeout

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -885,6 +885,9 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
 	if (!strm)
 		return;
 
+	if (!sdp_media_has_media(stream_sdpmedia(strm)))
+		return;
+
 	strm->rtp_timeout_ms = timeout_ms;
 
 	tmr_cancel(&strm->tmr_rtp);


### PR DESCRIPTION
Fixes the unwanted call termination by the  `check_rtp_handler` for an audio-only call in an audio+video setup.