### PR TITLE
auto answer beep per alert info URI

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -854,6 +854,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   bool use_rtp);
 struct call *ua_find_call_state(const struct ua *ua, enum call_state st);
 int ua_raise(struct ua *ua);
+int ua_set_autoanswer_value(struct ua *ua, const char *value);
 
 
 /* One instance */

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -227,6 +227,7 @@ const char   *call_id(const struct call *call);
 const char   *call_peeruri(const struct call *call);
 const char   *call_peername(const struct call *call);
 const char   *call_localuri(const struct call *call);
+const char   *call_alerturi(const struct call *call);
 struct audio *call_audio(const struct call *call);
 struct video *call_video(const struct call *call);
 struct list  *call_streaml(const struct call *call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -952,6 +952,7 @@ static int module_close(void)
 	menu.dialbuf = mem_deref(menu.dialbuf);
 	menu.callid = mem_deref(menu.callid);
 	menu.ovaufile = mem_deref(menu.ovaufile);
+	menu.ansval = mem_deref(menu.ansval);
 	menu_stop_play();
 
 	tmr_cancel(&menu.tmr_redial);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -204,20 +204,22 @@ static bool menu_play(const struct call *call,
 	char *file = NULL;
 	int err;
 
-	err = menu_ovkey_str(&ovkey, call, ckey);
-	if (!err) {
-		ovaukey = odict_string(menu.ovaufile, ovkey);
-		mem_deref(ovkey);
+	if (ckey) {
+		err = menu_ovkey_str(&ovkey, call, ckey);
+		if (!err) {
+			ovaukey = odict_string(menu.ovaufile, ovkey);
+			mem_deref(ovkey);
+		}
+
+		if (ovaukey && !strcmp(ovaukey, "none"))
+			return false;
+
+		if (ovaukey)
+			(void)conf_get(conf_cur(), ovaukey, &pl);
+
+		if (!pl_isset(&pl))
+			(void)conf_get(conf_cur(), ckey, &pl);
 	}
-
-	if (ovaukey && !strcmp(ovaukey, "none"))
-		return false;
-
-	if (ovaukey)
-		(void)conf_get(conf_cur(), ovaukey, &pl);
-
-	if (!pl_isset(&pl))
-		(void)conf_get(conf_cur(), ckey, &pl);
 
 	if (!pl_isset(&pl))
 		pl_set_str(&pl, fname);
@@ -227,11 +229,12 @@ static bool menu_play(const struct call *call,
 
 	pl_strdup(&file, &pl);
 	menu_stop_play();
-	(void)play_file(&menu.play, player, file, repeat,
+	err = play_file(&menu.play, player, file, repeat,
 			cfg->audio.alert_mod,
 			cfg->audio.alert_dev);
 	mem_deref(file);
-	return true;
+
+	return err == 0;
 }
 
 
@@ -386,19 +389,40 @@ static void auans_play_finished(struct play *play, void *arg)
 }
 
 
+static bool alert_uri_supported(const char *uri)
+{
+	if (!re_regex(uri, strlen(uri), "https://"))
+		return true;
+
+	if (!re_regex(uri, strlen(uri), "http://"))
+		return true;
+
+	if (!re_regex(uri, strlen(uri), "file://") && fs_isfile(uri + 7))
+		return true;
+
+	return false;
+}
+
+
 static void start_sip_autoanswer(struct call *call)
 {
 	struct account *acc = call_account(call);
 	int32_t adelay = call_answer_delay(call);
-	bool beep = true;
+	const char *aluri = call_alerturi(call);
+	enum sipansbeep bmet = account_sipansbeep(acc);
+	bool beep = false;
 
 	if (adelay == -1)
 		return;
 
-	beep = account_sipansbeep(acc) != SIPANSBEEP_OFF;
-	if (beep) {
-		beep = menu_play(call,
-				 "sip_autoanswer_aufile", "autoanswer.wav", 1);
+	if (bmet) {
+		if (bmet != SIPANSBEEP_LOCAL && aluri &&
+				alert_uri_supported(aluri))
+			beep = menu_play(call, NULL, aluri, 1);
+
+		if (!beep)
+			beep = menu_play(call, "sip_autoanswer_aufile",
+					 "autoanswer.wav", 1);
 	}
 
 	if (beep) {

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -28,6 +28,7 @@ struct menu{
 	bool clean_number;            /**< Remove -/() from diald numbers */
 	char redial_aor[128];
 	int32_t adelay;               /**< Outgoing auto answer delay     */
+	char *ansval;                 /**< Call-Info/Alert-Info value     */
 	struct odict *ovaufile;       /**< Override aufile dictionary     */
 };
 

--- a/src/play.c
+++ b/src/play.c
@@ -527,10 +527,15 @@ int play_file(struct play **playp, struct player *player,
 	str_ncpy(file, filename, sizeof(file));
 	parse_play_settings(file, &repeat, &delay);
 
-	if (re_snprintf(path, sizeof(path), "%s/%s",
+	/* absolute path? */
+	if (file[0] == '/') {
+		if (re_snprintf(path, sizeof(path), "%s",
+				file) < 0)
+			return ENOMEM;
+	}
+	else if (re_snprintf(path, sizeof(path), "%s/%s",
 			player->play_path, file) < 0)
 		return ENOMEM;
-
 
 	if (!conf_get_str(conf_cur(), "file_ausrc", srcn, sizeof(srcn))) {
 		ausrc = ausrc_find(baresip_ausrcl(), srcn);

--- a/src/play.c
+++ b/src/play.c
@@ -572,7 +572,7 @@ int play_file(struct play **playp, struct player *player,
 	if (err) {
 		mem_deref(play);
 	}
-	else if (playp) {
+	else if (play && playp) {
 		play->playp = playp;
 		*playp = play;
 	}

--- a/src/play.c
+++ b/src/play.c
@@ -528,7 +528,10 @@ int play_file(struct play **playp, struct player *player,
 	parse_play_settings(file, &repeat, &delay);
 
 	/* absolute path? */
-	if (file[0] == '/') {
+	if (file[0] == '/' ||
+	    !re_regex(file, strlen(file), "https://") ||
+	    !re_regex(file, strlen(file), "http://") ||
+	    !re_regex(file, strlen(file), "file://")) {
 		if (re_snprintf(path, sizeof(path), "%s",
 				file) < 0)
 			return ENOMEM;

--- a/src/ua.c
+++ b/src/ua.c
@@ -29,6 +29,7 @@ struct ua {
 	bool catchall;               /**< Catch all inbound requests         */
 	struct list hdr_filter;      /**< Filter for incoming headers        */
 	struct list custom_hdrs;     /**< List of outgoing headers           */
+	char *ansval;                /**< SIP auto answer value              */
 };
 
 struct ua_xhdr_filter {
@@ -50,6 +51,7 @@ static void ua_destructor(void *arg)
 	list_flush(&ua->regl);
 	mem_deref(ua->cuser);
 	mem_deref(ua->pub_gruu);
+	mem_deref(ua->ansval);
 	mem_deref(ua->acc);
 
 	if (uag_delayed_close() && list_isempty(uag_list())) {
@@ -1732,7 +1734,7 @@ int  ua_enable_autoanswer(struct ua *ua, int32_t adelay,
 	struct pl n;
 	struct pl v;
 	struct mbuf *mb = NULL;
-	struct pl url = PL("<>");
+	struct pl val = PL("<>");
 	int err = 0;
 	const char *name;
 
@@ -1745,17 +1747,20 @@ int  ua_enable_autoanswer(struct ua *ua, int32_t adelay,
 			return ENOMEM;
 	}
 
+	if (ua->ansval)
+		pl_set_str(&val, ua->ansval);
+
 	switch (met) {
 
 	case ANSM_RFC5373:
 		err = mbuf_printf(mb, "Auto");
 		break;
 	case ANSM_CALLINFO:
-		err = mbuf_printf(mb, "%r;answer-after=%d", &url, adelay);
+		err = mbuf_printf(mb, "%r;answer-after=%d", &val, adelay);
 		break;
 	case ANSM_ALERTINFO:
 		err = mbuf_printf(mb, "%r;info=alert-autoanswer;delay=%d",
-				&url, adelay);
+				&val, adelay);
 		break;
 	default:
 		err = EINVAL;
@@ -1805,4 +1810,17 @@ int ua_raise(struct ua *ua)
 		return EINVAL;
 
 	return uag_raise(ua, &ua->le);
+}
+
+
+int ua_set_autoanswer_value(struct ua *ua, const char *value)
+{
+	if (!ua)
+		return EINVAL;
+
+	ua->ansval = mem_deref(ua->ansval);
+	if (!value)
+		return 0;
+
+	return str_dup(&ua->ansval, value);
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -1732,7 +1732,7 @@ int  ua_enable_autoanswer(struct ua *ua, int32_t adelay,
 	struct pl n;
 	struct pl v;
 	struct mbuf *mb = NULL;
-	struct pl url = PL("<http://www.notused.com>");
+	struct pl url = PL("<>");
 	int err = 0;
 	const char *name;
 


### PR DESCRIPTION
Add support for overriding beep tone with Alert-Info URI. E.g.

```
Alert-Info: <file:///usr/local/share/baresip/autoanswer.wav>;info=alert-autoanswer;delay=0
```
```
Alert-Info: <https://github.com/baresip/baresip/raw/master/share/soundd.wav>;info=alert-autoanswer;delay=0
```
### Example
1. At callee side:
- accounts
```
"A" <sip:A@localhost>;regint=0;sip_autoanswer=yes
```
- config
```
module			gst.so

file_ausrc		gst
```

2. At caller side invoke:
```
/setadelay 0
/setansval <https://github.com/baresip/baresip/raw/master/share/soundd.wav>
/dial callee-IP
```