### PR TITLE
auframe: always set srate and ch

### DIFF
--- a/modules/aubridge/device.c
+++ b/modules/aubridge/device.c
@@ -109,12 +109,14 @@ static void *device_thread(void *arg)
 		}
 
 		if (dev->ausrc->rh) {
-			struct auframe af = {
-				.fmt   = dev->ausrc->prm.fmt,
-				.sampv = sampv_in,
-				.sampc = sampc_in,
-				.timestamp = ts * 1000
-			};
+			struct auframe af;
+
+			auframe_init(&af, dev->ausrc->prm.fmt, sampv_in,
+			             sampc_in, dev->auplay->prm.srate,
+			             dev->auplay->prm.ch);
+
+			af.timestamp = ts * 1000;
+
 			dev->ausrc->rh(&af, dev->ausrc->arg);
 		}
 

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -76,13 +76,11 @@ static void *play_thread(void *arg)
 		return NULL;
 
 	while (st->run) {
+		struct auframe af;
 
-		struct auframe af = {
-			.fmt   = AUFMT_S16LE,
-			.sampv = sampv,
-			.sampc = st->sampc,
-			.timestamp = ts * 1000
-		};
+		auframe_init(&af, AUFMT_S16LE, sampv, st->sampc,
+		             st->prm->srate, st->prm->ch);
+		af.timestamp = ts * 1000;
 
 		sys_msleep(ms);
 

--- a/modules/ausine/ausine.c
+++ b/modules/ausine/ausine.c
@@ -48,6 +48,7 @@ struct ausrc_st {
 	int freq;
 	double sec_offset;
 	enum channels ch;
+	struct ausrc_prm prm;
 };
 
 
@@ -81,14 +82,12 @@ static void *play_thread(void *arg)
 		return NULL;
 
 	while (st->run) {
-
-		struct auframe af = {
-			.fmt   = AUFMT_S16LE,
-			.sampv = sampv,
-			.sampc = st->sampc,
-			.timestamp = ts * 1000
-		};
+		struct auframe af;
 		size_t frame;
+
+		auframe_init(&af, AUFMT_S16LE, sampv, st->sampc, st->prm.srate,
+		             st->prm.ch);
+		af.timestamp = ts * 1000;
 
 		sys_msleep(4);
 
@@ -200,6 +199,7 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 	st->errh = errh;
 	st->arg  = arg;
 	st->sec_offset = 0.0;
+	st->prm = *prm;
 
 	st->freq = atoi(dev);
 

--- a/modules/gst/gst.c
+++ b/modules/gst/gst.c
@@ -149,11 +149,10 @@ static void format_check(struct ausrc_st *st, GstStructure *s)
 
 static void play_packet(struct ausrc_st *st)
 {
-	struct auframe af = {
-		.fmt   = AUFMT_S16LE,
-		.sampv = st->buf,
-		.sampc = st->sampc
-	};
+	struct auframe af;
+
+	auframe_init(&af, AUFMT_S16LE, st->buf, st->sampc, st->prm.srate,
+	             st->prm.ch);
 
 	/* timed read from audio-buffer */
 	if (st->prm.ptime && aubuf_get_samp(st->aubuf, st->prm.ptime, st->buf,

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -111,6 +111,8 @@ static int stream_recv_handler(const struct rtp_header *hdr, struct mbuf *mb)
 	size_t sampc = AUDIO_SAMPSZ;
 	bool marker = hdr->m;
 	void *sampv;
+	uint32_t srate;
+	uint8_t ch;
 	int err = 0;
 
 	if (!player)
@@ -140,8 +142,16 @@ static int stream_recv_handler(const struct rtp_header *hdr, struct mbuf *mb)
 		sampc = 0;
 	}
 
-	auframe_init(&af, player->dec_fmt, player->sampv, sampc,
-		     player->resamp.irate, player->resamp.ich);
+	if (player->resamp.resample) {
+		srate = player->resamp.irate;
+		ch = player->resamp.ich;
+	}
+	else {
+		srate = player->auplay_prm.srate;
+		ch = player->auplay_prm.ch;
+	}
+
+	auframe_init(&af, player->dec_fmt, player->sampv, sampc, srate, ch);
 
 	for (le = player->filterl.tail; le; le = le->prev) {
 		struct aufilt_dec_st *st = le->data;

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -176,6 +176,8 @@ static void poll_aubuf_tx(struct mcsource *src)
 	size_t sz;
 	size_t num_bytes;
 	struct le *le;
+	uint32_t srate;
+	uint8_t ch;
 	int err = 0;
 
 	sz = aufmt_sample_size(src->src_fmt);
@@ -224,8 +226,16 @@ static void poll_aubuf_tx(struct mcsource *src)
 		sampc = sampc_rs;
 	}
 
-	auframe_init(&af, src->enc_fmt, sampv, sampc, src->resamp.orate,
-		     src->resamp.och);
+	if (src->resamp.resample) {
+		srate = src->resamp.irate;
+		ch = src->resamp.ich;
+	}
+	else {
+		srate = src->ausrc_prm.srate;
+		ch = src->ausrc_prm.ch;
+	}
+
+	auframe_init(&af, src->enc_fmt, sampv, sampc, srate, ch);
 
 	/* process exactly one audio-frame in list order */
 	for (le = src->filtl.head; le; le = le->next) {

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -64,14 +64,13 @@ static void *read_thread(void *arg)
 	last_read = tmr_jiffies();
 
 	while (st->run) {
+		struct auframe af;
 
-		struct auframe af = {
-			.fmt   = st->fmt,
-			.sampv = st->sampv,
-			.sampc = st->sampc,
-			.timestamp = sampc * AUDIO_TIMEBASE
-			             / (st->prm.srate * st->prm.ch)
-		};
+		auframe_init(&af, st->fmt, st->sampv, st->sampc, st->prm.srate,
+		             st->prm.ch);
+
+		af.timestamp = sampc * AUDIO_TIMEBASE
+		               / (st->prm.srate * st->prm.ch);
 
 		ret = pa_simple_read(st->s, st->sampv, num_bytes, &pa_error);
 		if (ret < 0) {

--- a/modules/rst/audio.c
+++ b/modules/rst/audio.c
@@ -31,7 +31,7 @@ struct ausrc_st {
 	uint32_t ptime;
 	size_t sampc;
 	size_t sampsz;
-	enum aufmt fmt;
+	struct ausrc_prm prm;
 };
 
 
@@ -71,13 +71,11 @@ static void *play_thread(void *arg)
 		return NULL;
 
 	while (st->run) {
+		struct auframe af;
 
-		struct auframe af = {
-			.fmt   = st->fmt,
-			.sampv = sampv,
-			.sampc = st->sampc,
-			.timestamp = ts * 1000
-		};
+		auframe_init(&af, st->prm.fmt, sampv, st->sampc, st->prm.srate,
+		             st->prm.ch);
+		af.timestamp = ts * 1000;
 
 		sys_msleep(4);
 
@@ -226,7 +224,7 @@ static int alloc_handler(struct ausrc_st **stp, const struct ausrc *as,
 
 	st->sampc = prm->srate * prm->ch * st->ptime / 1000;
 	st->sampsz = aufmt_sample_size(prm->fmt);
-	st->fmt = prm->fmt;
+	st->prm = *prm;
 
 
 	info("rst: audio ptime=%u sampc=%zu aubuf=[%u:%u]\n",


### PR DESCRIPTION
https://github.com/baresip/baresip/commit/1ef3a96412667581ac35547c53394426a8a261c1 added `srate` and `ch` to `auframe`. However there are several cases where the values are not actually set. If I haven't missed anything, this should fix the remaining cases. 