### PR TITLE
account: fix IPv6 only URI for account_uri_complete()

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -1611,7 +1611,7 @@ int account_uri_complete(const struct account *acc, struct mbuf *buf,
 	bool uri_is_ip;
 	char *uridup;
 	char *host;
-	char *param;
+	char *c;
 	int err = 0;
 
 	if (!buf || !uri)
@@ -1644,13 +1644,18 @@ int account_uri_complete(const struct account *acc, struct mbuf *buf,
 	else
 		host = uridup;
 
-	param = strchr(host, ';');
-	if (param)
-		*param = 0;
+	c = strchr(host, ';');
+	if (c)
+		*c = 0;
 
 	uri_is_ip =
 		!sa_decode(&sa_addr, host, strlen(host)) ||
 		!sa_set_str(&sa_addr, host, 0);
+	if (!uri_is_ip && host[0] == '[' && (c = strchr(host, ']'))) {
+		*c = 0;
+		uri_is_ip = !sa_set_str(&sa_addr, host+1, 0);
+	}
+
 	mem_deref(uridup);
 
 	if (0 != re_regex(uri, len, "[^@]+@[^]+", NULL, NULL) &&

--- a/test/main.c
+++ b/test/main.c
@@ -20,6 +20,7 @@ struct test {
 
 static const struct test tests[] = {
 	TEST(test_account),
+	TEST(test_account_uri_complete),
 	TEST(test_aulevel),
 	TEST(test_call_answer),
 	TEST(test_call_answer_hangup_a),

--- a/test/test.h
+++ b/test/test.h
@@ -43,6 +43,16 @@
 		goto out;						\
 	}
 
+#define ASSERT_PLEQ(expected, actual)					\
+	if (0 != pl_cmp((expected), (actual))) {			\
+		warning("selftest: ASSERT_PLEQ: %s:%u:"			\
+			" expected = '%r', actual = '%r'\n",		\
+			__FILE__, __LINE__,				\
+			(expected), (actual));				\
+		err = EBADMSG;						\
+		goto out;						\
+	}
+
 #define TEST_ERR(err)							\
 	if ((err)) {							\
 		(void)re_fprintf(stderr, "\n");				\
@@ -50,6 +60,16 @@
 			      " (%m)\n",				\
 			      __FILE__, __LINE__,			\
 			      (err));					\
+		goto out;						\
+	}
+
+#define TEST_ERR_TXT(err,txt)						\
+	if ((err)) {							\
+		(void)re_fprintf(stderr, "\n");				\
+		warning("TEST_ERR: %s:%u: %s"				\
+			      " (%m)\n",				\
+			      __FILE__, __LINE__,			\
+			      (txt), (err));				\
 		goto out;						\
 	}
 
@@ -204,6 +224,7 @@ int mock_vidisp_register(struct vidisp **vidispp,
 /* test cases */
 
 int test_account(void);
+int test_account_uri_complete(void);
 int test_aulevel(void);
 int test_call_answer(void);
 int test_call_answer_hangup_a(void);


### PR DESCRIPTION
```
/dial [IPv6]
```
lead to wrong append of the account host
```
sip:[IPv6]@account-host
```