### PR TITLE
IPv6 link local support

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -689,6 +689,7 @@ const char *menc_event_name(enum menc_event event);
 struct network;
 
 typedef void (net_change_h)(void *arg);
+typedef int (net_laddr_h)(const struct sa *sa);
 
 int  net_alloc(struct network **netp, const struct config_net *cfg);
 int  net_use_nameserver(struct network *net,
@@ -704,6 +705,8 @@ void net_dns_refresh(struct network *net);
 int  net_dns_debug(struct re_printf *pf, const struct network *net);
 int  net_debug(struct re_printf *pf, const struct network *net);
 const struct sa *net_laddr_af(const struct network *net, int af);
+int net_laddr_apply(const struct network *net, net_laddr_h *laddrh);
+bool net_is_laddr(const struct network *net, struct sa *sa);
 struct dnsc     *net_dnsc(const struct network *net);
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -334,6 +334,7 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 bool stream_is_ready(const struct stream *strm);
 int  stream_decode(struct stream *s);
 void stream_silence_on(struct stream *s, bool on);
+const struct sa *stream_raddr(const struct stream *s);
 
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -35,12 +35,19 @@ static void signal_handler(int sig)
 }
 
 
+static int laddr_print(const struct sa *sa)
+{
+	info("  %j\n", sa);
+	return 0;
+}
+
+
 static void net_change_handler(void *arg)
 {
 	(void)arg;
 
-	info("IP-address changed: %j\n",
-	     net_laddr_af(baresip_network(), AF_INET));
+	info("Local network addresses changed:\n");
+	net_laddr_apply(baresip_network(), laddr_print);
 
 	(void)uag_reset_transp(true, true);
 }

--- a/src/net.c
+++ b/src/net.c
@@ -313,6 +313,7 @@ bool net_check(struct network *net)
 	if (!net)
 		return false;
 
+	list_init(&net->laddrs_tmp);
 	if (str_isset(cfg->ifname) && 0 == sa_set_str(&sa, cfg->ifname, 0)) {
 
 		info("Binding to IP address '%j'\n", &sa);
@@ -330,6 +331,7 @@ bool net_check(struct network *net)
 		return true;
 	}
 
+	list_flush(&net->laddrs_tmp);
 	return false;
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1211,3 +1211,12 @@ const char *stream_name(const struct stream *strm)
 
 	return media_name(strm->type);
 }
+
+
+const struct sa *stream_raddr(const struct stream *strm)
+{
+	if (!strm)
+		return NULL;
+
+	return &strm->raddr_rtp;
+}

--- a/src/ua.c
+++ b/src/ua.c
@@ -516,7 +516,7 @@ static int sdp_originator(struct mbuf *mb, int *af, struct sa *sa)
 	}
 
 	pl_strdup(&addr, &pl2);
-	err = sa_set_str(sa, addr, 0);
+	err = sa_set_str(sa, addr, 5060);
 	mem_deref(addr);
 	return err;
 }
@@ -893,7 +893,11 @@ static int ua_check_dst_ip(struct ua *ua, struct pl *pl)
 
 	sa_init(&ua->dst, AF_UNSPEC);
 	err = sip_addr_decode(&addr, pl);
-	err |= sa_set(&ua->dst, &addr.uri.host, 0);
+	err |= sa_set(&ua->dst, &addr.uri.host, addr.uri.port);
+
+	if (!sa_isset(&ua->dst, SA_PORT))
+		sa_set_port(&ua->dst, 5060);
+
 	return err;
 }
 


### PR DESCRIPTION
This PR adds IPv6 link local addresses as SIP transport.

This adds support for outgoing calls to IPv6 link local addresses and answering incoming calls from IPv6 link local peers.