### PR TITLE
ua, menu: move auto answer delay handling to menu (#1474)

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -129,6 +129,8 @@ const char *account_call_transfer(const struct account *acc);
 const char *account_extra(const struct account *acc);
 int account_uri_complete(const struct account *acc, struct mbuf *buf,
 			 const char *uri);
+int account_adelay(const struct account *acc);
+void account_set_adelay(struct account *acc, int adelay);
 bool account_sip_autoanswer(const struct account *acc);
 void account_set_sip_autoanswer(struct account *acc, bool allow);
 enum sipansbeep account_sipansbeep(const struct account *acc);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -129,8 +129,8 @@ const char *account_call_transfer(const struct account *acc);
 const char *account_extra(const struct account *acc);
 int account_uri_complete(const struct account *acc, struct mbuf *buf,
 			 const char *uri);
-int account_adelay(const struct account *acc);
-void account_set_adelay(struct account *acc, int adelay);
+int account_answerdelay(const struct account *acc);
+void account_set_answerdelay(struct account *acc, int adelay);
 bool account_sip_autoanswer(const struct account *acc);
 void account_set_sip_autoanswer(struct account *acc, bool allow);
 enum sipansbeep account_sipansbeep(const struct account *acc);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -422,7 +422,7 @@ static void start_autoanswer(struct call *call)
 
 		if (!beep)
 			beep = menu_play(call, "sip_autoanswer_aufile",
-					 "autonswer.wav", 1);
+					 "autoanswer.wav", 1);
 	}
 
 	if (beep) {
@@ -522,8 +522,8 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		if (account_sip_autoanswer(acc)) {
 			adelay = call_answer_delay(call);
 		}
-		else if (account_adelay(acc)) {
-			adelay = account_adelay(acc);
+		else if (account_answerdelay(acc)) {
+			adelay = account_answerdelay(acc);
 			call_set_answer_delay(call, adelay);
 		}
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -422,7 +422,7 @@ static void start_autoanswer(struct call *call)
 
 		if (!beep)
 			beep = menu_play(call, "sip_autoanswer_aufile",
-					 "autoanswer.wav", 1);
+					 "autonswer.wav", 1);
 	}
 
 	if (beep) {
@@ -519,10 +519,13 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		     account_aor(acc), call_peername(call), call_peeruri(call),
 		     sdp_dir_name(ardir), sdp_dir_name(vrdir));
 
-		if (account_sip_autoanswer(acc))
+		if (account_sip_autoanswer(acc)) {
 			adelay = call_answer_delay(call);
-		else if (account_adelay(acc))
+		}
+		else if (account_adelay(acc)) {
 			adelay = account_adelay(acc);
+			call_set_answer_delay(call, adelay);
+		}
 
 		if (adelay == -1)
 			play_incoming(call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -404,7 +404,7 @@ static bool alert_uri_supported(const char *uri)
 }
 
 
-static void start_sip_autoanswer(struct call *call)
+static void start_autoanswer(struct call *call)
 {
 	struct account *acc = call_account(call);
 	int32_t adelay = call_answer_delay(call);
@@ -519,13 +519,15 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		     account_aor(acc), call_peername(call), call_peeruri(call),
 		     sdp_dir_name(ardir), sdp_dir_name(vrdir));
 
-		if (acc && account_sip_autoanswer(acc))
+		if (account_sip_autoanswer(acc))
 			adelay = call_answer_delay(call);
+		else if (account_adelay(acc))
+			adelay = account_adelay(acc);
 
 		if (adelay == -1)
 			play_incoming(call);
 		else
-			start_sip_autoanswer(call);
+			start_autoanswer(call);
 
 		break;
 

--- a/src/account.c
+++ b/src/account.c
@@ -1422,13 +1422,13 @@ uint16_t account_stun_port(const struct account *acc)
 }
 
 
-int32_t account_adelay(const struct account *acc)
+int32_t account_answerdelay(const struct account *acc)
 {
 	return acc ? acc->adelay : 0;
 }
 
 
-void account_set_adelay(struct account *acc, int32_t adelay)
+void account_set_answerdelay(struct account *acc, int32_t adelay)
 {
 	if (!acc)
 		return;

--- a/src/account.c
+++ b/src/account.c
@@ -1422,13 +1422,13 @@ uint16_t account_stun_port(const struct account *acc)
 }
 
 
-int account_adelay(const struct account *acc)
+int32_t account_adelay(const struct account *acc)
 {
 	return acc ? acc->adelay : 0;
 }
 
 
-void account_set_adelay(struct account *acc, int adelay)
+void account_set_adelay(struct account *acc, int32_t adelay)
 {
 	if (!acc)
 		return;

--- a/src/account.c
+++ b/src/account.c
@@ -1422,6 +1422,21 @@ uint16_t account_stun_port(const struct account *acc)
 }
 
 
+int account_adelay(const struct account *acc)
+{
+	return acc ? acc->adelay : 0;
+}
+
+
+void account_set_adelay(struct account *acc, int adelay)
+{
+	if (!acc)
+		return;
+
+	acc->adelay = adelay;
+}
+
+
 /**
  * Returns if SIP auto answer is allowed for the account
  *

--- a/src/core.h
+++ b/src/core.h
@@ -45,7 +45,7 @@ struct account {
 	bool sipans;                 /**< Allow SIP header auto answer mode  */
 	enum sipansbeep sipansbeep;  /**< Beep mode for SIP auto answer      */
 	enum answermode answermode;  /**< Answermode for incoming calls      */
-	uint32_t adelay;             /**< Delay for delayed auto answer [ms] */
+	int32_t adelay;              /**< Delay for delayed auto answer [ms] */
 	enum dtmfmode dtmfmode;      /**< Send type for DTMF tones           */
 	struct le acv[16];           /**< List elements for aucodecl         */
 	struct list aucodecl;        /**< List of preferred audio-codecs     */

--- a/src/ua.c
+++ b/src/ua.c
@@ -402,26 +402,14 @@ static void call_event_handler(struct call *call, enum call_event ev,
 		case ANSWERMODE_EARLY_VIDEO:
 			ua_event(ua, UA_EVENT_CALL_INCOMING, call, peeruri);
 			(void)call_progress(call);
-			if (ua->acc->adelay)
-				call_start_answtmr(call, ua->acc->adelay);
-
-			break;
-
-		case ANSWERMODE_AUTO:
-			if (ua->acc->adelay) {
-				ua_event(ua, UA_EVENT_CALL_INCOMING, call,
-						peeruri);
-				call_start_answtmr(call, ua->acc->adelay);
-			}
-			else {
-				(void)call_answer(call, 200, VIDMODE_ON);
-			}
 			break;
 
 		case ANSWERMODE_MANUAL:
 			ua_event(ua, UA_EVENT_CALL_INCOMING, call, peeruri);
-			if (ua->acc->adelay)
-				call_start_answtmr(call, ua->acc->adelay);
+			break;
+
+		case ANSWERMODE_AUTO:
+			(void)call_answer(call, 200, VIDMODE_ON);
 			break;
 		}
 		break;


### PR DESCRIPTION
This simplifies auto answer mode and the handling for the answer delay.

- The account answer delay is handled in menu instead of ua.c.
- The `ANSWERMODE_AUTO` simply answer the call immediately.

After this PR is merged, I will update the wiki.