### PR TITLE
ipv6ll scope id

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -707,6 +707,7 @@ int  net_debug(struct re_printf *pf, const struct network *net);
 const struct sa *net_laddr_af(const struct network *net, int af);
 int net_laddr_apply(const struct network *net, net_laddr_h *laddrh);
 bool net_is_laddr(const struct network *net, struct sa *sa);
+int net_set_dst_scopeid(const struct network *net, struct sa *dst);
 struct dnsc     *net_dnsc(const struct network *net);
 
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -689,6 +689,7 @@ const char *menc_event_name(enum menc_event event);
 struct network;
 
 typedef void (net_change_h)(void *arg);
+typedef int (net_laddr_h)(const struct sa *sa);
 
 int  net_alloc(struct network **netp, const struct config_net *cfg);
 int  net_use_nameserver(struct network *net,
@@ -704,6 +705,8 @@ void net_dns_refresh(struct network *net);
 int  net_dns_debug(struct re_printf *pf, const struct network *net);
 int  net_debug(struct re_printf *pf, const struct network *net);
 const struct sa *net_laddr_af(const struct network *net, int af);
+int net_laddr_apply(const struct network *net, net_laddr_h *laddrh);
+bool net_is_laddr(const struct network *net, struct sa *sa);
 struct dnsc     *net_dnsc(const struct network *net);
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -334,6 +334,7 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 bool stream_is_ready(const struct stream *strm);
 int  stream_decode(struct stream *s);
 void stream_silence_on(struct stream *s, bool on);
+const struct sa *stream_raddr(const struct stream *s);
 
 
 /*

--- a/src/main.c
+++ b/src/main.c
@@ -35,12 +35,19 @@ static void signal_handler(int sig)
 }
 
 
+static int laddr_print(const struct sa *sa)
+{
+	info("  %j\n", sa);
+	return 0;
+}
+
+
 static void net_change_handler(void *arg)
 {
 	(void)arg;
 
-	info("IP-address changed: %j\n",
-	     net_laddr_af(baresip_network(), AF_INET));
+	info("Local network addresses changed:\n");
+	net_laddr_apply(baresip_network(), laddr_print);
 
 	(void)uag_reset_transp(true, true);
 }

--- a/src/net.c
+++ b/src/net.c
@@ -644,6 +644,22 @@ enum laddr_check {
 };
 
 
+static int net_dst_is_source_addr(const struct sa *dst, const struct sa *ip)
+{
+	struct sa src;
+	int err;
+
+	err = net_dst_source_addr_get(dst, &src);
+	if (err)
+		return err;
+
+	if (!sa_cmp(ip, &src, SA_ADDR))
+		return ECONNREFUSED;
+
+	return 0;
+}
+
+
 static const struct sa *find_laddr_af(const struct network *net, int af,
 		enum laddr_check lc)
 {
@@ -732,6 +748,30 @@ int net_laddr_apply(const struct network *net, net_laddr_h *laddrh)
 bool net_is_laddr(const struct network *net, struct sa *sa)
 {
 	return NULL != list_apply(&net->laddrs, true, laddr_cmp, sa);
+}
+
+
+int net_set_dst_scopeid(const struct network *net, struct sa *dst)
+{
+	struct le *le;
+	if (!net || !dst)
+		return EINVAL;
+
+	if (sa_af(dst) != AF_INET6 || !sa_is_linklocal(dst))
+		return 0;
+
+	LIST_FOREACH(&net->laddrs, le) {
+		struct laddr *laddr = le->data;
+		struct sa *sa = &laddr->sa;
+		if (sa_af(sa) != AF_INET6 || !sa_is_linklocal(sa))
+			continue;
+
+		sa_set_scopeid(dst, sa_scopeid(&laddr->sa));
+		if (!net_dst_is_source_addr(dst, &laddr->sa))
+			return 0;
+	}
+
+	return ECONNREFUSED;
 }
 
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -717,6 +717,8 @@ static void stream_remote_set(struct stream *s)
 	else
 		sdp_media_raddr_rtcp(s->sdp, &s->raddr_rtcp);
 
+	net_set_dst_scopeid(baresip_network(), &s->raddr_rtp);
+	net_set_dst_scopeid(baresip_network(), &s->raddr_rtcp);
 	if (stream_is_ready(s)) {
 
 		stream_start(s);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1211,3 +1211,12 @@ const char *stream_name(const struct stream *strm)
 
 	return media_name(strm->type);
 }
+
+
+const struct sa *stream_raddr(const struct stream *strm)
+{
+	if (!strm)
+		return NULL;
+
+	return &strm->raddr_rtp;
+}

--- a/src/ua.c
+++ b/src/ua.c
@@ -498,6 +498,7 @@ static int sdp_originator(struct mbuf *mb, int *af, struct sa *sa)
 {
 	struct pl pl1, pl2;
 	char *addr;
+	const struct network *net = baresip_network();
 	int err;
 
 	*af = AF_UNSPEC;
@@ -516,7 +517,8 @@ static int sdp_originator(struct mbuf *mb, int *af, struct sa *sa)
 	}
 
 	pl_strdup(&addr, &pl2);
-	err = sa_set_str(sa, addr, 5060);
+	err  = sa_set_str(sa, addr, 5060);
+	err |= net_set_dst_scopeid(net, sa);
 	mem_deref(addr);
 	return err;
 }
@@ -893,6 +895,7 @@ static const char *autoans_header_name(enum answer_method met)
 static int ua_check_dst_ip(struct ua *ua, struct pl *pl)
 {
 	struct sip_addr addr;
+	const struct network *net = baresip_network();
 	int err;
 
 	sa_init(&ua->dst, AF_UNSPEC);
@@ -902,6 +905,7 @@ static int ua_check_dst_ip(struct ua *ua, struct pl *pl)
 	if (!sa_isset(&ua->dst, SA_PORT))
 		sa_set_port(&ua->dst, 5060);
 
+	err |= net_set_dst_scopeid(net, &ua->dst);
 	return err;
 }
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -516,7 +516,7 @@ static int sdp_originator(struct mbuf *mb, int *af, struct sa *sa)
 	}
 
 	pl_strdup(&addr, &pl2);
-	err = sa_set_str(sa, addr, 0);
+	err = sa_set_str(sa, addr, 5060);
 	mem_deref(addr);
 	return err;
 }
@@ -893,7 +893,11 @@ static int ua_check_dst_ip(struct ua *ua, struct pl *pl)
 
 	sa_init(&ua->dst, AF_UNSPEC);
 	err = sip_addr_decode(&addr, pl);
-	err |= sa_set(&ua->dst, &addr.uri.host, 0);
+	err |= sa_set(&ua->dst, &addr.uri.host, addr.uri.port);
+
+	if (!sa_isset(&ua->dst, SA_PORT))
+		sa_set_port(&ua->dst, 5060);
+
 	return err;
 }
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -584,6 +584,7 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 
 	/* Check if offered media AF is supported and available */
 	if (!sdp_originator(msg->mb, &af_sdp, &oaddr)) {
+		sa_set_port(&oaddr, 5060);
 		if (!net_af_enabled(net, af_sdp)) {
 			warning("ua: SDP offer AF not supported (%s)\n",
 				net_af2name(af_sdp));
@@ -726,6 +727,9 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 	memset(&cprm, 0, sizeof(cprm));
 
 	if (sa_isset(&ua->dst, SA_ADDR)) {
+		if (!sa_isset(&ua->dst, SA_PORT))
+			sa_set_port(&ua->dst, 5060);
+
 		err |= net_dst_source_addr_get(&ua->dst, &cprm.laddr);
 	}
 	else {


### PR DESCRIPTION
Second part for IPv6ll support. Setting the scope ID.

Has to be re-based after merge of https://github.com/baresip/baresip/pull/1473