### PR TITLE
stream: fix telephone event (#1494)

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -286,7 +286,6 @@ struct stream {
 	uint32_t pseq;           /**< Sequence number for incoming RTP      */
 	bool pseq_set;           /**< True if sequence number is set        */
 	int pt_enc;              /**< Payload type for encoding             */
-	int pt_dec;              /**< Payload type for decoding             */
 	bool rtcp_mux;           /**< RTP/RTCP multiplex supported by peer  */
 	bool jbuf_started;       /**< True if jitter-buffer was started     */
 	stream_pt_h *pth;        /**< Stream payload type handler           */

--- a/src/stream.c
+++ b/src/stream.c
@@ -293,12 +293,9 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 	}
 
 	/* payload-type changed? */
-	if (s->pt_dec != hdr->pt) {
-		s->pt_dec = hdr->pt;
-		err = s->pth(hdr->pt, mb, s->arg);
-		if (err)
-			return;
-	}
+	err = s->pth(hdr->pt, mb, s->arg);
+	if (err)
+		return;
 
 	if (s->jbuf) {
 
@@ -526,7 +523,6 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	s->arg    = arg;
 	s->pseq   = -1;
 	s->ldir   = SDP_SENDRECV;
-	s->pt_dec = -1;
 
 	if (prm->use_rtp) {
 		err = stream_sock_alloc(s, prm->af);


### PR DESCRIPTION
Fixes #1494 

Tested with `jitter_buffer_type` `off`, `fixed` and `adaptive`.

Problem consists since dbb4a985ca4184b73bb32a4e490d9a154ee327b3.

@alfredh I can remember that you wanted to call the `s->pth()` only if the pt differ from the audio codec pt. The solution with `s->pt_dec` was wrong. What we want is to check if `rx->pt` differs from `hdr->pt`. In `stream.c` we don't have the `rx->pt`. So the simplest solution is to call `s->pth()` for each RTP packet and do the check in audio.c (video.c).

Found the old PR: https://github.com/baresip/baresip/pull/1128 