### PR TITLE
config,audio: add setting audio.telev_pt

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -49,6 +49,7 @@ auplay_format		s16		# s16, float, ..
 auenc_format		s16		# s16, float, ..
 audec_format		s16		# s16, float, ..
 audio_buffer		20-160		# ms
+audio_telev_pt		101		# payload type for telephone-event
 
 # Video
 #video_source		v4l2,/dev/video0

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -322,6 +322,7 @@ struct config_audio {
 	int enc_fmt;            /**< Audio encoder sample format    */
 	int dec_fmt;            /**< Audio decoder sample format    */
 	struct range buffer;    /**< Audio receive buffer in [ms]   */
+	uint32_t telev_pt;      /**< Payload type for tel.-event    */
 };
 
 /** Video */

--- a/src/audio.c
+++ b/src/audio.c
@@ -1218,11 +1218,15 @@ static int add_telev_codec(struct audio *a)
 {
 	struct sdp_media *m = stream_sdpmedia(audio_strm(a));
 	struct sdp_format *sf;
+	uint32_t pt = a->cfg.telev_pt;
+	char pts[11];
 	int err;
+
+	(void)re_snprintf(pts, sizeof(pts), "%u", pt);
 
 	/* Use payload-type 101 if available, for CiscoGW interop */
 	err = sdp_format_add(&sf, m, false,
-			     (!sdp_media_lformat(m, 101)) ? "101" : NULL,
+			     (!sdp_media_lformat(m, pt)) ? pts : NULL,
 			     telev_rtpfmt, TELEV_SRATE, 1, NULL,
 			     NULL, NULL, false, "0-15");
 	if (err)

--- a/src/config.c
+++ b/src/config.c
@@ -60,6 +60,7 @@ static struct config core_config = {
 		AUFMT_S16LE,
 		AUFMT_S16LE,
 		{20, 160},
+		101
 	},
 
 	/** Video */
@@ -360,6 +361,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 		return EINVAL;
 	}
 
+	(void)conf_get_u32(conf, "audio_telev_pt", &cfg->audio.telev_pt);
+
 	/* Video */
 	(void)conf_get_csv(conf, "video_source",
 			   cfg->video.src_mod, sizeof(cfg->video.src_mod),
@@ -456,6 +459,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "auplay_channels\t\t%u\n"
 			 "ausrc_channels\t\t%u\n"
 			 "audio_level\t\t%s\n"
+			 "audio_telev_pt\t\t%u\n"
 			 "\n"
 			 "# Video\n"
 			 "video_source\t\t%s,%s\n"
@@ -501,6 +505,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->audio.srate_play, cfg->audio.srate_src,
 			 cfg->audio.channels_play, cfg->audio.channels_src,
 			 cfg->audio.level ? "yes" : "no",
+			 cfg->audio.telev_pt,
 
 			 cfg->video.src_mod, cfg->video.src_dev,
 			 cfg->video.disp_mod, cfg->video.disp_dev,
@@ -669,6 +674,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "auenc_format\t\ts16\t\t# s16, float, ..\n"
 			  "audec_format\t\ts16\t\t# s16, float, ..\n"
 			  "audio_buffer\t\t%H\t\t# ms\n"
+			  "audio_telev_pt\t\t%u\t\t"
+			  "# payload type for telephone-event\n"
 			  ,
 			  poll_method_name(poll_method_best()),
 			  default_cafile(),
@@ -677,7 +684,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  default_audio_device(),
 			  default_audio_device(),
 			  default_audio_device(),
-			  range_print, &cfg->audio.buffer);
+			  range_print, &cfg->audio.buffer,
+			  cfg->audio.telev_pt);
 
 	err |= re_hprintf(pf,
 			  "\n# Video\n"


### PR DESCRIPTION
RFC-4733 tells that the payload type for the telephone-event should be set
dynamically. Baresip sets it to 101 if it is available. This commit adds a
setting for the payload type with default value 101.