### PR TITLE
Fix I2S compile error, use auframe

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -163,7 +163,7 @@ USE_SNDFILE := $(shell [ -f $(SYSROOT)/include/sndfile.h ] || \
 USE_SNDIO := $(shell [ -f $(SYSROOT)/include/sndio.h ] || \
 	[ -f $(SYSROOT)/local/include/sndio.h ] && echo "yes")
 USE_STDIO := $(shell [ -f $(SYSROOT)/include/termios.h ] && echo "yes")
-HAVE_GLIB := $(shell pkg-config --exists glib-2.0 && echo "yes")
+HAVE_GLIB := $(shell pkg-config --exists "glib-2.0 >= 2.56" && echo "yes")
 HAVE_SPEEXDSP := $(shell \
 	[ -f $(SYSROOT)/local/lib/libspeexdsp$(LIB_SUFFIX) ] || \
 	[ -f $(SYSROOT)/lib64/libspeexdsp$(LIB_SUFFIX) ] || \

--- a/modules/i2s/i2s_play.c
+++ b/modules/i2s/i2s_play.c
@@ -74,7 +74,7 @@ static void *write_thread(void *arg)
 		st->sampv,
 		st->sampc,
 		st->prm.srate,
-		st->prm.c
+		st->prm.ch
 		);
 
 	while (st->run) {

--- a/modules/i2s/i2s_play.c
+++ b/modules/i2s/i2s_play.c
@@ -65,12 +65,15 @@ static void convert_sampv(struct auplay_st *st, size_t i, size_t n)
 static void *write_thread(void *arg)
 {
 	struct auplay_st *st = arg;
+	struct auframe af;
 
 	i2s_set_clk(I2S_PORT, st->prm.srate, 32, st->prm.ch);
+	auframe_init(&af, st->prm.fmt, st->sampv, st->sampc, st->prm.srate, st->prm.ch);
+
 	while (st->run) {
 		size_t i;
 
-		st->wh(st->sampv, st->sampc, st->arg);
+		st->wh(&af, st->arg);
 		for (i = 0; i + DMA_SIZE / 4 <= st->sampc;) {
 			size_t n;
 			convert_sampv(st, i, DMA_SIZE / 4);

--- a/modules/i2s/i2s_play.c
+++ b/modules/i2s/i2s_play.c
@@ -68,7 +68,14 @@ static void *write_thread(void *arg)
 	struct auframe af;
 
 	i2s_set_clk(I2S_PORT, st->prm.srate, 32, st->prm.ch);
-	auframe_init(&af, st->prm.fmt, st->sampv, st->sampc, st->prm.srate, st->prm.ch);
+
+	auframe_init(&af,
+		st->prm.fmt,
+		st->sampv,
+		st->sampc,
+		st->prm.srate,
+		st->prm.c
+		);
 
 	while (st->run) {
 		size_t i;

--- a/modules/i2s/i2s_src.c
+++ b/modules/i2s/i2s_src.c
@@ -70,6 +70,7 @@ static void convert_pcm(struct ausrc_st *st, size_t i, size_t n)
 static void *read_thread(void *arg)
 {
 	struct ausrc_st *st = arg;
+	struct auframe af;
 
 	while (st->run) {
 		size_t i;
@@ -86,11 +87,15 @@ static void *read_thread(void *arg)
 			convert_pcm(st, i, n / 4);
 			i += (n / 4);
 		}
-		
-		struct auframe af = {
-           .sampc = st->sampc,
-           .sampv = st->sampv
-		   };
+
+		auframe_init(&af, 
+			st->prm.fmt, 
+			st->sampv, 
+			st->sampc, 
+			st->prm.srate, 
+			st->prm.ch
+			);
+
 		st->rh(&af, st->arg);
 	}
 

--- a/modules/i2s/i2s_src.c
+++ b/modules/i2s/i2s_src.c
@@ -86,8 +86,12 @@ static void *read_thread(void *arg)
 			convert_pcm(st, i, n / 4);
 			i += (n / 4);
 		}
-
-		st->rh(st->sampv, st->sampc, st->arg);
+		
+		struct auframe af = {
+           .sampc = st->sampc,
+           .sampv = st->sampv
+		   };
+		st->rh(&af, st->arg);
 	}
 
 	i2s_stop_bus(I2O_RECO);

--- a/modules/i2s/i2s_src.c
+++ b/modules/i2s/i2s_src.c
@@ -88,11 +88,11 @@ static void *read_thread(void *arg)
 			i += (n / 4);
 		}
 
-		auframe_init(&af, 
-			st->prm.fmt, 
-			st->sampv, 
-			st->sampc, 
-			st->prm.srate, 
+		auframe_init(&af,
+			st->prm.fmt,
+			st->sampv,
+			st->sampc,
+			st->prm.srate,
 			st->prm.ch
 			);
 


### PR DESCRIPTION
This PR makes the I2S module compile again using auframe.
However, the microphone does not seem to work.