### PR TITLE
account: add setting audio payload type for telephone-event

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -12,6 +12,7 @@
 #    ;audio_codecs=opus/48000/2,pcma,...
 #    ;audio_source=alsa,default
 #    ;audio_player=alsa,default
+#    ;autelev_pt=101
 #    ;sip_autoanswer={yes, no}
 #    ;sip_autoanswer_beep={off, on, local}
 #    ;dtmfmode={rtpevent, info}

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -135,6 +135,8 @@ bool account_sip_autoanswer(const struct account *acc);
 void account_set_sip_autoanswer(struct account *acc, bool allow);
 enum sipansbeep account_sipansbeep(const struct account *acc);
 void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
+void account_set_autelev_pt(struct account *acc, uint32_t pt);
+uint32_t account_autelev_pt(struct account *acc);
 
 
 /*

--- a/src/account.c
+++ b/src/account.c
@@ -533,6 +533,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	if (err)
 		goto out;
 
+	param_u32(&acc->autelev_pt, &acc->laddr.params, "autelev_pt");
 	err  = decode_pair(&acc->ausrc_mod, &acc->ausrc_dev,
 			   &acc->laddr.params, "audio_source");
 	err |= decode_pair(&acc->auplay_mod, &acc->auplay_dev,
@@ -1488,6 +1489,34 @@ void account_set_sipansbeep(struct account *acc, enum sipansbeep beep)
 }
 
 
+/**
+ * Sets the audio payload type for telephone-events
+ *
+ * @param acc User-Agent account
+ * @param pt  Payload type
+ */
+void account_set_autelev_pt(struct account *acc, uint32_t pt)
+{
+	if (!acc)
+		return;
+
+	acc->autelev_pt = pt;
+}
+
+
+/**
+ * Returns the audio payload type for telephone-events
+ *
+ * @param acc User-Agent account
+ *
+ * @return Telephone-event payload type
+ */
+uint32_t account_autelev_pt(struct account *acc)
+{
+	return acc ? acc->autelev_pt : 0;
+}
+
+
 static const char *answermode_str(enum answermode mode)
 {
 	switch (mode) {
@@ -1742,6 +1771,7 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 		}
 		err |= re_hprintf(pf, "\n");
 	}
+	err |= re_hprintf(pf, " autelev_pt:   %u\n", acc->autelev_pt);
 	err |= re_hprintf(pf, " auth_user:    %s\n", acc->auth_user);
 	err |= re_hprintf(pf, " mediaenc:     %s\n",
 			  acc->mencid ? acc->mencid : "none");

--- a/src/audio.c
+++ b/src/audio.c
@@ -1404,6 +1404,9 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 			goto out;
 	}
 
+	if (acc && acc->autelev_pt)
+		a->cfg.telev_pt = acc->autelev_pt;
+
 	rx->pt     = -1;
 	rx->ptime  = ptime;
 #ifdef HAVE_PTHREAD

--- a/src/core.h
+++ b/src/core.h
@@ -77,6 +77,7 @@ struct account {
 	char *ausrc_dev;
 	char *auplay_mod;
 	char *auplay_dev;
+	uint32_t autelev_pt;         /**< Payload type for telephone-events  */
 	char *extra;                 /**< Extra parameters                   */
 };
 


### PR DESCRIPTION
It makes sense to make the config option for telephone-event payload type per account.
