### PR TITLE
ua: check if peer is capable of video for early video

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -193,6 +193,7 @@ int  call_set_video_dir(struct call *call, enum sdp_dir dir);
 int  call_send_digit(struct call *call, char key);
 bool call_has_audio(const struct call *call);
 bool call_has_video(const struct call *call);
+bool call_early_video_available(const struct call *call);
 int  call_transfer(struct call *call, const char *uri);
 int  call_replace_transfer(struct call *target_call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -245,7 +245,8 @@ static void play_incoming(const struct call *call)
 	/* stop any ringtones */
 	menu_stop_play();
 
-	if (am != ANSWERMODE_MANUAL && am != ANSWERMODE_EARLY_VIDEO)
+	if (am != ANSWERMODE_MANUAL && (am != ANSWERMODE_EARLY_VIDEO &&
+		call_early_video_available(call)))
 		return;
 
 	if (menu_find_call(active_call_test)) {

--- a/src/call.c
+++ b/src/call.c
@@ -2095,6 +2095,34 @@ static int send_dtmf_info(struct call *call, char key)
 
 
 /**
+ * Find the peer capabilites of early video in the remote SDP
+ *
+ * @param call Call object
+ *
+ * @return True if peer accepts early video, otherwise false
+ */
+bool call_early_video_available(const struct call *call)
+{
+	enum answermode m = account_answermode(call->acc);
+
+	if (m == ANSWERMODE_EARLY_VIDEO) {
+		struct le *le;
+		struct sdp_media *v;
+
+		LIST_FOREACH(sdp_session_medial(call->sdp, false), le) {
+			v = le->data;
+			if (0 == str_cmp(sdp_media_name(v), "video") &&
+				(sdp_media_rdir(v) == SDP_SENDONLY ||
+				 sdp_media_rdir(v) == SDP_SENDRECV))
+				return true;
+		}
+	}
+
+	return false;
+}
+
+
+/**
  * Get the current call duration in seconds
  *
  * @param call  Call object

--- a/src/ua.c
+++ b/src/ua.c
@@ -400,7 +400,16 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 		case ANSWERMODE_EARLY:
 		case ANSWERMODE_EARLY_AUDIO:
+			(void)call_progress(call);
+			break;
+
 		case ANSWERMODE_EARLY_VIDEO:
+			if (!call_early_video_available(call)) {
+				info ("ua: peer is not capable of early "
+					"video. proceed as normal call\n");
+				break;
+			}
+
 			(void)call_progress(call);
 			break;
 


### PR DESCRIPTION
In case the peer is not capable of video, handle the incoming
call as normal call without pre video.