### PR TITLE
account: add enable/disable flag for video

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -137,6 +137,8 @@ enum sipansbeep account_sipansbeep(const struct account *acc);
 void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
 void account_set_autelev_pt(struct account *acc, uint32_t pt);
 uint32_t account_autelev_pt(struct account *acc);
+void account_enable_video(struct account *acc, bool enable);
+bool account_video_enabled(struct account *acc);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -138,7 +138,7 @@ void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
 void account_set_autelev_pt(struct account *acc, uint32_t pt);
 uint32_t account_autelev_pt(struct account *acc);
 void account_enable_video(struct account *acc, bool enable);
-bool account_video_enabled(struct account *acc);
+bool account_video_enabled(const struct account *acc);
 
 
 /*

--- a/src/account.c
+++ b/src/account.c
@@ -377,6 +377,7 @@ static int video_codecs_decode(struct account *acc, const struct pl *prm)
 		char cname[64];
 		unsigned i = 0;
 
+		acc->videoen = false;
 		if (msg_param_decode(prm, "video_codecs", &vcs))
 			return 0;
 
@@ -393,6 +394,7 @@ static int video_codecs_decode(struct account *acc, const struct pl *prm)
 				list_append(&acc->vidcodecl, &acc->vcv[i++],
 						vc);
 
+				acc->videoen = true;
 				if (i >= ARRAY_SIZE(acc->vcv))
 					return 0;
 			}
@@ -503,6 +505,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 
 	acc->maf = AF_UNSPEC;
 	acc->sipansbeep = SIPANSBEEP_ON;
+	acc->videoen = true;
 	err = str_dup(&acc->buf, sipaddr);
 	if (err)
 		goto out;
@@ -1091,10 +1094,13 @@ struct list *account_aucodecl(const struct account *acc)
  *
  * @param acc User-Agent account
  *
- * @return List of video codecs (struct vidcodec)
+ * @return List of video codecs (struct vidcodec), NULL if video is disabled
  */
 struct list *account_vidcodecl(const struct account *acc)
 {
+	if (acc && !acc->videoen)
+		return NULL;
+
 	return (acc && !list_isempty(&acc->vidcodecl))
 		? (struct list *)&acc->vidcodecl : baresip_vidcodecl();
 }
@@ -1635,6 +1641,35 @@ const char *account_call_transfer(const struct account *acc)
 const char *account_extra(const struct account *acc)
 {
 	return acc ? acc->extra : NULL;
+}
+
+
+/**
+ * Enables/Disables video for an account
+ *
+ * @param acc    User-Agent account
+ * @param enable True to enable, false to disable
+ */
+void account_enable_video(struct account *acc, bool enable)
+{
+	if (!acc)
+		return;
+
+	acc->videoen = enable;
+}
+
+
+/**
+ * Returns if video is enabled
+ *
+ * @param acc User-Agent account
+ *
+ * @return True if video is enabled, otherwise false
+ */
+bool account_video_enabled(struct account *acc)
+{
+
+	return acc ? acc->videoen : false;
 }
 
 

--- a/src/account.c
+++ b/src/account.c
@@ -1666,7 +1666,7 @@ void account_enable_video(struct account *acc, bool enable)
  *
  * @return True if video is enabled, otherwise false
  */
-bool account_video_enabled(struct account *acc)
+bool account_video_enabled(const struct account *acc)
 {
 
 	return acc ? acc->videoen : false;

--- a/src/core.h
+++ b/src/core.h
@@ -70,6 +70,7 @@ struct account {
 	struct stun_uri *stun_host;  /**< STUN Server                        */
 	struct le vcv[4];            /**< List elements for vidcodecl        */
 	struct list vidcodecl;       /**< List of preferred video-codecs     */
+	bool videoen;                /**< Video enabled flag                 */
 	bool mwi;                    /**< MWI on/off                         */
 	bool refer;                  /**< REFER method on/off                */
 	char *cert;                  /**< SIP TLS client certificate+keyfile */


### PR DESCRIPTION
This allows to disable video for specific accounts.

Examples to disable video:
```
<sip:user@example.com>;video_codecs=
<sip:user@example.com>;video_codecs=none
```