### PR TITLE
net: add missing HAVE_INET6

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -698,7 +698,9 @@ void net_laddr_apply(const struct network *net, net_ifaddr_h *ifh, void *arg)
 		return;
 
 	handle_addr(&net->laddr,  ifh, arg);
+#ifdef HAVE_INET6
 	handle_addr(&net->laddr6, ifh, arg);
+#endif
 }
 
 


### PR DESCRIPTION
I know we discussed once about to remove all the HAVE_INET6 switches. But then baresip will not build on old systems.

Currently indeed we have a customer that didn't activate IPv6 on their devices.