### PR TITLE
multicast: add new configurable multicast TTL config parameter

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -296,6 +296,7 @@ video_selfview		window # {window,pip}
 
 # multicast receivers (in priority order)- port number must be even
 #multicast_call_prio	0
+#multicast_ttl		1
 #multicast_listener	224.0.2.21:50000
 #multicast_listener	224.0.2.21:50002
 

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -18,10 +18,12 @@
 
 struct mccfg {
 	uint32_t callprio;
+	uint32_t ttl;
 };
 
 static struct mccfg mccfg = {
 	0,
+	1,
 };
 
 
@@ -109,6 +111,17 @@ static int check_rtp_pt(struct aucodec *ac)
 uint8_t multicast_callprio(void)
 {
 	return mccfg.callprio;
+}
+
+
+/**
+ * Getter for configurable multicast TTL
+ *
+ * @return uint8_t multicast TTL
+ */
+uint8_t multicast_ttl(void)
+{
+	return mccfg.ttl;
 }
 
 
@@ -496,6 +509,12 @@ static int module_read_config(void)
 	struct sa laddr;
 
 	(void)conf_get_u32(conf_cur(), "multicast_call_prio", &mccfg.callprio);
+	if (mccfg.callprio > 255)
+		mccfg.callprio = 255;
+
+	(void)conf_get_u32(conf_cur(), "multicast_ttl", &mccfg.ttl);
+	if (mccfg.ttl > 255)
+		mccfg.ttl = 255;
 
 	sa_init(&laddr, AF_INET);
 	err = conf_apply(conf_cur(), "multicast_listener",

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -19,6 +19,7 @@ enum {
 
 
 uint8_t multicast_callprio(void);
+uint8_t multicast_ttl(void);
 
 
 /* Sender */

--- a/src/config.c
+++ b/src/config.c
@@ -1202,6 +1202,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "\n# multicast receivers (in priority order)"
 			 "- port number must be even\n"
 			 "#multicast_call_prio\t0\n"
+			 "#multicast_ttl\t1\n"
 			 "#multicast_listener\t224.0.2.21:50000\n"
 			 "#multicast_listener\t224.0.2.21:50002\n");
 


### PR DESCRIPTION
The standard value of TTL for a multicast addesse is 1 to limit the multicast package range to the local network. In some networks it might be necessary to set the multicast TTL value to higher values than 1. This TTL value is now configurable via the `multicast_ttl` config parameter.

The value for the underlying UDP socket is set in the multicast/sender.c since it is a multicast module related option.
If somebody wants to be able to set the TTL for any RTP socket, it is possible to move the part into libre/rtp.