### PR TITLE
call: fix early video capability check (wrong SDP direction checked)

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2107,19 +2107,14 @@ static int send_dtmf_info(struct call *call, char key)
  */
 bool call_early_video_available(const struct call *call)
 {
-	enum answermode m = account_answermode(call->acc);
+	struct le *le;
+	struct sdp_media *v;
 
-	if (m == ANSWERMODE_EARLY_VIDEO) {
-		struct le *le;
-		struct sdp_media *v;
-
-		LIST_FOREACH(sdp_session_medial(call->sdp, false), le) {
-			v = le->data;
-			if (0 == str_cmp(sdp_media_name(v), "video") &&
-				(sdp_media_rdir(v) == SDP_SENDONLY ||
-				 sdp_media_rdir(v) == SDP_SENDRECV))
-				return true;
-		}
+	LIST_FOREACH(sdp_session_medial(call->sdp, false), le) {
+		v = le->data;
+		if (0 == str_cmp(sdp_media_name(v), "video") &&
+			(sdp_media_rdir(v) & SDP_RECVONLY))
+			return true;
 	}
 
 	return false;


### PR DESCRIPTION
In #1526 i took the wrong remote direction for this check.
Now if the caller is capable of video sendonly, the callee actually can request a video stream from the caller to the callee.

Tested with accounts:
`"coffeeA"<sip:coffeeA@192.168.1.1>;regint=0;answermode=early-video` (callee)
`"coffeeB"<sip:coffeeB@192.168.1.1>;regint=0` (caller)

coffeeB: `/dialdir coffeeA audio=sendrecv video=sendonly`: Early video is established. After Call established unidirectional video since coffeeB is in video=sendonly

coffeeB: `/dialdir coffeeA audio=sendrecv video=sendrecv`: Early video is established. After Call established bidirectional video
coffeeB: `/dialdir coffeeA audio=sendrecv video=inactive`: Handle the call without 183 Session Progress as normal call. 