### PR TITLE
audio: catch end of file message in ausrc error handler (#1539)

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -918,8 +918,13 @@ static void ausrc_error_handler(int err, const char *str, void *arg)
 	struct audio *a = arg;
 	MAGIC_CHECK(a);
 
-	if (a->errh)
-		a->errh(err, str, a->arg);
+	if (!err) {
+		warning("audio: ausrc warning (%s)\n", str);
+	}
+	else {
+		if (a->errh)
+			a->errh(err, str, a->arg);
+	}
 }
 
 


### PR DESCRIPTION
If the error code equals 0 in the _ausrc_error_handler_, only a warning is logged and the error is not forwarded.