### PR TITLE
move network check to module

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -699,10 +699,6 @@ int  net_alloc(struct network **netp, const struct config_net *cfg);
 int  net_use_nameserver(struct network *net,
 			const struct sa *srvv, size_t srvc);
 int  net_set_address(struct network *net, const struct sa *ip);
-void net_change(struct network *net, uint32_t interval,
-		net_change_h *ch, void *arg);
-void net_force_change(struct network *net);
-bool net_check(struct network *net);
 bool net_af_enabled(const struct network *net, int af);
 int  net_set_af(struct network *net, int af);
 void net_dns_refresh(struct network *net);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -705,6 +705,8 @@ void net_dns_refresh(struct network *net);
 int  net_dns_debug(struct re_printf *pf, const struct network *net);
 int  net_debug(struct re_printf *pf, const struct network *net);
 void net_laddr_apply(const struct network *net, net_ifaddr_h *ifh, void *arg);
+bool net_ifaddr_filter(const struct network *net, const char *ifname,
+		       const struct sa *sa);
 const struct sa *net_laddr_af(const struct network *net, int af);
 struct dnsc     *net_dnsc(const struct network *net);
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -858,6 +858,7 @@ void uag_set_sub_handler(sip_msg_h *subh);
 int  uag_set_extra_params(const char *eprm);
 int  uag_enable_transport(enum sip_transp tp, bool en);
 int  uag_transp_add(const struct sa *laddr);
+int  uag_transp_rm(const struct sa *laddr);
 struct ua   *uag_find(const struct pl *cuser);
 struct ua   *uag_find_msg(const struct sip_msg *msg);
 struct ua   *uag_find_aor(const char *aor);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -857,6 +857,7 @@ int  uag_reset_transp(bool reg, bool reinvite);
 void uag_set_sub_handler(sip_msg_h *subh);
 int  uag_set_extra_params(const char *eprm);
 int  uag_enable_transport(enum sip_transp tp, bool en);
+int  uag_transp_add(const struct sa *laddr);
 struct ua   *uag_find(const struct pl *cuser);
 struct ua   *uag_find_msg(const struct sip_msg *msg);
 struct ua   *uag_find_aor(const char *aor);

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -32,6 +32,7 @@
 #   USE_L16           L16 audio codec
 #   USE_MPA           MPA audio codec
 #   USE_MPG123        Use mpg123
+#   USE_NETCHECK      Network change check
 #   USE_OMX_RPI       RaspberryPi VideoCore display driver
 #   USE_OMX_BELLAGIO  libomxil-bellagio xvideosink driver
 #   USE_OPUS          Opus audio codec
@@ -63,6 +64,7 @@ USE_G711  := 1
 USE_L16   := 1
 USE_DBUS  := 1
 USE_HTTPREQ  := 1
+USE_NETCHECK := 1
 
 ifneq ($(OS),win32)
 
@@ -385,6 +387,9 @@ MODULES   += mpa
 endif
 ifneq ($(USE_MQTT),)
 MODULES   += mqtt
+endif
+ifneq ($(USE_NETCHECK),)
+MODULES   += netcheck
 endif
 ifneq ($(USE_OPUS),)
 MODULES   += opus

--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -89,24 +89,6 @@ static void http_resph(int err, const struct http_msg *msg, void *arg)
 }
 
 
-static void net_handler(void *arg)
-{
-	const struct sa *sa;
-	(void) arg;
-
-	sa = net_laddr_af(d->net, AF_INET);
-	if (sa)
-		http_client_set_laddr(d->client, sa);
-	info("httpreq: network changed %j", sa);
-#ifdef HAVE_INET6
-	sa = net_laddr_af(d->net, AF_INET6);
-	if (sa)
-		http_client_set_laddr6(d->client, sa);
-	info("httpreq: network changed %j", sa);
-#endif
-}
-
-
 static int ensure_alloc(void)
 {
 	int err = 0;
@@ -118,7 +100,6 @@ static int ensure_alloc(void)
 		return err;
 	}
 
-	net_change(d->net, 60, net_handler, NULL);
 	if (!d->client)
 		err = http_client_alloc(&d->client, net_dnsc(d->net));
 

--- a/modules/netcheck/module.mk
+++ b/modules/netcheck/module.mk
@@ -1,0 +1,10 @@
+#
+# module.mk
+#
+# Copyright (C) 2021 Commend.com - Christian Spielberger
+#
+
+MOD		:= netcheck
+$(MOD)_SRCS	+= netcheck.c
+
+include mk/mod.mk

--- a/modules/netcheck/netcheck.c
+++ b/modules/netcheck/netcheck.c
@@ -1,0 +1,135 @@
+/**
+ * @file net.c Network change detection module
+ *
+ * Copyright (C) 2021 Commend.com - c.spielberger@commend.com
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <re.h>
+#include <baresip.h>
+
+
+/**
+ * @defgroup netcheck netcheck
+ *
+ * The network check structure
+ *
+ */
+
+struct netcheck {
+	const struct config_net *cfg;
+	struct network *net;
+	uint32_t interval;
+	struct tmr tmr;
+	struct sa laddr;
+};
+
+
+static struct netcheck d;
+
+
+static bool laddr_obsolete(enum sip_transp tp, const struct sa *laddr,
+			   void *arg)
+{
+	struct netcheck *n = arg;
+	char ifname[256] = "???";
+	int err;
+	(void) tp;
+
+	err = net_if_getname(ifname, sizeof(ifname), sa_af(laddr), laddr);
+	if (err == ENODEV) {
+		sa_cpy(&n->laddr, laddr);
+		return true;
+	}
+
+	return false;
+}
+
+
+static bool laddr_find(enum sip_transp tp, const struct sa *laddr, void *arg)
+{
+	const struct sa *sa = arg;
+	(void) tp;
+
+	return sa_cmp(sa, laddr, SA_ADDR);
+}
+
+
+static bool netcheck_find_obsolete(struct netcheck *n)
+{
+	sip_transp_list(uag_sip(), laddr_obsolete, n);
+	return sa_isset(&n->laddr, SA_ADDR);
+}
+
+
+static bool sip_transp_misses_laddr(const char *ifname, const struct sa *sa,
+			     void *arg)
+{
+	struct netcheck *n = arg;
+
+	if (!net_ifaddr_filter(baresip_network(), ifname, sa))
+		return false;
+
+	if (!sip_transp_list(uag_sip(), laddr_find, (void*) sa)) {
+		sa_cpy(&n->laddr, sa);
+		return true;
+	}
+
+	return false;
+}
+
+
+static void poll_changes(void *arg)
+{
+	struct netcheck *n = arg;
+	bool changed = false;
+	net_dns_refresh(baresip_network());
+
+	/* was a local IP added? */
+	sa_init(&n->laddr, AF_UNSPEC);
+	net_if_apply(sip_transp_misses_laddr, n);
+	if (sa_isset(&n->laddr, SA_ADDR)) {
+		debug("netcheck: new IP address %j\n", &n->laddr);
+		uag_transp_add(&n->laddr);
+		changed = true;
+	}
+
+	/* was a local IP removed? */
+	sa_init(&n->laddr, AF_UNSPEC);
+	if (netcheck_find_obsolete(n)) {
+		debug("netcheck: IP address %j was removed\n", &n->laddr);
+		uag_transp_rm(&n->laddr);
+		changed = true;
+	}
+
+	tmr_start(&n->tmr, changed ? 1000 : n->interval * 1000,
+		  poll_changes, n);
+}
+
+
+static int module_init(void)
+{
+	int err = 0;
+	d.cfg = &conf_config()->net;
+	d.net = baresip_network();
+	d.interval = 2;
+	tmr_start(&d.tmr, d.interval * 1000, poll_changes, &d);
+
+	return err;
+}
+
+
+static int module_close(void)
+{
+	tmr_cancel(&d.tmr);
+	return 0;
+}
+
+
+const struct mod_export DECL_EXPORTS(netcheck) = {
+	"netcheck",
+	"application",
+	module_init,
+	module_close
+};

--- a/src/call.c
+++ b/src/call.c
@@ -2204,6 +2204,12 @@ int call_reset_transp(struct call *call, const struct sa *laddr)
 }
 
 
+const struct sa *call_laddr(const struct call *call)
+{
+	return sdp_session_laddr(call->sdp);
+}
+
+
 /**
  * Send a SIP NOTIFY with a SIP message fragment
  *

--- a/src/core.h
+++ b/src/core.h
@@ -197,6 +197,7 @@ int  reg_debug(struct re_printf *pf, const struct reg *reg);
 int  reg_json_api(struct odict *od, const struct reg *reg);
 int  reg_status(struct re_printf *pf, const struct reg *reg);
 int  reg_af(const struct reg *reg);
+const struct sa *reg_laddr(const struct reg *reg);
 
 
 /*
@@ -311,6 +312,7 @@ struct call *ua_find_active_call(struct ua *ua);
 void ua_handle_options(struct ua *ua, const struct sip_msg *msg);
 void sipsess_conn_handler(const struct sip_msg *msg, void *arg);
 bool ua_catchall(struct ua *ua);
+bool ua_reghasladdr(const struct ua *ua, const struct sa *laddr);
 
 /*
  * User-Agent Group

--- a/src/core.h
+++ b/src/core.h
@@ -127,6 +127,7 @@ int  call_reset_transp(struct call *call, const struct sa *laddr);
 int  call_af(const struct call *call);
 void call_set_xrtpstat(struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
+const struct sa *call_laddr(const struct call *call);
 
 /*
 * Custom headers

--- a/src/main.c
+++ b/src/main.c
@@ -35,17 +35,6 @@ static void signal_handler(int sig)
 }
 
 
-static void net_change_handler(void *arg)
-{
-	(void)arg;
-
-	info("IP-address changed: %j\n",
-	     net_laddr_af(baresip_network(), AF_INET));
-
-	(void)uag_reset_transp(true, true);
-}
-
-
 static void ua_exit_handler(void *arg)
 {
 	(void)arg;
@@ -267,8 +256,6 @@ int main(int argc, char *argv[])
 		      true, true, true);
 	if (err)
 		goto out;
-
-	net_change(baresip_network(), 60, net_change_handler, NULL);
 
 	uag_set_exit_handler(ua_exit_handler, NULL);
 

--- a/src/net.c
+++ b/src/net.c
@@ -511,6 +511,27 @@ static bool if_debug_handler(const char *ifname, const struct sa *sa,
 }
 
 
+bool net_ifaddr_filter(const struct network *net, const char *ifname,
+			      const struct sa *sa)
+{
+	const struct config_net *cfg = &net->cfg;
+
+	if (!sa_isset(sa, SA_ADDR))
+		return false;
+
+	if (str_isset(cfg->ifname) && str_cmp(cfg->ifname, ifname))
+		return false;
+
+	if (!net_af_enabled(net, sa_af(sa)))
+		return false;
+
+	if (sa_is_loopback(sa))
+		return false;
+
+	return true;
+}
+
+
 /**
  * Get the local IP Address for a specific Address Family (AF)
  *

--- a/src/reg.c
+++ b/src/reg.c
@@ -365,3 +365,12 @@ int reg_af(const struct reg *reg)
 
 	return reg->af;
 }
+
+
+const struct sa *reg_laddr(const struct reg *reg)
+{
+	if (!reg)
+		return NULL;
+
+	return sipreg_laddr(reg->sipreg);
+}

--- a/src/ua.c
+++ b/src/ua.c
@@ -273,6 +273,24 @@ bool ua_regfailed(const struct ua *ua)
 }
 
 
+bool ua_reghasladdr(const struct ua *ua, const struct sa *laddr)
+{
+	struct le *le;
+
+	if (!ua || !laddr)
+		return false;
+
+	for (le = ua->regl.head; le; le = le->next) {
+
+		const struct reg *reg = le->data;
+		if (sa_cmp(reg_laddr(reg), laddr, SA_ADDR))
+			return true;
+	}
+
+	return false;
+}
+
+
 /**
  * Destroy the user-agent, terminate all active calls and
  * send the SHUTDOWN event.

--- a/src/uag.c
+++ b/src/uag.c
@@ -670,7 +670,6 @@ int uag_reset_transp(bool reg, bool reinvite)
 	/* Update SIP transports */
 	sip_transp_flush(uag.sip);
 
-	(void)net_check(net);
 	err = ua_add_transp(net);
 	if (err)
 		return err;

--- a/src/uag.c
+++ b/src/uag.c
@@ -457,7 +457,7 @@ int  uag_transp_rm(const struct sa *laddr)
 	struct sa laddrn;
 	int err = 0;
 
-	if (!laddr)
+	if (!sa_isset(laddr, SA_ADDR))
 		return EINVAL;
 
 	sip_transp_rmladdr(uag_sip(), laddr);

--- a/src/uag.c
+++ b/src/uag.c
@@ -294,7 +294,7 @@ static int add_transp_clientcert(void)
 #endif
 
 
-static int add_transp_af(const struct sa *laddr)
+int uag_transp_add(const struct sa *laddr)
 {
 	struct sa local;
 #ifdef USE_TLS
@@ -446,16 +446,16 @@ static int add_transp_af(const struct sa *laddr)
 }
 
 
-static int ua_add_transp(struct network *net)
+static int ua_transp_addall(struct network *net)
 {
 	int err = 0;
 
 	if (sa_isset(net_laddr_af(net, AF_INET), SA_ADDR))
-		err |= add_transp_af(net_laddr_af(net, AF_INET));
+		err |= uag_transp_add(net_laddr_af(net, AF_INET));
 
 #if HAVE_INET6
 	if (sa_isset(net_laddr_af(net, AF_INET6), SA_ADDR))
-		err |= add_transp_af(net_laddr_af(net, AF_INET6));
+		err |= uag_transp_add(net_laddr_af(net, AF_INET6));
 #endif
 
 	return err;
@@ -544,7 +544,7 @@ int ua_init(const char *software, bool udp, bool tcp, bool tls)
 		goto out;
 	}
 
-	err = ua_add_transp(net);
+	err = ua_transp_addall(net);
 	if (err)
 		goto out;
 
@@ -670,7 +670,7 @@ int uag_reset_transp(bool reg, bool reinvite)
 	/* Update SIP transports */
 	sip_transp_flush(uag.sip);
 
-	err = ua_add_transp(net);
+	err = ua_transp_addall(net);
 	if (err)
 		return err;
 

--- a/src/uag.c
+++ b/src/uag.c
@@ -304,6 +304,9 @@ int uag_transp_add(const struct sa *laddr)
 #endif
 	int err = 0;
 
+	if (!sa_isset(laddr, SA_ADDR))
+		return EINVAL;
+
 	if (str_isset(uag.cfg->local)) {
 		err = sa_decode(&local, uag.cfg->local,
 				str_len(uag.cfg->local));

--- a/test/net.c
+++ b/test/net.c
@@ -14,18 +14,9 @@ static struct config_net default_config = {
 };
 
 
-static void net_change_handler(void *arg)
-{
-	unsigned *count = arg;
-	++*count;
-	info("network changed\n");
-}
-
-
 int test_network(void)
 {
 	struct network *net = NULL;
-	unsigned change_count = 0;
 	int err;
 
 	err = net_alloc(&net, &default_config);
@@ -34,14 +25,6 @@ int test_network(void)
 
 	ASSERT_TRUE( net_af_enabled(net, AF_INET));
 	ASSERT_TRUE(!net_af_enabled(net, AF_INET6));
-
-	net_change(net, 1, net_change_handler, &change_count);
-
-	ASSERT_EQ(0, change_count);
-
-	net_force_change(net);
-
-	ASSERT_EQ(1, change_count);
 
  out:
 	mem_deref(net);


### PR DESCRIPTION
Based on our discussions in #1535.

TODOs:
- Remove `laddr`, `laddr6` in net.c. The local address can be queried from transport list.
- Remove `net_laddr_apply()` and `handle_addr()` from net.c.
- Add to uag.c:
   - `uag_laddr_dst(struct sa *dst)`
   - `uag_laddr_af(int af)` replaces the `net_laddr_af()`. We are currently not able to get the destination IP for an outgoing request if the user specifies a SIP URI that does not contain an IP address.