### PR TITLE
serreg: fix server selection in case all server were unavailable

### DIFF
--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -40,6 +40,7 @@ enum {
 
 static struct {
 	uint32_t prio;            /**< Current account prio           */
+	bool registered;          /**< Currently registered flag      */
 	uint32_t maxprio;         /**< Maximum account prio           */
 	bool ready;               /**< All UA registered flag         */
 	uint32_t sprio;           /**< Prev successful prio           */
@@ -218,7 +219,7 @@ static void fallback_ok(struct ua *ua)
 
 	debug("serreg: fallback prio %u ok %s.\n", prio, account_aor(acc));
 
-	if (prio <= sreg.prio) {
+	if (prio <= sreg.prio || !sreg.registered) {
 		info("serreg: Fallback %s ok -> prio %u.\n",
 		     account_aor(acc), prio);
 		sreg.prio = prio;
@@ -303,6 +304,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_REGISTER_OK:
+		sreg.registered = true;
 		sreg.prio = account_prio(ua_account(ua));
 		check_registrations();
 		sreg.sprio = sreg.prio;
@@ -310,6 +312,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_REGISTER_FAIL:
 		/* did we already increment? */
+		sreg.registered = false;
 		if (account_prio(ua_account(ua)) != sreg.prio)
 			break;
 


### PR DESCRIPTION
In case all SIP servers go down (primary and the fallback servers) and one of the fallback servers comes back online, the serreg modules does not register at this server.
The module polls the information that a fallback server is back online. In the case of the fallback server, the module never register on that server since it behaves like it is already registered at the primary server.

A boolean flag is introduced to save the registration state information if any server is registered. If the flag is false, just register at the highest prio server which is available.