### PR TITLE
multicast: fix missing unlock

### DIFF
--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -349,7 +349,6 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 			rx_thread, player);
 		if (err) {
 			player->thr.run = false;
-			return;
 		}
 	}
 

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -347,9 +347,8 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 		player->thr.run = true;
 		err = pthread_create(&player->thr.tid, NULL,
 			rx_thread, player);
-		if (err) {
+		if (err)
 			player->thr.run = false;
-		}
 	}
 
 	pthread_cond_signal(&player->thr.cond);


### PR DESCRIPTION
found with Coverity Scan:

```c
        if (!player->thr.run) {
345                int err;
346
347                player->thr.run = true;
348                err = pthread_create(&player->thr.tid, NULL,
349                        rx_thread, player);
   	4. Condition err, taking true branch.
350                if (err) {
351                        player->thr.run = false;

CID 331124 (#1 of 1): Missing unlock (LOCK)
5. missing_unlock: Returning without unlocking player->thr.mutex.
352                        return;
353                }
354        }
355
356        pthread_cond_signal(&player->thr.cond);
357        pthread_mutex_unlock(&player->thr.mutex);
```

@cHuberCoffee 