### PR TITLE
multicast,config: add separate jitter buffer configuration

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -297,6 +297,9 @@ video_selfview		window # {window,pip}
 # multicast receivers (in priority order)- port number must be even
 #multicast_call_prio	0
 #multicast_ttl		1
+#multicast_jbuf_type	fixed		# off, fixed, adaptive
+#multicast_jbuf_delay	5-10		# frames
+#multicast_jbuf_wish	6		# frames for start
 #multicast_listener	224.0.2.21:50000
 #multicast_listener	224.0.2.21:50002
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -246,6 +246,12 @@ int custom_hdrs_apply(const struct list *hdrs, custom_hdrs_h *h, void *arg);
  * Conf (utils)
  */
 
+/** A range of numbers */
+struct range {
+	uint32_t min;  /**< Minimum number */
+	uint32_t max;  /**< Maximum number */
+};
+
 
 /** Defines the configuration line handler */
 typedef int (confline_h)(const struct pl *addr, void *arg);
@@ -256,9 +262,12 @@ int  conf_modules(void);
 void conf_path_set(const char *path);
 int  conf_path_get(char *path, size_t sz);
 int  conf_parse(const char *filename, confline_h *ch, void *arg);
+int  conf_get_range(const struct conf *conf, const char *name,
+		    struct range *rng);
 int  conf_get_vidsz(const struct conf *conf, const char *name,
 		    struct vidsz *sz);
 int  conf_get_sa(const struct conf *conf, const char *name, struct sa *sa);
+enum jbuf_type conf_get_jbuf_type(const struct pl *pl);
 bool conf_fileexist(const char *path);
 void conf_close(void);
 struct conf *conf_cur(void);
@@ -267,12 +276,6 @@ struct conf *conf_cur(void);
 /*
  * Config (core configuration)
  */
-
-/** A range of numbers */
-struct range {
-	uint32_t min;  /**< Minimum number */
-	uint32_t max;  /**< Maximum number */
-};
 
 static inline bool in_range(const struct range *rng, uint32_t val)
 {

--- a/src/conf.c
+++ b/src/conf.c
@@ -325,6 +325,17 @@ int conf_get_float(const struct conf *conf, const char *name, double *val)
 }
 
 
+enum jbuf_type conf_get_jbuf_type(const struct pl *pl)
+{
+	if (0 == pl_strcasecmp(pl, "off"))      return JBUF_OFF;
+	if (0 == pl_strcasecmp(pl, "fixed"))    return JBUF_FIXED;
+	if (0 == pl_strcasecmp(pl, "adaptive")) return JBUF_ADAPTIVE;
+
+	warning("unsupported jitter buffer type (%r)\n", pl);
+	return JBUF_FIXED;
+}
+
+
 /**
  * Configure the system with default settings
  *

--- a/src/config.c
+++ b/src/config.c
@@ -236,17 +236,6 @@ static const char *jbuf_type_str(enum jbuf_type jbtype)
 }
 
 
-static enum jbuf_type resolve_jbuf_type(const struct pl *pl)
-{
-	if (0 == pl_strcasecmp(pl, "off"))      return JBUF_OFF;
-	if (0 == pl_strcasecmp(pl, "fixed"))    return JBUF_FIXED;
-	if (0 == pl_strcasecmp(pl, "adaptive")) return JBUF_ADAPTIVE;
-
-	warning("unsupported jitter buffer type (%r)\n", pl);
-	return JBUF_FIXED;
-}
-
-
 static void decode_sip_transports(struct config_sip *cfg,
 				      const struct pl *pl)
 {
@@ -439,7 +428,7 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 
 	(void)conf_get_bool(conf, "rtcp_mux", &cfg->avt.rtcp_mux);
 	if (0 == conf_get(conf, "jitter_buffer_type", &jbtype))
-		cfg->avt.jbtype = resolve_jbuf_type(&jbtype);
+		cfg->avt.jbtype = conf_get_jbuf_type(&jbtype);
 
 	(void)conf_get_range(conf, "jitter_buffer_delay",
 			     &cfg->avt.jbuf_del);
@@ -1205,6 +1194,10 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "- port number must be even\n"
 			 "#multicast_call_prio\t0\n"
 			 "#multicast_ttl\t1\n"
+			 "#multicast_jbuf_type\tfixed\t\t"
+				"# off, fixed, adaptive\n"
+			 "#multicast_jbuf_delay\t5-10\t\t# frames\n"
+			 "#multicast_jbuf_wish\t6\t\t# frames for start\n"
 			 "#multicast_listener\t224.0.2.21:50000\n"
 			 "#multicast_listener\t224.0.2.21:50002\n");
 

--- a/src/core.h
+++ b/src/core.h
@@ -138,8 +138,6 @@ int custom_hdrs_print(struct re_printf *pf,
  * Conf
  */
 
-int conf_get_range(const struct conf *conf, const char *name,
-		   struct range *rng);
 int conf_get_csv(const struct conf *conf, const char *name,
 		 char *str1, size_t sz1, char *str2, size_t sz2);
 int conf_get_float(const struct conf *conf, const char *name, double *val);


### PR DESCRIPTION
If multiple baresip instances which are in near range receive a multicast RTP
stream, it should be possible to adjust their playback latency to achieve a
simultaneous audio playback on all devices.

On the other hand the jitter buffer configuration for a SIP call should be
optimized to minimum latency.