### PR TITLE
core: move stream_enable_rtp_timeout to api

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1373,6 +1373,7 @@ void stream_set_session_handlers(struct stream *strm,
 				 stream_error_h *errorh, void *arg);
 const char *stream_name(const struct stream *strm);
 int  stream_debug(struct re_printf *pf, const struct stream *s);
+void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -287,7 +287,6 @@ int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 		 struct mbuf *mb);
 
 /* Receive */
-void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);
 void stream_flush_jbuf(struct stream *s);
 void stream_silence_on(struct stream *s, bool on);
 int  stream_decode(struct stream *s);


### PR DESCRIPTION
For RTP Connections like webrtc (module/app) its useful to make `stream_enable_rtp_timeout` available.