### PR TITLE
avcodec: remove old backwards compat wrapper

### DIFF
--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -5,11 +5,6 @@
  */
 
 
-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(52, 20, 100)
-#define av_frame_alloc avcodec_alloc_frame
-#endif
-
-
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 63, 100)
 #define avcodec_free_context(ctx)				\
 								\


### PR DESCRIPTION
supported ffmpeg:

FFmpeg 3.2.14 "Hypatia" or later