### PR TITLE
menu fix tones for parallel outgoing calls

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -179,7 +179,7 @@ struct call;
 typedef void (call_event_h)(struct call *call, enum call_event ev,
 			    const char *str, void *arg);
 typedef void (call_dtmf_h)(struct call *call, char key, void *arg);
-typedef bool (call_match_h)(const struct call *call);
+typedef bool (call_match_h)(const struct call *call, void *arg);
 typedef void (call_list_h)(struct call *call, void *arg);
 
 

--- a/src/uag.c
+++ b/src/uag.c
@@ -173,7 +173,7 @@ void uag_filter_calls(call_list_h *listh, call_match_h *matchh, void *arg)
 		for (lec = list_tail(ua_calls(ua)); lec; lec = lec->prev) {
 			struct call *call = lec->data;
 
-			if (!matchh || matchh(call))
+			if (!matchh || matchh(call, arg))
 				listh(call, arg);
 		}
 	}


### PR DESCRIPTION
- uag: add argument to call match handler for uag_filter_calls()
- menu: play ringback and error tone correctly for parallel call feature

    - If there are multiple outgoing calls and the peers all reject the calls, then
      the error tone only should be played if the last call was rejected.
    - When an outgoing call was rejected, the function menu_selcall() did not
      select another outgoing call.
