### PR TITLE
Fix static analyzer warnings

### DIFF
--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -343,8 +343,8 @@ static int config_pin(struct vidsrc_st *st, IPin *pin)
 	IAMStreamConfig *stream_conf = NULL;
 	VIDEOINFOHEADER *vih;
 	HRESULT hr;
-	int h = st->size.h;
-	int w = st->size.w;
+	int h;
+	int w;
 	int rh, rw;
 	int wh, rwrh;
 	int best_match = 0;
@@ -356,7 +356,8 @@ static int config_pin(struct vidsrc_st *st, IPin *pin)
 	hr = pin->EnumMediaTypes(&media_enum);
 	if (FAILED(hr))
 		return ENODATA;
-
+	h = st->size.h;
+	w = st->size.w;
 	while ((hr = media_enum->Next(1, &mt, NULL)) == S_OK) {
 		if (mt->formattype != FORMAT_VideoInfo)
 			continue;

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -397,7 +397,7 @@ static void clean_number(char *str)
 	 * In other cases trust the user input
 	 */
 	while (str[i]) {
-		if (isalpha(str[i] != 0))
+		if (isalpha(str[i]) != 0)
 			return;
 		else if (str[i] == '@')
 			return;

--- a/src/video.c
+++ b/src/video.c
@@ -1171,7 +1171,6 @@ int video_update(struct video *v, struct media_ctx **ctx, const char *peer)
  */
 int video_start_source(struct video *v, struct media_ctx **ctx)
 {
-	struct vtx *vtx = &v->vtx;
 	struct vidsz size;
 	int err;
 
@@ -1185,6 +1184,7 @@ int video_start_source(struct video *v, struct media_ctx **ctx)
 
 	if (vidsrc_find(baresip_vidsrcl(), NULL)) {
 
+		struct vtx* vtx = &v->vtx;
 		struct vidsrc *vs;
 
 		vs = (struct vidsrc *)vidsrc_find(baresip_vidsrcl(),


### PR DESCRIPTION
p.s. I would like to write tests for case with `clean_number `. 
How do you look at adding the ability to run tests in the visual studio?
And to simplify access to the `clean_number` method, it would be well to remove the static attribute from it, otherwise it is so difficult to call through `dial_handler`. 
if you agree, I will prepare a new PR, in which I will add a new visual studio project, only for running tests, and the new test itself.
