### PR TITLE
stream: RTP inbound telephone events should not lead to packet loss

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -254,7 +254,7 @@ struct rtp_header;
 
 enum {STREAM_PRESZ = 4+12}; /* same as RTP_HEADER_SIZE */
 
-typedef void (stream_rtp_h)(const struct rtp_header *hdr,
+typedef int (stream_rtp_h)(const struct rtp_header *hdr,
 			    struct rtpext *extv, size_t extc,
 			    struct mbuf *mb, unsigned lostc, void *arg);
 typedef int (stream_pt_h)(uint8_t pt, struct mbuf *mb, void *arg);

--- a/src/video.c
+++ b/src/video.c
@@ -794,7 +794,7 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 
 
 /* Handle incoming stream data from the network */
-static void stream_recv_handler(const struct rtp_header *hdr,
+static int stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc, void *arg)
 {
@@ -808,7 +808,7 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	if (lostc)
 		request_picture_update(&v->vrx);
 
-	(void)video_stream_decode(&v->vrx, hdr, mb);
+	return video_stream_decode(&v->vrx, hdr, mb);
 }
 
 


### PR DESCRIPTION
Telephone-event packets also increment the RTP sequence number and thus have to
be put into the jitter buffer. Otherwise missing packets are detected wrongly.
This leads to audio PLC (Packet loss concealment) or double playback of an
audio frame.
If a telephone event packet is read from jitter buffer, it has to be ignored
by reading a second packet. So the `stream_recv_handler()` needs a return
value which can be EAGAIN.
