### PR TITLE
call: added auto dtmf mode

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -15,7 +15,7 @@
 #    ;autelev_pt=101
 #    ;sip_autoanswer={yes, no}
 #    ;sip_autoanswer_beep={off, on, local}
-#    ;dtmfmode={rtpevent, info}
+#    ;dtmfmode={rtpevent, info, auto}
 #    ;auth_user=username
 #    ;auth_pass=password
 #    ;call_transfer=no

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -61,7 +61,8 @@ enum answermode {
 /** Defines the DTMF send type */
 enum dtmfmode {
 	DTMFMODE_RTP_EVENT = 0,
-	DTMFMODE_SIP_INFO
+	DTMFMODE_SIP_INFO,
+	DTMFMODE_AUTO
 };
 
 /** SIP auto answer beep modes */

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -57,7 +57,7 @@ static int account_write_template(const char *file)
 			 "#    ;audio_player=alsa,default\n"
 			 "#    ;sip_autoanswer={yes, no}\n"
 			 "#    ;sip_autoanswer_beep={off, on, local}\n"
-			 "#    ;dtmfmode={rtpevent, info}\n"
+			 "#    ;dtmfmode={rtpevent, info, auto}\n"
 			 "#    ;auth_user=username\n"
 			 "#    ;auth_pass=password\n"
 			 "#    ;call_transfer=no\n"

--- a/src/account.c
+++ b/src/account.c
@@ -280,6 +280,9 @@ static void dtmfmode_decode(struct account *prm, const struct pl *pl)
 		if (0 == pl_strcasecmp(&dtmfmode, "info")) {
 			prm->dtmfmode = DTMFMODE_SIP_INFO;
 		}
+		else if (0 == pl_strcasecmp(&dtmfmode, "auto")) {
+			prm->dtmfmode = DTMFMODE_AUTO;
+		}
 		else {
 			prm->dtmfmode = DTMFMODE_RTP_EVENT;
 		}
@@ -1249,7 +1252,9 @@ int account_set_dtmfmode(struct account *acc, enum dtmfmode mode)
 	if (!acc)
 		return EINVAL;
 
-	if ((mode != DTMFMODE_RTP_EVENT) && (mode != DTMFMODE_SIP_INFO)) {
+	if ((mode != DTMFMODE_RTP_EVENT) &&
+	    (mode != DTMFMODE_SIP_INFO) &&
+	    (mode != DTMFMODE_AUTO)) {
 		warning("account: invalid dtmfmode : `%d'\n", mode);
 		return EINVAL;
 	}
@@ -1543,6 +1548,7 @@ static const char *dtmfmode_str(enum dtmfmode mode)
 
 	case DTMFMODE_RTP_EVENT: return "rtpevent";
 	case DTMFMODE_SIP_INFO:  return "info";
+	case DTMFMODE_AUTO: 	 return "auto";
 	default: return "???";
 	}
 }

--- a/src/call.c
+++ b/src/call.c
@@ -1476,7 +1476,7 @@ int call_info(struct re_printf *pf, const struct call *call)
  */
 int call_send_digit(struct call *call, char key)
 {
-	int err;
+	int err = 0;
 	const struct sdp_format *fmt;
 	bool info = true;
 
@@ -1485,7 +1485,7 @@ int call_send_digit(struct call *call, char key)
 
 	switch (account_dtmfmode(call->acc)) {
 		case DTMFMODE_SIP_INFO:
-			info = key != KEYCODE_REL;
+			info = true;
 			break;
 		case DTMFMODE_AUTO:
 			fmt = sdp_media_rformat(
@@ -1500,7 +1500,9 @@ int call_send_digit(struct call *call, char key)
 	}
 
 	if (info) {
-		err = send_dtmf_info(call, key);
+		if (key != KEYCODE_REL) {
+			err = send_dtmf_info(call, key);
+		}
 	}
 	else {
 		err = audio_send_digit(call->audio, key);


### PR DESCRIPTION
Added new value DTMFMODE_AUTO to the dtmfmode enumeration.

If this value is selected, it is checked whether the remote station has a media typefor the "telephone-event" in the sdp description.
If not, then the DTMF digit is sent as a sip info message, otherwise as an RTP event.