### PR TITLE
net,uag: allow incoming peer-to-peer calls with user@domain

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -718,6 +718,7 @@ void net_set_rm_handler(struct network *net, net_ifaddr_h *ifh, void *arg);
 bool net_ifaddr_filter(const struct network *net, const char *ifname,
 		       const struct sa *sa);
 const struct sa *net_laddr_af(const struct network *net, int af);
+bool net_is_laddr(const struct network *net, struct sa *sa);
 struct dnsc     *net_dnsc(const struct network *net);
 
 

--- a/src/net.c
+++ b/src/net.c
@@ -680,6 +680,29 @@ const struct sa *net_laddr_af(const struct network *net, int af)
 }
 
 
+static bool laddr_cmp(struct le *le, void *arg)
+{
+	struct laddr *laddr = le->data;
+	struct sa *sa = arg;
+
+	return sa_cmp(&laddr->sa, sa, SA_ADDR);
+}
+
+
+/**
+ * Checks if given IP address is a local address.
+ *
+ * @param net Network instance
+ * @param sa  IP address to check
+ *
+ * @return true if sa is a local address, false if not
+ */
+bool net_is_laddr(const struct network *net, struct sa *sa)
+{
+	return NULL != list_apply(&net->laddrs, true, laddr_cmp, sa);
+}
+
+
 /**
  * Get the DNS Client
  *

--- a/src/uag.c
+++ b/src/uag.c
@@ -238,8 +238,6 @@ static bool uri_host_local(const struct uri *uri)
 		"127.0.0.1",
 		"::1"
 	};
-	int afv[2] = {AF_INET, AF_INET6};
-	const struct sa *sal;
 	struct sa sap;
 	size_t i;
 	int err;
@@ -253,17 +251,12 @@ static bool uri_host_local(const struct uri *uri)
 			return true;
 	}
 
-	for (i=0; i<ARRAY_SIZE(afv); i++) {
+	err = sa_set(&sap, &uri->host, 0);
+	if (err)
+		return true;
 
-		sal = net_laddr_af(baresip_network(), afv[i]);
-
-		err = sa_set(&sap, &uri->host, 0);
-		if (err)
-			continue;
-
-		if (sa_cmp(sal, &sap, SA_ADDR))
-			return true;
-	}
+	if (net_is_laddr(baresip_network(), &sap))
+		return true;
 
 	return false;
 }


### PR DESCRIPTION
Simplifies function `uri_host_local()` and add support for incoming
peer-to-peer calls with SIP URI user@domain.
