### PR TITLE
uag: exit if transport could not be added

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -512,10 +512,18 @@ static int  uag_transp_rm(const struct sa *laddr)
 static bool transp_add_laddr(const char *ifname, const struct sa *sa,
 			     void *arg)
 {
+	int err;
+	int *errp = arg;
 	(void) ifname;
-	(void) arg;
 
-	(void)uag_transp_add(sa);
+	err = uag_transp_add(sa);
+	if (err) {
+		if (errp)
+			*errp = err;
+
+		return true;
+	}
+
 	return false;
 }
 
@@ -535,7 +543,7 @@ static int ua_transp_addall(struct network *net)
 	int err = 0;
 	struct config_sip *cfg = &conf_config()->sip;
 
-	net_laddr_apply(net, transp_add_laddr, NULL);
+	net_laddr_apply(net, transp_add_laddr, &err);
 	sip_transp_set_default(uag.sip, cfg->transp);
 	return err;
 }


### PR DESCRIPTION
Behavior in error case like it was before the commit
```
commit b4fba202193ff4e7ef93578bd718c57a76c75756
Author: Christian Spielberger <c.spielberger@commend.com>
Date:   Wed Sep 1 11:29:08 2021 +0200

    move network check to module (#1584
```