### PR TITLE
mixausrc: no warnings flood when sampc changes

### DIFF
--- a/modules/mixausrc/mixausrc.c
+++ b/modules/mixausrc/mixausrc.c
@@ -482,6 +482,8 @@ static int process(struct mixstatus *st, struct auframe *af)
 		warning("mixausrc: sampc changed %lu --> %lu.\n",
 				st->sampc, n);
 		stop_ausrc(st);
+		st->nextmode = FM_FADEIN;
+		st->sampc = 0;
 		return EINVAL;
 	}
 


### PR DESCRIPTION
Fixes a lot of
```
mixausrc: sampc changed 160 --> 320.
mixausrc: sampc changed 160 --> 320.
mixausrc: sampc changed 160 --> 320.
mixausrc: sampc changed 160 --> 320.
mixausrc: sampc changed 160 --> 320.
```
in situations where the sample rate/codec changes.