### PR TITLE
start without network

### DIFF
--- a/src/baresip.c
+++ b/src/baresip.c
@@ -112,7 +112,7 @@ int baresip_init(struct config *cfg)
 	/* Initialise Network */
 	err = net_alloc(&baresip.net, &cfg->net);
 	if (err) {
-		warning("ua: network init failed: %m\n", err);
+		warning("baresip: network init failed: %m\n", err);
 		return err;
 	}
 

--- a/src/net.c
+++ b/src/net.c
@@ -400,15 +400,12 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 	}
 
 	net_if_apply(add_laddr_filter, net);
-	if (!list_count(&net->laddrs)) {
-		warning("net: %s: could not get network address\n",
-			cfg->ifname);
-		err = EADDRNOTAVAIL;
-	}
-	else {
-		info("Local network addresses:\n");
+	info("Local network addresses:\n");
+	if (!list_count(&net->laddrs))
+		warning("  None for net_interface: %s\n",
+				str_isset(cfg->ifname) ? cfg->ifname : "-");
+	else
 		net_laddr_apply(net, print_addr, NULL);
-	}
 
 	(void)dns_srv_get(NULL, 0, nsv, &nsn);
 


### PR DESCRIPTION
Allows baresip to start without any network interface/local IP.

Instead only prints a warning.

The network addresses can be added later.