### PR TITLE
multicast: allow any port number for sender and receiver

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -44,11 +44,9 @@ static int decode_addr(struct pl *pladdr, struct sa *addr)
 		warning ("multicast: address decode (%m)\n", err);
 
 
-	if (sa_port(addr) % 2) {
-		err = EINVAL;
+	if (sa_port(addr) % 2)
 		warning("multicast: address port for RTP should be even"
 			" (%d)\n" , sa_port(addr));
-	}
 
 	return err;
 }


### PR DESCRIPTION
* Allow any port number for any multicast direction
* Warn the user about an odd port number
* The implementation uses a plain UDP socket
* The payload of the UDP package gets fixed decoded as RTP package