### PR TITLE
net dns srv get

### DIFF
--- a/modules/netroam/netroam.c
+++ b/modules/netroam/netroam.c
@@ -87,7 +87,9 @@ static void poll_changes(void *arg)
 {
 	struct netroam *n = arg;
 	bool changed = false;
-	net_dns_refresh(baresip_network());
+
+	if (!n->cfg->nsc)
+		net_dns_refresh(baresip_network());
 
 	/* was a local IP added? */
 	sa_init(&n->laddr, AF_UNSPEC);

--- a/src/net.c
+++ b/src/net.c
@@ -341,8 +341,6 @@ static bool print_addr(const char *ifname, const struct sa *sa, void *arg)
 int net_alloc(struct network **netp, const struct config_net *cfg)
 {
 	struct network *net;
-	struct sa nsv[NET_MAX_NS];
-	uint32_t nsn = ARRAY_SIZE(nsv);
 	int err;
 
 	if (!netp || !cfg)
@@ -412,8 +410,6 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 				str_isset(cfg->ifname) ? cfg->ifname : "-");
 	else
 		net_laddr_apply(net, print_addr, NULL);
-
-	(void)dns_srv_get(NULL, 0, nsv, &nsn);
 
  out:
 	if (err)

--- a/src/net.c
+++ b/src/net.c
@@ -81,11 +81,6 @@ static int net_dns_srv_get(const struct network *net,
 	uint32_t limit = *n;
 	int err;
 
-	err = dns_srv_get(NULL, 0, nsv, &nsn);
-	if (err) {
-		nsn = 0;
-	}
-
 	if (net->nsn) {
 
 		if (net->nsn > limit)
@@ -102,6 +97,10 @@ static int net_dns_srv_get(const struct network *net,
 			*from_sys = false;
 	}
 	else {
+		err = dns_srv_get(NULL, 0, nsv, &nsn);
+		if (err)
+			nsn = 0;
+
 		if (nsn > limit)
 			return E2BIG;
 


### PR DESCRIPTION
Only query local DNS settings if necessary.

In Android function `dns_srv_get()` does not work according to @juha-h. If DNS was configured with `dns_server`, then this function needs not be called.

Another check for `config_net->nsc` in module `netroam` is not really need. Should we add it anyway?
```c
static void poll_changes(void *arg)
{
...
if (!cfg->nsc)
    net_dns_refresh(baresip_network());
...
```
