### PR TITLE
remove uag transp rm (#1611)

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -705,6 +705,8 @@ int  net_use_nameserver(struct network *net,
 			const struct sa *srvv, size_t srvc);
 int  net_set_address(struct network *net, const struct sa *ip);
 int  net_add_address(struct network *net, const struct sa *ip);
+int  net_add_address_ifname(struct network *net, const struct sa *sa,
+			    const char *ifname);
 int  net_flush_addresses(struct network *net);
 int  net_rm_address(struct network *net, const struct sa *ip);
 bool net_af_enabled(const struct network *net, int af);
@@ -713,8 +715,6 @@ void net_dns_refresh(struct network *net);
 int  net_dns_debug(struct re_printf *pf, const struct network *net);
 int  net_debug(struct re_printf *pf, const struct network *net);
 bool net_laddr_apply(const struct network *net, net_ifaddr_h *ifh, void *arg);
-void net_set_add_handler(struct network *net, net_ifaddr_h *ifh, void *arg);
-void net_set_rm_handler(struct network *net, net_ifaddr_h *ifh, void *arg);
 bool net_ifaddr_filter(const struct network *net, const char *ifname,
 		       const struct sa *sa);
 const struct sa *net_laddr_af(const struct network *net, int af);

--- a/modules/netroam/netroam.c
+++ b/modules/netroam/netroam.c
@@ -28,6 +28,7 @@ struct netroam {
 	uint32_t interval;
 	struct tmr tmr;
 	struct sa laddr;
+	bool reset;
 };
 
 
@@ -123,12 +124,19 @@ static void poll_changes(void *arg)
 		changed = true;
 	}
 
-	if (n->interval)
-		tmr_start(&n->tmr, changed ? 1000 : n->interval * 1000,
-			  poll_changes, n);
-
-	if (changed)
+	if (n->reset) {
+		uag_reset_transp(true, true);
+		n->reset = false;
 		print_changes(n);
+	}
+
+	if (changed) {
+		n->reset = true;
+		tmr_start(&n->tmr, 1000, poll_changes, n);
+	}
+	else if (n->interval) {
+		tmr_start(&n->tmr, n->interval * 1000, poll_changes, n);
+	}
 }
 
 

--- a/src/net.c
+++ b/src/net.c
@@ -407,7 +407,9 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 		goto out;
 	}
 
+#if !defined(ANDROID)
 	net_if_apply(add_laddr_filter, net);
+#endif
 	info("Local network addresses:\n");
 	if (!list_count(&net->laddrs))
 		warning("  None for net_interface: %s\n",
@@ -735,8 +737,10 @@ int net_debug(struct re_printf *pf, const struct network *net)
 	err |= re_hprintf(pf, "enabled interfaces:\n");
 	net_laddr_apply(net, if_debug_handler, argv);
 
+#if !defined(ANDROID)
 	err |= re_hprintf(pf, "network interfaces:\n");
 	err |= net_if_apply( if_debug_handler, argv);
+#endif
 
 	err |= net_dns_debug(pf, net);
 

--- a/src/net.c
+++ b/src/net.c
@@ -412,7 +412,7 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 #endif
 	info("Local network addresses:\n");
 	if (!list_count(&net->laddrs))
-		warning("  None for net_interface: %s\n",
+		info("  None for net_interface: %s\n",
 				str_isset(cfg->ifname) ? cfg->ifname : "-");
 	else
 		net_laddr_apply(net, print_addr, NULL);

--- a/src/net.c
+++ b/src/net.c
@@ -412,7 +412,7 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 #endif
 	info("Local network addresses:\n");
 	if (!list_count(&net->laddrs))
-		info("  None for net_interface: %s\n",
+		info("  None available for net_interface: %s\n",
 				str_isset(cfg->ifname) ? cfg->ifname : "-");
 	else
 		net_laddr_apply(net, print_addr, NULL);

--- a/src/net.c
+++ b/src/net.c
@@ -737,11 +737,6 @@ int net_debug(struct re_printf *pf, const struct network *net)
 	err |= re_hprintf(pf, "enabled interfaces:\n");
 	net_laddr_apply(net, if_debug_handler, argv);
 
-#if !defined(ANDROID)
-	err |= re_hprintf(pf, "network interfaces:\n");
-	err |= net_if_apply( if_debug_handler, argv);
-#endif
-
 	err |= net_dns_debug(pf, net);
 
 	return err;

--- a/src/net.c
+++ b/src/net.c
@@ -407,9 +407,7 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 		goto out;
 	}
 
-#if !defined(ANDROID)
 	net_if_apply(add_laddr_filter, net);
-#endif
 	info("Local network addresses:\n");
 	if (!list_count(&net->laddrs))
 		info("  None available for net_interface: %s\n",

--- a/src/net.c
+++ b/src/net.c
@@ -17,11 +17,6 @@ struct network {
 	uint32_t nsn;        /**< Number of configured name servers      */
 	struct sa nsvf[NET_MAX_NS];/**< Configured fallback name servers */
 	uint32_t nsnf;       /**< Number of configured fallback name servers */
-
-	net_ifaddr_h *addh;  /**< Local address added handler            */
-	void *addh_arg;
-	net_ifaddr_h *rmh;   /**< Local address removed handler          */
-	void *rmh_arg;
 };
 
 
@@ -202,8 +197,16 @@ static bool check_ipv6(void)
 }
 
 
-static int net_add_laddr(struct network *net, const char *ifname,
-			 const struct sa *sa)
+/**
+ * Add a local IP address with given interface name
+ *
+ * @param net  Network instance
+ * @param ip   IP address
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int  net_add_address_ifname(struct network *net, const struct sa *sa,
+			    const char *ifname)
 {
 	struct le *le;
 	struct laddr *laddr;
@@ -228,8 +231,6 @@ static int net_add_laddr(struct network *net, const char *ifname,
 		goto out;
 
 	list_append(&net->laddrs, &laddr->le, laddr);
-	if (net->addh)
-		net->addh(laddr->ifname, &laddr->sa, net->addh_arg);
 
 out:
 	if (err)
@@ -247,7 +248,7 @@ static bool add_laddr_filter(const char *ifname, const struct sa *sa,
 	if (!net_ifaddr_filter(net, ifname, sa))
 		return false;
 
-	(void)net_add_laddr(net, ifname, sa);
+	(void)net_add_address_ifname(net, sa, ifname);
 	return false;
 }
 
@@ -499,7 +500,7 @@ int net_add_address(struct network *net, const struct sa *ip)
 	if (err)
 		goto out;
 
-	err = net_add_laddr(net, ifname, ip);
+	err = net_add_address_ifname(net, ip, ifname);
 
 out:
 	return err;
@@ -523,9 +524,6 @@ int net_rm_address(struct network *net, const struct sa *ip)
 	LIST_FOREACH(&net->laddrs, le) {
 		struct laddr *laddr = le->data;
 		if (sa_cmp(&laddr->sa, ip, SA_ADDR)) {
-			if (net->rmh)
-				net->rmh(laddr->ifname, &laddr->sa,
-					 net->rmh_arg);
 			mem_deref(laddr);
 			break;
 		}
@@ -552,33 +550,11 @@ int net_flush_addresses(struct network *net)
 	while (le) {
 		struct laddr *laddr = le->data;
 		le = le->next;
-		if (net->rmh)
-			net->rmh(laddr->ifname, &laddr->sa, net->rmh_arg);
 
 		mem_deref(laddr);
 	}
 
 	return 0;
-}
-
-
-void net_set_add_handler(struct network *net, net_ifaddr_h *ifh, void *arg)
-{
-	if (!net)
-		return;
-
-	net->addh = ifh;
-	net->addh_arg = arg;
-}
-
-
-void net_set_rm_handler(struct network *net, net_ifaddr_h *ifh, void *arg)
-{
-	if (!net)
-		return;
-
-	net->rmh = ifh;
-	net->rmh_arg = arg;
 }
 
 


### PR DESCRIPTION
net,uag: remove differential uag transport changes (#1611)
    
- removes the `uag_transp_rm()` and re-registration/re-invite from `net_rm_address()`
- adds function `net_add_address_ifname()`
- `net_add_address()`, `net_rm_address()` will not call `uag_transp_add()`, `uag_transp_rm()`
    
Instead `uag_reset_transp()` has to be called by the application/netroam module after one or several calls to `net_rm_address()`, `net_add_address()` or `net_add_address_ifname()`.

Previously we wanted to send only re-register for UAs for which we know that the local IP address changed. But what we didn't think about, that also the default route may change if an interface is added. Thus it is best to send re-register/re-invite for all UAs when the network changes.
