### PR TITLE
move calls to stream_start_rtcp to call.c

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -342,7 +342,14 @@ static int update_media(struct call *call)
 
 	/* Update each stream */
 	FOREACH_STREAM {
-		stream_update(le->data);
+		struct stream *strm = le->data;
+
+		stream_update(strm);
+
+		if (stream_is_ready(strm)) {
+
+			stream_start_rtcp(strm);
+		}
 	}
 
 	if (call->acc->mnat && call->acc->mnat->updateh && call->mnats)
@@ -528,6 +535,8 @@ static void stream_mnatconn_handler(struct stream *strm, void *arg)
 		}
 	}
 	else if (stream_is_ready(strm)) {
+
+		stream_start_rtcp(strm);
 
 		switch (stream_type(strm)) {
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -610,11 +610,6 @@ static void mnat_connected_handler(const struct sa *raddr1,
 		update_all_remote_addr(strm->le.list, raddr1);
 	}
 
-	if (stream_is_ready(strm)) {
-
-		stream_start_rtcp(strm);
-	}
-
 	if (strm->mnatconnh)
 		strm->mnatconnh(strm, strm->sess_arg);
 
@@ -969,10 +964,6 @@ static void stream_remote_set(struct stream *s)
 	}
 
 
-	if (stream_is_ready(s)) {
-
-		stream_start_rtcp(s);
-	}
 }
 
 


### PR DESCRIPTION
this PR has no functional changes.

move calling stream_start_rtcp from stream.c to the user of stream.c (call.c).
this is just for best current practice, functions declared in a class should not be
called from within the class, but from the user of the class.