### PR TITLE
New module providing webrtc aec mobile mode filter

### DIFF
--- a/modules/webrtc_aecm/aec.cpp
+++ b/modules/webrtc_aecm/aec.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file aec.cpp  WebRTC Acoustic Echo Cancellation (AEC) Mobile Mode
+ *
+ * Copyright (C) 2010 Alfred E. Heggestad
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+#include "aec.h"
+
+
+/**
+ * @defgroup webrtc_aec webrtc_aecm
+ *
+ * Acoustic Echo Cancellation (AEC) Mobile Mode using WebRTC SDK.
+ *
+ * Reference:
+ *
+ *     https://webrtc.org/native-code/
+ */
+
+
+using namespace webrtc;
+
+
+static void aec_destructor(void *arg)
+{
+	struct aec *st = (struct aec *)arg;
+
+	if (st->inst)
+		WebRtcAecm_Free(st->inst);
+}
+
+
+int webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
+{
+	struct conf *conf = conf_cur();
+	struct aec *aec;
+	int err = 0;
+	int r;
+
+	if (!stp || !ctx || !prm)
+		return EINVAL;
+
+	if (prm->ch > MAX_CHANNELS) {
+		warning("webrtc_aecm: unsupported channels (%u > %u)\n",
+			prm->ch, MAX_CHANNELS);
+		return ENOTSUP;
+	}
+
+	if (*ctx) {
+		aec = (struct aec *)*ctx;
+
+		if (prm->srate != aec->srate) {
+
+			warning("webrtc_aecm: srate mismatch\n");
+			return ENOTSUP;
+		}
+
+		*stp = (struct aec *)mem_ref(*ctx);
+		return 0;
+	}
+
+	aec = (struct aec *)mem_zalloc(sizeof(*aec), aec_destructor);
+	if (!aec)
+		return ENOMEM;
+
+	aec->srate = prm->srate;
+
+	pthread_mutex_init(&aec->mutex, NULL);
+
+	if (prm->srate > 8000)
+		aec->subframe_len = 160;
+	else
+		aec->subframe_len = 80;
+
+	if (prm->srate > 16000)
+		aec->num_bands = prm->srate / 16000;
+	else
+		aec->num_bands = 1;
+
+	info("webrtc_aecm: creating shared state:"
+	     " [%u Hz, %u channels, subframe %u samples, num_bands %d]\n",
+	     prm->srate, prm->ch, aec->subframe_len, aec->num_bands);
+
+	aec->inst = WebRtcAecm_Create();
+	if (!aec->inst) {
+		err = ENODEV;
+		goto out;
+	}
+
+	r = WebRtcAecm_Init(aec->inst, prm->srate);
+	if (r != 0) {
+		err = ENODEV;
+		goto out;
+	}
+
+	aec->config.cngMode       = AecmTrue;
+	aec->config.echoMode      = 3;
+
+	/* Sets local configuration modes. */
+	r = WebRtcAecm_set_config(aec->inst, aec->config);
+	if (r != 0) {
+		err = ENODEV;
+		goto out;
+	}
+
+ out:
+	if (err)
+		mem_deref(aec);
+	else {
+		*stp = aec;
+		*ctx = aec;
+	}
+
+	return err;
+}
+
+
+static struct aufilt webrtc_aec = {
+	.le      = LE_INIT,
+	.name    = "webrtc_aecm",
+	.encupdh = webrtc_aec_encode_update,
+	.ench    = webrtc_aec_encode,
+	.decupdh = webrtc_aec_decode_update,
+	.dech    = webrtc_aec_decode
+};
+
+
+static int module_init(void)
+{
+	aufilt_register(baresip_aufiltl(), &webrtc_aec);
+	return 0;
+}
+
+
+static int module_close(void)
+{
+	aufilt_unregister(&webrtc_aec);
+	return 0;
+}
+
+
+extern "C" const struct mod_export DECL_EXPORTS(webrtc_aecm) = {
+	"webrtc_aecm",
+	"aufilt",
+	module_init,
+	module_close
+};

--- a/modules/webrtc_aecm/aec.h
+++ b/modules/webrtc_aecm/aec.h
@@ -1,0 +1,47 @@
+/**
+ * @file aec.h  WebRTC Acoustic Echo Cancellation (AEC) -- internal API
+ *
+ * Copyright (C) 2010 Alfred E. Heggestad
+ */
+
+
+#include <pthread.h>
+#include "modules/audio_processing/aecm/echo_control_mobile.h"
+
+
+#define MAX_CHANNELS         1
+
+
+using namespace webrtc;
+
+
+struct aec {
+	AecmConfig config;
+	void *inst;
+	pthread_mutex_t mutex;
+	uint32_t srate;
+	uint32_t subframe_len;
+	int num_bands;
+};
+
+
+/* Encoder */
+
+int webrtc_aec_encode_update(struct aufilt_enc_st **stp, void **ctx,
+			     const struct aufilt *af, struct aufilt_prm *prm,
+			     const struct audio *au);
+int webrtc_aec_encode(struct aufilt_enc_st *st, struct auframe *af);
+
+
+/* Decoder */
+
+int webrtc_aec_decode_update(struct aufilt_dec_st **stp, void **ctx,
+			     const struct aufilt *af, struct aufilt_prm *prm,
+			     const struct audio *au);
+int webrtc_aec_decode(struct aufilt_dec_st *st, struct auframe *af);
+
+
+/* Common */
+
+int  webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm);
+void webrtc_aec_debug(const struct aec *aec);

--- a/modules/webrtc_aecm/decode.cpp
+++ b/modules/webrtc_aecm/decode.cpp
@@ -1,0 +1,136 @@
+/**
+ * @file decode.cpp  WebRTC Acoustic Echo Cancellation (AEC) -- Decode
+ *
+ * Copyright (C) 2010 Alfred E. Heggestad
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+#include "aec.h"
+
+
+struct aec_dec {
+	struct aufilt_dec_st af;  /* inheritance */
+
+	struct aec *aec;
+};
+
+
+static void dec_destructor(void *arg)
+{
+	struct aec_dec *st = (struct aec_dec *)arg;
+
+	list_unlink(&st->af.le);
+	mem_deref(st->aec);
+}
+
+
+int webrtc_aec_decode_update(struct aufilt_dec_st **stp, void **ctx,
+			     const struct aufilt *af, struct aufilt_prm *prm,
+			     const struct audio *au)
+{
+	struct aec_dec *st;
+	int err;
+
+	if (!stp || !af || !prm)
+		return EINVAL;
+
+	switch (prm->fmt) {
+
+	case AUFMT_S16LE:
+	case AUFMT_FLOAT:
+		break;
+
+	default:
+		warning("webrtc_aecm: dec: unsupported sample format (%s)\n",
+			aufmt_name((enum aufmt)prm->fmt));
+		return ENOTSUP;
+	}
+
+	if (*stp)
+		return 0;
+
+	st = (struct aec_dec *)mem_zalloc(sizeof(*st), dec_destructor);
+	if (!st)
+		return ENOMEM;
+
+	err = webrtc_aec_alloc(&st->aec, ctx, prm);
+	if (err)
+		goto out;
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = (struct aufilt_dec_st *)st;
+
+	return err;
+}
+
+
+static int decode_s16(struct aec_dec *dec, const int16_t *sampv, size_t sampc)
+{
+	struct aec *aec = dec->aec;
+	const int16_t *farend = sampv;
+	size_t i;
+	int r;
+	int err = 0;
+
+	pthread_mutex_lock(&aec->mutex);
+
+	for (i = 0; i < sampc; i += aec->subframe_len) {
+
+		r = WebRtcAecm_BufferFarend(aec->inst, farend + i,
+					    aec->subframe_len);
+		if (r != 0) {
+			warning("webrtc_aecm: decode: WebRtcAecm_BufferFarend"
+				" error (%d)\n", r);
+			err = EPROTO;
+			goto out;
+		}
+	}
+
+ out:
+	pthread_mutex_unlock(&aec->mutex);
+
+	return err;
+}
+
+
+int webrtc_aec_decode(struct aufilt_dec_st *st, struct auframe *af)
+{
+	struct aec_dec *dec = (struct aec_dec *)st;
+	int16_t *s16;
+	int err = 0;
+
+	if (!st || !af)
+		return EINVAL;
+
+	/* convert samples to float if needed */
+	switch (af->fmt) {
+
+	case AUFMT_S16LE:
+		err = decode_s16(dec, (int16_t *)af->sampv, af->sampc);
+		break;
+
+	case AUFMT_FLOAT:
+		s16 = (int16_t *)mem_alloc(af->sampc * sizeof(int16_t), NULL);
+		if (!s16)
+			return ENOMEM;
+
+		auconv_to_s16(s16, AUFMT_FLOAT,	(float *)af->sampv,
+			      af->sampc);
+		err = decode_s16(dec, s16, af->sampc);
+		mem_deref(s16);
+		break;
+
+	default:
+		return ENOTSUP;
+	}
+
+	return err;
+}

--- a/modules/webrtc_aecm/encode.cpp
+++ b/modules/webrtc_aecm/encode.cpp
@@ -1,0 +1,158 @@
+/**
+ * @file encode.cpp  WebRTC Acoustic Echo Cancellation (AEC) -- Encode
+ *
+ * Copyright (C) 2010 Alfred E. Heggestad
+ */
+
+#include <string.h>
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#ifdef HAVE_PTHREAD
+#include <pthread.h>
+#endif
+#include "aec.h"
+
+
+#define SOUND_CARD_BUF 20
+
+
+struct aec_enc {
+	struct aufilt_enc_st af;  /* inheritance */
+
+	struct aec *aec;
+	float buf[160];
+};
+
+
+static void enc_destructor(void *arg)
+{
+	struct aec_enc *st = (struct aec_enc *)arg;
+
+	list_unlink(&st->af.le);
+	mem_deref(st->aec);
+}
+
+
+int webrtc_aec_encode_update(struct aufilt_enc_st **stp, void **ctx,
+			     const struct aufilt *af, struct aufilt_prm *prm,
+			     const struct audio *au)
+{
+	struct aec_enc *st;
+	int err;
+
+	if (!stp || !af || !prm)
+		return EINVAL;
+
+	switch (prm->fmt) {
+
+	case AUFMT_S16LE:
+	case AUFMT_FLOAT:
+		break;
+
+	default:
+		warning("webrtc_aecm: enc: unsupported sample format (%s)\n",
+			aufmt_name((enum aufmt)prm->fmt));
+		return ENOTSUP;
+	}
+
+	if (*stp)
+		return 0;
+
+	st = (struct aec_enc *)mem_zalloc(sizeof(*st), enc_destructor);
+	if (!st)
+		return ENOMEM;
+
+	err = webrtc_aec_alloc(&st->aec, ctx, prm);
+	if (err)
+		goto out;
+
+ out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = (struct aufilt_enc_st *)st;
+
+	return err;
+}
+
+
+static int encode_s16(struct aec_enc *enc, int16_t *sampv, size_t sampc)
+{
+	struct aec *aec = enc->aec;
+	const int16_t *nearend = (const int16_t *)sampv;
+	const int16_t *in;
+	int16_t *out;
+	int16_t *rec = (int16_t *)sampv;
+	size_t i;
+	int r;
+	int err = 0;
+
+	pthread_mutex_lock(&aec->mutex);
+
+	for (i = 0; i < sampc; i += aec->subframe_len) {
+
+		in  = &nearend[i];
+		/* is this cast OK? */
+		out = (int16_t *)(&enc->buf[0]);
+
+		r = WebRtcAecm_Process(aec->inst, in, NULL, out,
+				       aec->subframe_len,
+				       SOUND_CARD_BUF);
+		if (r != 0) {
+			warning("webrtc_aecm: encode:"
+				" WebRtcAecm_Process error (%d)\n",
+				r);
+			err = EPROTO;
+			goto out;
+		}
+
+		memcpy(&rec[i], out, aec->subframe_len * sizeof(int16_t));
+	}
+
+ out:
+	pthread_mutex_unlock(&aec->mutex);
+
+	return err;
+}
+
+
+int webrtc_aec_encode(struct aufilt_enc_st *st, struct auframe *af)
+{
+	struct aec_enc *enc = (struct aec_enc *)st;
+	int16_t *s16;
+	int err = 0;
+
+	if (!st || !af)
+		return EINVAL;
+
+	switch (af->fmt) {
+
+	case AUFMT_S16LE:
+	        err = encode_s16(enc, (int16_t *)af->sampv, af->sampc);
+		break;
+
+	case AUFMT_FLOAT:
+		/* convert from FLOAT to S16 */
+		s16 = (int16_t *)mem_alloc(af->sampc * sizeof(int16_t), NULL);
+		if (!s16)
+			return ENOMEM;
+
+		auconv_to_s16(s16, AUFMT_FLOAT, (float *)af->sampv, af->sampc);
+
+		/* process */
+		err = encode_s16(enc, s16, af->sampc);
+
+		/* convert from S16 to FLOAT */
+		auconv_from_s16(AUFMT_FLOAT, (float *)af->sampv,
+				s16, af->sampc);
+
+		mem_deref(s16);
+		break;
+
+	default:
+		return ENOTSUP;
+	}
+
+	return err;
+}

--- a/modules/webrtc_aecm/module.mk
+++ b/modules/webrtc_aecm/module.mk
@@ -1,0 +1,25 @@
+#
+# module.mk
+#
+# Copyright (C) 2010 Alfred E. Heggestad
+#
+
+
+WEBRTC_PATH	:= ../webrtc_sdk
+
+
+MOD		:= webrtc_aecm
+
+$(MOD)_SRCS	+= aec.cpp
+$(MOD)_SRCS	+= encode.cpp
+$(MOD)_SRCS	+= decode.cpp
+
+CPPFLAGS	+= -isystem $(WEBRTC_PATH)/include
+
+$(MOD)_LFLAGS	+= \
+	-L$(WEBRTC_PATH)/lib/x64/Debug \
+	-lwebrtc_full \
+	-lstdc++
+
+
+include mk/mod.mk


### PR DESCRIPTION
In my tests, aec mobile mode filtering is used in calls and baresip does not crash, but I don't know if there is any difference in call quality as compared to webrtc_aec module.

WebRtcAecm API calls don't take same arguments  as WebRtcAec calls,  The main difference is that WebRtcAecm API calls take sound bytes as int16_t when WebRtcAecm API them as float.

Review and other comments are appreciated.
