### PR TITLE
menu: add an event for call transfer

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -655,6 +655,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 				warning("ua: transfer: connect error: %m\n",
 					err);
 			}
+			else {
+				module_event("menu", "transfer", ua, call,
+					     "target %s", call_id(call2));
+			}
 		}
 
 		if (err) {


### PR DESCRIPTION
This allows an application to match the involved calls in a call transfer.
call 1 is the call to the transfer initiator.
call 2 is the call to the transfer target.
The CALL_TRANSFER event that is currently available does not contain the call-
id of the target call. And it is not possible to add this call-id to the
TRANSFER event because module menu invokes the call to the target as reaction
on this event.