### PR TITLE
mk: use CC_TEST for auto detect modules

### DIFF
--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -70,10 +70,11 @@ ifneq ($(OS),win32)
 
 USE_AAC       := $(shell $(call CC_TEST,fdk-aac/FDK_audio.h))
 USE_ALSA      := $(shell $(call CC_TEST,alsa/asoundlib.h))
-USE_AMR       := $(shell $(call CC_TEST,opencore-amrnb/interf_dec.h))
-ifeq ($(USE_AMR),)
-USE_AMR       := $(shell $(call CC_TEST,opencore-amrwb/dec_if.h))
-endif
+USE_AMR       := $(shell [ -d $(SYSROOT)/include/opencore-amrnb ] || \
+	[ -d $(SYSROOT_LOCAL)/include/opencore-amrnb ] || \
+	[ -d $(SYSROOT_ALT)/include/opencore-amrnb ] || \
+	[ -d $(SYSROOT)/local/include/amrnb ] || \
+	[ -d $(SYSROOT)/include/amrnb ] && echo "yes")
 USE_APTX      := $(shell $(call CC_TEST,openaptx.h))
 USE_AV1       := $(shell $(call CC_TEST,aom/aom.h))
 USE_AVCODEC   := $(shell $(call CC_TEST,libavcodec/avcodec.h))


### PR DESCRIPTION
This PR uses the new CC_TEST to detect headers. It uses the compiler with CFLAGS and EXTRA_CFLAGS with a real include check. Recognized headers are cached in ".cache/baresip/cc_test/...". (cleaned up by `make clean`). Unrecognized headers are not cached.

Inspired by debian patches: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911358