### PR TITLE
stream: split up sender/receiver

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -277,6 +277,8 @@ enum media_type {
 	MEDIA_VIDEO,
 };
 
+struct sender;
+struct receiver;
 struct stream;
 struct rtp_header;
 


### PR DESCRIPTION
propsals for naming the sender/receiver structs:

1. struct sender
2. struct rtp_sender
3. struct rtpsender

same with "receiver".

Please chime in with your preference...