### PR TITLE
serreg fix fallback accounts

### DIFF
--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -40,7 +40,6 @@ enum {
 
 static struct {
 	uint32_t prio;            /**< Current account prio           */
-	bool registered;          /**< Currently registered flag      */
 	uint32_t maxprio;         /**< Maximum account prio           */
 	bool ready;               /**< All UA registered flag         */
 	uint32_t sprio;           /**< Prev successful prio           */
@@ -229,7 +228,7 @@ static void fallback_ok(struct ua *ua)
 
 	debug("serreg: fallback prio %u ok %s.\n", prio, account_aor(acc));
 
-	if (prio <= sreg.prio || !sreg.registered) {
+	if (prio <= sreg.prio) {
 		info("serreg: Fallback %s ok -> prio %u.\n",
 		     account_aor(acc), prio);
 		sreg.prio = prio;
@@ -323,7 +322,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_REGISTER_OK:
-		sreg.registered = true;
 		sreg.prio = account_prio(ua_account(ua));
 		check_registrations();
 		sreg.sprio = sreg.prio;
@@ -331,7 +329,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_REGISTER_FAIL:
 		/* did we already increment? */
-		sreg.registered = false;
 		if (account_prio(ua_account(ua)) != sreg.prio)
 			break;
 

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -328,10 +328,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		break;
 
 	case UA_EVENT_REGISTER_FAIL:
-		/* did we already increment? */
-		if (account_prio(ua_account(ua)) != sreg.prio)
-			break;
-
 		next_account(ua);
 		if (account_fbregint(ua_account(ua)))
 			(void)ua_fallback(ua);

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -249,7 +249,6 @@ static void restart(void *arg)
 	struct le *le;
 	(void) arg;
 
-	sreg.prio = 0;
 	sreg.sprio = (uint32_t) -1;
 	for (le = list_head(uag_list()); le; le = le->next) {
 		struct ua *ua = le->data;
@@ -266,6 +265,7 @@ static void restart(void *arg)
 			continue;
 
 		debug("serreg: restart %s prio 0.\n", account_aor(acc));
+		sreg.prio = 0;
 		err = ua_register(ua);
 		if (err) {
 			tmr_start(&sreg.tmr, failwait(++sreg.failc),

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -200,9 +200,6 @@ static void next_account(struct ua *ua)
 {
 	uint32_t prio = sreg.prio;
 
-	if (sreg.sprio == (uint32_t) -1)
-		sreg.sprio = prio;
-
 	while (check_registrations()) {
 		inc_account_prio();
 
@@ -222,6 +219,9 @@ static void next_account(struct ua *ua)
 			sreg.prio = (uint32_t) -1;
 			break;
 		}
+
+		if (prio == (uint32_t) -1)
+			prio = sreg.prio;
 	}
 }
 

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -117,6 +117,7 @@ static bool check_registrations(void)
 static int register_curprio(void)
 {
 	int err = EINVAL;
+	int erc;
 	struct le *le;
 	for (le = list_head(uag_list()); le; le = le->next) {
 		struct ua *ua = le->data;
@@ -133,8 +134,12 @@ static int register_curprio(void)
 			continue;
 		}
 
-		if (!fbregint || !ua_regfailed(ua))
-			err = ua_register(ua);
+		if (!fbregint || !ua_regfailed(ua)) {
+			erc = ua_register(ua);
+
+			if (err)
+				err = erc;
+		}
 	}
 
 	return err;


### PR DESCRIPTION
This fixes a lot of fast switches between primary/secondary SIP server (REGISTER and de-REGISTER) if `fbregint` was set for the accounts (Cisco Mode).

We tested this and the issue of the reverted commit.
We made
- manual tests against baresip
- automated tests against baresip
- manual tests in two products
and used two Cisco Call Manager as SIP servers. But the issue also could arise on other SIP servers.