### PR TITLE
alsa: use snd_pcm_drop instead of snd_pcm_drain

### DIFF
--- a/modules/alsa/alsa_play.c
+++ b/modules/alsa/alsa_play.c
@@ -38,7 +38,6 @@ static void auplay_destructor(void *arg)
 	if (st->run) {
 		debug("alsa: stopping playback thread (%s)\n", st->device);
 		st->run = false;
-		snd_pcm_drop(st->write);
 		(void)pthread_join(st->thread, NULL);
 	}
 
@@ -92,7 +91,7 @@ static void *write_thread(void *arg)
 		}
 	}
 
-	snd_pcm_drain(st->write);
+	snd_pcm_drop(st->write);
 
 	return NULL;
 }


### PR DESCRIPTION
Fixes https://github.com/baresip/baresip/issues/1668

I suspect that the parallel use of snd_pcm_drop and snd_pcm_drain leads to problems.

From alsa doc:
```
snd_pcm_drain()
...
For stopping the PCM stream immediately, use ::snd_pcm_drop() instead.
```
https://www.alsa-project.org/alsa-doc/alsa-lib/group___p_c_m.html#ga49afc5b8527f30c33fafa476533c9f86
