### PR TITLE
stream flush rtp socket

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1360,6 +1360,7 @@ void stream_set_secure(struct stream *strm, bool secure);
 bool stream_is_secure(const struct stream *strm);
 int  stream_start_mediaenc(struct stream *strm);
 int  stream_start_rtcp(const struct stream *strm);
+int  stream_enable(struct stream *strm, bool enable);
 int stream_open_natpinhole(const struct stream *strm);
 void stream_mnat_attr(struct stream *strm, const char *name,
 		      const char *value);

--- a/src/audio.c
+++ b/src/audio.c
@@ -2101,7 +2101,7 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 	if (reset || ac != rx->ac) {
 		rx->auplay = mem_deref(rx->auplay);
 		aubuf_flush(rx->aubuf);
-		stream_flush_jbuf(a->strm);
+		stream_flush(a->strm);
 
 		/* Reset audio filter chain */
 		list_flush(&rx->filtl);

--- a/src/call.c
+++ b/src/call.c
@@ -174,6 +174,7 @@ static int start_audio(struct call *call)
 static void call_stream_start(struct call *call, bool active)
 {
 	int err;
+	struct le *le;
 
 	debug("call: stream start (active=%d)\n", active);
 
@@ -192,7 +193,6 @@ static void call_stream_start(struct call *call, bool active)
 	}
 
 	if (active) {
-		struct le *le;
 
 		tmr_cancel(&call->tmr_inv);
 		call->time_start = time(NULL);
@@ -200,6 +200,10 @@ static void call_stream_start(struct call *call, bool active)
 		FOREACH_STREAM {
 			stream_flush(le->data);
 		}
+	}
+
+	FOREACH_STREAM {
+		stream_enable(le->data, true);
 	}
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -198,7 +198,7 @@ static void call_stream_start(struct call *call, bool active)
 		call->time_start = time(NULL);
 
 		FOREACH_STREAM {
-			stream_flush_jbuf(le->data);
+			stream_flush(le->data);
 		}
 	}
 }

--- a/src/core.h
+++ b/src/core.h
@@ -319,7 +319,7 @@ int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 		 struct mbuf *mb);
 
 /* Receive */
-void stream_flush_jbuf(struct stream *s);
+void stream_flush(struct stream *s);
 void stream_silence_on(struct stream *s, bool on);
 int  stream_decode(struct stream *s);
 int  stream_ssrc_rx(const struct stream *strm, uint32_t *ssrc);

--- a/src/stream.c
+++ b/src/stream.c
@@ -1087,7 +1087,7 @@ void stream_hold(struct stream *s, bool hold)
 	}
 
 	sdp_media_set_ldir(s->sdp, dir);
-	stream_flush_jbuf(s);
+	stream_flush(s);
 }
 
 
@@ -1105,7 +1105,7 @@ void stream_set_ldir(struct stream *s, enum sdp_dir dir)
 
 	sdp_media_set_ldir(s->sdp, dir);
 
-	stream_flush_jbuf(s);
+	stream_flush(s);
 }
 
 
@@ -1127,13 +1127,15 @@ void stream_set_srate(struct stream *s, uint32_t srate_tx, uint32_t srate_rx)
 }
 
 
-void stream_flush_jbuf(struct stream *s)
+void stream_flush(struct stream *s)
 {
 	if (!s)
 		return;
 
 	if (s->rx.jbuf)
 		jbuf_flush(s->rx.jbuf);
+
+	rtp_clear(s->rtp);
 }
 
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -43,6 +43,7 @@ struct receiver {
 	bool ssrc_set;        /**< Incoming SSRC is set             */
 	bool pseq_set;        /**< True if sequence number is set   */
 	bool rtp_estab;       /**< True if RTP stream established   */
+	bool enabled;         /**< True if enabled                  */
 };
 
 
@@ -342,6 +343,9 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 	int err;
 
 	MAGIC_CHECK(s);
+
+	if (!s->rx.enabled && s->type == MEDIA_AUDIO)
+		return;
 
 	if (rtp_pt_is_rtcp(hdr->pt)) {
 		info("stream: drop incoming RTCP packet on RTP port"
@@ -1385,6 +1389,26 @@ int stream_start_rtcp(const struct stream *strm)
 		}
 	}
 
+	return 0;
+}
+
+
+/**
+ * Enable stream
+ *
+ * @param strm   Stream object
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int stream_enable(struct stream *strm, bool enable)
+{
+	if (!strm)
+		return EINVAL;
+
+	debug("stream: %s: %s RTP from remote\n", media_name(strm->type),
+			enable ? "enable":"disable");
+
+	strm->rx.enabled = enable;
 	return 0;
 }
 


### PR DESCRIPTION
based on: https://github.com/baresip/re/pull/185

Flushes not only the jbuf but also the packets that are waiting in the RTP socket for processing. This ensures a clean start of the audio playback.

This might be independent from https://github.com/baresip/re/discussions/184.