### PR TITLE
Transfer like rfc5589

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -222,7 +222,12 @@ static int call_xfer(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
 	struct ua *ua = carg->data ? carg->data : menu_uacur();
+	int err = 0;
 	(void)pf;
+
+	err = call_hold(ua_call(ua), true);
+	if (err)
+		return err;
 
 	return call_transfer(ua_call(ua), carg->prm);
 }

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -669,6 +669,9 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_CALL_TRANSFER_FAILED:
 		info("menu: transfer failure: %s\n", prm);
+		menu_stop_play();
+		call_hold(call, false);
+		menu_selcall(call);
 		break;
 
 	case UA_EVENT_REGISTER_OK:

--- a/src/ua.c
+++ b/src/ua.c
@@ -477,7 +477,6 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 	case CALL_EVENT_TRANSFER_FAILED:
 		ua_event(ua, UA_EVENT_CALL_TRANSFER_FAILED, call, str);
-		mem_deref(call);
 		break;
 
 	case CALL_EVENT_MENC:

--- a/test/main.c
+++ b/test/main.c
@@ -43,6 +43,7 @@ static const struct test tests[] = {
 	TEST(test_call_tcp),
 	TEST(test_call_deny_udp),
 	TEST(test_call_transfer),
+	TEST(test_call_transfer_fail),
 	TEST(test_call_video),
 	TEST(test_call_webrtc),
 	TEST(test_call_bundle),

--- a/test/test.h
+++ b/test/test.h
@@ -228,6 +228,7 @@ int test_call_rtp_timeout(void);
 int test_call_tcp(void);
 int test_call_deny_udp(void);
 int test_call_transfer(void);
+int test_call_transfer_fail(void);
 int test_call_video(void);
 int test_call_webrtc(void);
 int test_call_bundle(void);


### PR DESCRIPTION
Current behavior: In case the transfer-target refuses the call, all calls get closed.

[RFC5589 Section 6.3.1](https://datatracker.ietf.org/doc/html/rfc5589#section-6.3.1) shows a different behavior.
If the transfer-target refuses the call, the original call between transferor and transferee should be reestablished. This means the original call should be unhold.

@juha-h opened a question in the mailing list ["call transfer question"](https://groups.google.com/g/baresip/c/NUHJeMqAyTw/m/O6wxqRVuAQAJ) earlier this year. This PR changes the behavior such that a failed transfer will resume the original call.