### PR TITLE
Multicast new functions

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -432,6 +432,49 @@ static int cmd_mcprioen(struct re_printf *pf, void *arg)
 
 
 /**
+ * Enable / Disable a certain range of priorities
+ *
+ * @param pf  Printer
+ * @param arg Command arguments
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int cmd_mcprioren(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	const struct cmd_arg *carg = arg;
+	struct pl plpriol, plprioh, plenable;
+	uint32_t priol = 0, prioh = 0;
+	bool enable = false;
+
+	err = re_regex(carg->prm, str_len(carg->prm),
+		"range=[0-9]*-[0-9]* enable=[0-1]1", &plpriol, &plprioh,
+		&plenable);
+	if (err)
+		goto out;
+
+	priol = pl_u32(&plpriol);
+	prioh = pl_u32(&plprioh);
+	enable = pl_u32(&plenable);
+
+	if (priol > prioh) {
+		err = EINVAL;
+		goto out;
+	}
+
+	mcreceiver_enrangeprio(priol, prioh, enable);
+
+  out:
+	if (err)
+		re_hprintf(pf, "usage: /mcprioren range=<1-255>-<1-255>"
+			" enable=<0,1>\n");
+
+	return err;
+}
+
+
+
+/**
  * Enable / Disable all multicast receiver without removing it
  *
  * @param pf  Printer
@@ -538,6 +581,7 @@ static const struct cmd cmdv[] = {
 		cmd_mcunregall},
 	{"mcchprio"  ,0, CMD_PRM, "Change priority"           , cmd_mcchprio },
 	{"mcprioen"  ,0, CMD_PRM, "Enable Listener Prio >="   , cmd_mcprioen },
+	{"mcprioren", 0, CMD_PRM, "Enable Listener Prio range", cmd_mcprioren},
 	{"mcregen"   ,0, CMD_PRM, "Enable / Disable all listener",
 		cmd_mcregen},
 };

--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -473,6 +473,43 @@ static int cmd_mcprioren(struct re_printf *pf, void *arg)
 }
 
 
+/**
+ * Set specified multicast as ignored
+ *
+ * @param pf  Printer
+ * @param arg Command arguments
+ *
+ * @return 0 if success, otherwise errorcode
+
+ */
+static int cmd_mcignore(struct re_printf *pf, void *arg)
+{
+	int err = 0;
+	const struct cmd_arg *carg = arg;
+	struct pl plprio;
+	uint32_t prio = 0;
+
+	err = re_regex(carg->prm, str_len(carg->prm),
+		"prio=[^ ]*", &plprio);
+	if (err)
+		goto out;
+
+	prio = pl_u32(&plprio);
+
+	if (!prio) {
+		err = EINVAL;
+		goto out;
+	}
+
+	err = mcreceiver_prioignore(prio);
+
+  out:
+	if (err)
+		re_hprintf(pf, "usage: /mcignore prio=<1-255>\n");
+
+	return err;
+}
+
 
 /**
  * Enable / Disable all multicast receiver without removing it
@@ -582,6 +619,7 @@ static const struct cmd cmdv[] = {
 	{"mcchprio"  ,0, CMD_PRM, "Change priority"           , cmd_mcchprio },
 	{"mcprioen"  ,0, CMD_PRM, "Enable Listener Prio >="   , cmd_mcprioen },
 	{"mcprioren", 0, CMD_PRM, "Enable Listener Prio range", cmd_mcprioren},
+	{"mcignore",  0, CMD_PRM, "Ignore stream priority"    , cmd_mcignore },
 	{"mcregen"   ,0, CMD_PRM, "Enable / Disable all listener",
 		cmd_mcregen},
 };

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -39,6 +39,7 @@ void mcreceiver_unregall(void);
 void mcreceiver_unreg(struct sa *addr);
 int mcreceiver_chprio(struct sa *addr, uint32_t prio);
 void mcreceiver_enprio(uint32_t prio);
+void mcreceiver_enrangeprio(uint32_t priol, uint32_t prioh, bool en);
 void mcreceiver_enable(bool enable);
 
 void mcreceiver_print(struct re_printf *pf);

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -40,6 +40,7 @@ void mcreceiver_unreg(struct sa *addr);
 int mcreceiver_chprio(struct sa *addr, uint32_t prio);
 void mcreceiver_enprio(uint32_t prio);
 void mcreceiver_enrangeprio(uint32_t priol, uint32_t prioh, bool en);
+int  mcreceiver_prioignore(uint32_t prio);
 void mcreceiver_enable(bool enable);
 
 void mcreceiver_print(struct re_printf *pf);


### PR DESCRIPTION
* Range priority enable/disable: A command to disable and enable a specific range (priority range) of multicast receivers
* Ignore stream: A command to ignore a current receiving stream on a specified priority