### PR TITLE
Support >20ms ptime values for AMR codec

### DIFF
--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -27,7 +27,6 @@
 #define IF2D_IF_decode D_IF_decode
 #endif
 
-
 /**
  * @defgroup amr amr
  *
@@ -59,10 +58,12 @@ static const int frame_size_nb[16] = {
 	40,  -1,  -1,  -1,  -1,  -1,  -1,   0
 };
 
+#ifdef AMR_WB
 static const int frame_size_wb[16] = {
 	132, 177, 253, 285, 317, 365, 397, 461,
 	477,  40,  -1,  -1,  -1,  -1,  -1,   0
 };
+#endif
 
 /* Samples per 20ms speech frame */
 enum {

--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -518,7 +518,7 @@ static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf,
 	if (!samps_per_frame || sampc % samps_per_frame)
 		return EINVAL;
 
-	num_frames = sampc / samps_per_frame;
+	num_frames = (uint32_t)sampc / samps_per_frame;
 	frame_idx = 0;
 
 	if (amr_ac->aligned) {

--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -244,14 +244,18 @@ static void decode_wrapper(struct audec_state *st, int16_t *speech) {
 #ifdef AMR_NB
 		Decoder_Interface_Decode(st->dec, st->ac->dec_arr, speech, 0);
 #endif
-	} else if (st->ac->ac.srate == 16000) {
+	}
+	else if (st->ac->ac.srate == 16000) {
 #ifdef AMR_WB
 		IF2D_IF_decode(st->dec, st->ac->dec_arr, speech, 0);
 #endif
 	}
 }
 
-static int decode_be(struct audec_state *st, const uint8_t *buf, size_t const len, uint32_t const samps_per_frame, const int * frame_size_tbl, void *sampv, size_t *sampc)
+static int decode_be(struct audec_state *st, const uint8_t *buf,
+		     size_t const len, uint32_t const samps_per_frame,
+		     const int * frame_size_tbl, void *sampv,
+		     size_t *sampc)
 {
 	const struct amr_aucodec *amr_ac;
 	signed int i;
@@ -266,17 +270,17 @@ static int decode_be(struct audec_state *st, const uint8_t *buf, size_t const le
 	p_out = sampv;
 
 	/*
-	 * Example AMR header for a payload that contains 6 AMR speech frames:
-	 *  0                   1                   2                   3
-	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9
-	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * | CMR=1 |F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|
-	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * Example AMR header for a payload that contains 5 AMR speech frames:
+	 * 0                   1                   2                   3
+	 * 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * |CMR=1 |F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|
+	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	*/
 	/* Start unpacking after the CMR field */
 	toc_bit_pos = 4;
-	/* Loop through TOC until we find an F=0 entry while counting number of frames
-	 * and bytes required to hold the unpacked payload */
+	/* Loop through TOC until we find an F=0 entry while counting number
+	 * of frames and bytes required to hold the unpacked payload */
 	while (more_toc) {
 		/*
 		 * Unpack TOC entry into left aligned temp variable:
@@ -285,64 +289,83 @@ static int decode_be(struct audec_state *st, const uint8_t *buf, size_t const le
 		 * temp = |F|   FT  |Q|X|X|
 		 *         +-+-+-+-+-+-+-+
 		*/
-		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) | (buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
+		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) |
+			(buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
 		more_toc = !!(temp & 0x80);
 		FT = (temp & 0x78) >> 3;
-		if (FT >= 16 || frame_size_tbl[FT] < 0 || toc_bit_pos / 8 > len-1)
+		if (FT >= 16 || frame_size_tbl[FT] < 0 ||
+		    toc_bit_pos / 8 > len-1) {
 			return EPROTO;
-		num_frames++;
+		}
+		++num_frames;
 		/* Increment bit_pos past this TOC entry */
 		toc_bit_pos += 6;
 	}
 
-	/* Reset the toc "pointer" back to the beginning and keep track of the beginning of the speech bits */
+	/* Reset the toc "pointer" back to the beginning and keep track of
+	 * the beginning of the speech bits */
 	speech_bit_pos = toc_bit_pos;
 	toc_bit_pos = 4;
 
-	/* Iterate through all the speech frames, converting bandwidth-effecient data into octet-aligned data
-	 * stored in dec_arr before passing it to the decoder */
+	/* Iterate through all the speech frames, converting
+	 * bandwidth-effecient data into octet-aligned data stored in dec_arr
+	 * before passing it to the decoder */
 	for (i = 0; i < num_frames; i++) {
-		/* Convert TOC to octet-aligned version and place at beginning of buffer */
-		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) | (buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
+		/* Convert TOC to octet-aligned version and place at beginning
+		 * of buffer */
+		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) |
+			(buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
 		FT = (temp & 0x78) >> 3;
 		toc_bit_pos += 6;
 		p_in = amr_ac->dec_arr;
-		*p_in++ = temp & 0x7C;
+		*p_in++ = temp & 0x7c;
 
-		/* Find the end of this speech frame and iterate through it unpacking 8 bits at a time */
+		/* Find the end of this speech frame and iterate through it
+		 * unpacking 8 bits at a time */
 		eof_bit_pos = speech_bit_pos + frame_size_tbl[FT];
 		if (eof_bit_pos / 8 > len)
 			return EPROTO;
 		while (speech_bit_pos < eof_bit_pos) {
-			/* Unpack all of the LSBs in the payload byte up to the current speech bit "pointer".
-			 * Any bits past the end of the frame will be masked later. */
+			/* Unpack all of the LSBs in the payload byte up to the
+			 * current speech bit "pointer". Any bits past the end
+			 * of the frame will be masked later. */
 			uint8_t shift = speech_bit_pos % 8;
 			*p_in = buf[speech_bit_pos/8] << shift;
 
 			if (speech_bit_pos + 8 < eof_bit_pos) {
-				/* If there were more than 8 bits remaining, unpack the MSBs of the next payload byte */
+				/* If there were more than 8 bits remaining,
+				 * unpack the MSBs of the next payload byte */
 				speech_bit_pos += (8-shift);
 				if (shift) {
-					/* If shift==0, then we're already on a byte boundary and don't need to shift in the
-					 * rest of the bits from the next payload byte */
-					*p_in |= buf[speech_bit_pos/8] >> (8 - shift);
-					/* Don't need to check for overflow here because we already made sure we needed
-					 * more than 8 bits */
+					/* If shift==0, then we're already on a
+					 * byte boundary and don't need to
+					 * shift in the rest of the bits from
+					 * the next payload byte */
+					*p_in |= buf[speech_bit_pos/8] >>
+						 (8 - shift);
+					/* Don't need to check for overflow
+					 * here because we already made sure we
+					 * needed more than 8 bits */
 					speech_bit_pos += shift;
 				}
-			} else {
+			}
+			else {
 				uint8_t mask;
-				/* Unpack bits from the next payload byte if we're not at the end of the frame yet */
+				/* Unpack bits from the next payload byte if
+				 * we're not at the end of the frame yet */
 				if (speech_bit_pos + (8-shift) < eof_bit_pos) {
 					speech_bit_pos += (8-shift);
-					*p_in |= buf[speech_bit_pos/8] >> (8 - shift);
+					*p_in |= buf[speech_bit_pos/8] >>
+						 (8 - shift);
 				}
-				/* At this point it's possible the unpacked buffer has some bits from the next speech frame.  Mask them off. */
-				mask = ~((1<<(8-(eof_bit_pos - speech_bit_pos))) - 1);
-				*p_in &= mask;
+				/* At this point it's possible the unpacked
+				 * buffer has some bits from the next speech
+				 * frame. Mask them off. */
+				mask = (1<<(8-(eof_bit_pos-speech_bit_pos)))-1;
+				*p_in &= ~mask;
 				speech_bit_pos = eof_bit_pos;
 			}
-			p_in++;
+			++p_in;
 		}
 		decode_wrapper(st, p_out);
 		*sampc += samps_per_frame;
@@ -356,18 +379,23 @@ static int encode_wrapper(struct auenc_state *st, const int16_t *speech) {
 	int n = 0;
 	if (st->ac->ac.srate == 8000) {
 #ifdef AMR_NB
-		n = Encoder_Interface_Encode(st->enc, NB_MODE, speech, st->ac->enc_arr, 0);
+		n = Encoder_Interface_Encode(st->enc, NB_MODE, speech,
+			st->ac->enc_arr, 0);
 #endif
-	} else if (st->ac->ac.srate == 16000) {
+	}
+	else if (st->ac->ac.srate == 16000) {
 #ifdef AMR_WB
-		n = IF2E_IF_encode(st->enc, WB_MODE, speech, st->ac->enc_arr, 0);
+		n = IF2E_IF_encode(st->enc, WB_MODE, speech,
+			st->ac->enc_arr, 0);
 #endif
 	}
 	return n;
 }
 
-
-static int encode_be(struct auenc_state *st, const int16_t *p_in, uint32_t const frame_cnt, uint32_t const samps_per_frame, const int * frame_size_tbl, uint8_t *buf, size_t *len) {
+static int encode_be(struct auenc_state *st, const int16_t *p_in,
+		     uint32_t const frame_cnt, uint32_t const samps_per_frame,
+		     const int * frame_size_tbl, uint8_t *buf, size_t *len)
+{
 	const uint8_t CMR_BITS = 4;
 	const uint8_t F_BITS = 1;
 	const uint8_t FT_BITS = 4;
@@ -395,12 +423,15 @@ static int encode_be(struct auenc_state *st, const int16_t *p_in, uint32_t const
 			return EPROTO;
 
 		/* Set F field for TOC entry */
-		if (frame_num != frame_cnt-1)
-			buf[toc_bit_pos/8] |= 1 << (8 - ((toc_bit_pos % 8) + F_BITS));
-		toc_bit_pos++;
+		if (frame_num != frame_cnt-1) {
+			buf[toc_bit_pos/8] |= 1 <<
+					      (8-((toc_bit_pos % 8) + F_BITS));
+		}
+		++toc_bit_pos;
 
-		/* Extract FT and use it to determine the bit position of the next frame */
-		FT = (amr_ac->enc_arr[0] >> 3) & 0x0F;
+		/* Extract FT and use it to determine the bit position of the
+		 * next frame */
+		FT = (amr_ac->enc_arr[0] >> 3) & 0x0f;
 		if (FT >= 16 || frame_size_tbl[FT] < 0)
 			return EPROTO;
 		eof_bit_pos = speech_bit_pos + frame_size_tbl[FT];
@@ -409,15 +440,19 @@ static int encode_be(struct auenc_state *st, const int16_t *p_in, uint32_t const
 		bits_remaining = 8 - (toc_bit_pos % 8);
 		if (bits_remaining >= FT_BITS) {
 			buf[toc_bit_pos/8] |= FT << (bits_remaining - FT_BITS);
-		} else {
+		}
+		else {
 			uint32_t idx = toc_bit_pos/8;
 			buf[idx] |= FT >> (FT_BITS - bits_remaining);
-			/*           |<---    Mask FT bits in prev byte   --->|  |<---  Shift into MSb  --->| */
-			buf[idx+1] |= (FT & ((1 << (FT_BITS-bits_remaining))-1))<<(8-(FT_BITS-bits_remaining));
+			/* Mask FT bits in prev byte */
+			buf[idx+1] |= (FT & ((1<<(FT_BITS-bits_remaining))-1))
+			/* Shift into MSb */
+				      << (8 - (FT_BITS-bits_remaining));
 		}
 		toc_bit_pos += FT_BITS;
-		buf[toc_bit_pos/8] |= (amr_ac->enc_arr[0]>>2 & 0x01) << (8 - ((toc_bit_pos % 8) + Q_BITS));
-		toc_bit_pos++;
+		buf[toc_bit_pos/8] |= (amr_ac->enc_arr[0]>>2 & 0x01)
+				      << (8 - ((toc_bit_pos % 8) + Q_BITS));
+		++toc_bit_pos;
 
 		for (i=1; i<encoded_bytes; i++) {
 			uint32_t idx = speech_bit_pos/8;
@@ -425,21 +460,25 @@ static int encode_be(struct auenc_state *st, const int16_t *p_in, uint32_t const
 			buf[idx] |= amr_ac->enc_arr[i] >> (8 - bits_remaining);
 			speech_bit_pos += bits_remaining;
 			if (speech_bit_pos < eof_bit_pos) {
-				buf[idx+1] = (amr_ac->enc_arr[i] & ((1 << (8-bits_remaining))-1))<<bits_remaining;
+				buf[idx+1] = (amr_ac->enc_arr[i] &
+					      ((1 << (8-bits_remaining))-1)) <<
+					     bits_remaining;
 			}
 			speech_bit_pos += (8-bits_remaining);
 		}
 		speech_bit_pos = eof_bit_pos;
 
 		p_in += samps_per_frame;
-		frame_num++;
+		++frame_num;
 	}
 
 	*len = (speech_bit_pos+7)/8;
 	return 0;
 }
 
-static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf, size_t *len, int fmt, const void *sampv, size_t sampc)
+static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf,
+			  size_t *len, int fmt, const void *sampv,
+			  size_t sampc)
 {
 	const struct amr_aucodec *amr_ac;
 	const int16_t *p = sampv;
@@ -482,7 +521,8 @@ static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf, si
 	frame_idx = 0;
 
 	if (amr_ac->aligned) {
-		/* Speech data starts after CMR header and TOC bytes for each frame */
+		/* Speech data starts after CMR header and TOC bytes for each
+		 * frame */
 		uint32_t payload_idx = 1 + num_frames;
 
 		/* CMR value 15 indicates that no mode request is present */
@@ -492,12 +532,13 @@ static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf, si
 			n = encode_wrapper(st, p);
 			if (n <= 0)
 				return EPROTO;
-			/* Move header byte into TOC and set F bit if more frames are expected */
+			/* Move header byte into TOC and set F bit if more
+			 * frames are expected */
 			if (frame_idx == num_frames-1)
 				buf[1+frame_idx] = amr_ac->enc_arr[0];
 			else
 				buf[1+frame_idx] = amr_ac->enc_arr[0] | 0x80;
-			frame_idx++;
+			++frame_idx;
 			memcpy(&buf[payload_idx], &amr_ac->enc_arr[1], n);
 			payload_idx += (n-1);
 			*len += n;
@@ -506,13 +547,14 @@ static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf, si
 		return 0;
 	}
 	else {
-		return encode_be(st, p, num_frames, samps_per_frame, frame_size_tbl, buf, len);
+		return encode_be(st, p, num_frames, samps_per_frame,
+				 frame_size_tbl, buf, len);
 	}
 }
 
 static int decode_handler(struct audec_state *st, int fmt, void *sampv,
-		     size_t *sampc,
-		     bool marker, const uint8_t *buf, size_t len)
+			  size_t *sampc, bool marker, const uint8_t *buf,
+			  size_t len)
 {
 	const struct amr_aucodec *amr_ac;
 	const int * frame_size_tbl;
@@ -556,27 +598,34 @@ static int decode_handler(struct audec_state *st, int fmt, void *sampv,
 
 	if (amr_ac->aligned) {
 		uint32_t payload_idx;
-		/* Iterate through all the TOC bytes to count the number of frames. First byte is CMR so skip that. */
+		/* Iterate through all the TOC bytes to count the number of
+		 * frames. First byte is CMR so skip that. */
 		while( (buf[1+(frame_cnt++)] & 0x80) && frame_cnt < len-1);
 		/* First frame payload starts after the TOC. */
 		payload_idx = 1+frame_cnt;
 		while (frame_num < frame_cnt) {
 			/* Extract frame type */
-			uint8_t FT = (buf[1+frame_num] >> 3) & 0x0F;
-			if (FT >= 16 || frame_size_tbl[FT] < 0 || (frame_size_tbl[FT]+7)/8 + payload_idx > len)
+			uint8_t FT = (buf[1+frame_num] >> 3) & 0x0f;
+			if (FT >= 16 || frame_size_tbl[FT] < 0 ||
+			    (frame_size_tbl[FT]+7)/8 + payload_idx > len) {
 				return EPROTO;
-			/* Opencore AMR decoder wrapper expects frame type in first byte followed by AMR speech frame */
+			}
+			/* Opencore AMR decoder wrapper expects frame type in
+			 * first byte followed by AMR speech frame */
 			amr_ac->dec_arr[0] = buf[1 + frame_num];
-			memcpy(&amr_ac->dec_arr[1], &buf[payload_idx], (frame_size_nb[FT]+7)/8);
+			memcpy(&amr_ac->dec_arr[1], &buf[payload_idx],
+			       (frame_size_nb[FT]+7)/8);
 			decode_wrapper(st, p);
 			p += samps_per_frame;
 			*sampc += samps_per_frame;
-			frame_num++;
+			++frame_num;
 			payload_idx += (frame_size_tbl[FT]+7)/8;
 		}
 		return 0;
-	} else {
-		return decode_be(st, buf, len, samps_per_frame, frame_size_tbl, sampv, sampc);
+	}
+	else {
+		return decode_be(st, buf, len, samps_per_frame, frame_size_tbl,
+				 sampv, sampc);
 	}
 }
 

--- a/modules/amr/amr.c
+++ b/modules/amr/amr.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Alfred E. Heggestad
  */
 #include <stdlib.h>
+#include <string.h>
 #ifdef AMR_NB
 #include <interf_enc.h>
 #include <interf_dec.h>
@@ -41,16 +42,32 @@
  */
 
 
-#ifndef L_FRAME16k
-#define L_FRAME16k 320
+#ifndef SERIAL_MAX
+/* Maximum size of buffer passed to encoder/decoder */
+#define SERIAL_MAX 61
 #endif
 
-#ifndef NB_SERIAL_MAX
-#define NB_SERIAL_MAX 61
-#endif
+/* Narrowband encoder bitrate = 12.2kbps */
+#define NB_MODE MR122
+/* Wideband encoder bitrate = 23.85 kbps */
+#define WB_MODE 8
 
+/* Bits per speech frame for a given bitrate/frame type.
+  -1 is an invalid frame type. */
+static const int frame_size_nb[16] = {
+	95, 103, 118, 134, 148, 159, 204, 244,
+	40,  -1,  -1,  -1,  -1,  -1,  -1,   0
+};
+
+static const int frame_size_wb[16] = {
+	132, 177, 253, 285, 317, 365, 397, 461,
+	477,  40,  -1,  -1,  -1,  -1,  -1,   0
+};
+
+/* Samples per 20ms speech frame */
 enum {
-	FRAMESIZE_NB = 160
+	NB_SAMPS_PER_FRAME = 160,
+	WB_SAMPS_PER_FRAME = 320
 };
 
 
@@ -97,7 +114,8 @@ static void decode_destructor(void *arg)
 	case 8000:
 		Decoder_Interface_exit(st->dec);
 
-		mem_deref(amr_ac->be_dec_arr);
+		mem_deref(amr_ac->dec_arr);
+		mem_deref(amr_ac->enc_arr);
 
 		break;
 #endif
@@ -106,7 +124,8 @@ static void decode_destructor(void *arg)
 	case 16000:
 		D_IF_exit(st->dec);
 
-		mem_deref(amr_ac->be_dec_arr);
+		mem_deref(amr_ac->dec_arr);
+		mem_deref(amr_ac->enc_arr);
 
 		break;
 #endif
@@ -189,12 +208,10 @@ static int decode_update(struct audec_state **adsp,
 	case 8000:
 		st->dec = Decoder_Interface_init();
 
-		if (!amr_ac->aligned) {
-			amr_ac->be_dec_arr = mem_zalloc(NB_SERIAL_MAX, NULL);
-
-			if (!amr_ac->be_dec_arr)
-				err = ENOMEM;
-		}
+		amr_ac->dec_arr = mem_zalloc(SERIAL_MAX, NULL);
+		amr_ac->enc_arr = mem_zalloc(SERIAL_MAX, NULL);
+		if (!amr_ac->dec_arr || !amr_ac->enc_arr)
+			err = ENOMEM;
 		break;
 #endif
 
@@ -202,12 +219,11 @@ static int decode_update(struct audec_state **adsp,
 	case 16000:
 		st->dec = D_IF_init();
 
-		if (!amr_ac->aligned) {
-			amr_ac->be_dec_arr = mem_zalloc(1+NB_SERIAL_MAX, NULL);
+		amr_ac->dec_arr = mem_zalloc(1+SERIAL_MAX, NULL);
+		amr_ac->enc_arr = mem_zalloc(1+SERIAL_MAX, NULL);
 
-			if (!amr_ac->be_dec_arr)
-				err = ENOMEM;
-		}
+		if (!amr_ac->dec_arr || !amr_ac->enc_arr)
+			err = ENOMEM;
 		break;
 #endif
 	}
@@ -223,153 +239,285 @@ static int decode_update(struct audec_state **adsp,
 	return err;
 }
 
-static void pack_be(uint8_t *buf, size_t len)
-{
-	/* basic bandwidth efficient pack and unpack. see
-	https://github.com/traud/asterisk-amr/blob/master/codecs/codec_amr.c */
-
-	const int another = ((buf[1] >> 7) & 0x01);
-	const int type    = ((buf[1] >> 3) & 0x0f);
-	const int quality = ((buf[1] >> 2) & 0x01);
-	unsigned int i;
-
-	/* to shift in place, clear bits beyond end and at start */
-	buf[0] = 0;
-	buf[1] = 0;
-	buf[len+1] = 0;
-	/* shift in place, 6 bits */
-	for (i = 1; i <= len; i++) {
-		buf[i] = ((buf[i] << 6) | (buf[i + 1] >> 2));
-	}
-	/* restore first two bytes: [ CMR |F| FT |Q] */
-	buf[1] |= ((type << 7) | (quality << 6));
-	buf[0] = ((15 << 4) | (another << 3) | (type >> 1)); /* CMR: no */
-}
-
-static void unpack_be(uint8_t *temp, const uint8_t *buf, size_t len)
-{
-	const int another = ((buf[0] >> 3) & 0x01);
-	const int type    = ((buf[0] << 1 | buf[1] >> 7) & 0x0f);
-	const int quality = ((buf[1] >> 6) & 0x01);
-	unsigned int i;
-
-	/* shift in place, 2 bits */
-	for (i = 1; i < (len - 1); i++) {
-		temp[i] = ((buf[i] << 2) | (buf[i + 1] >> 6));
-	}
-	temp[len - 1] = buf[len - 1] << 2;
-	/* restore first byte: [F| FT |Q] */
-	temp[0] = ((another << 7) | (type << 3) | (quality << 2));
-}
-
+static void decode_wrapper(struct audec_state *st, int16_t *speech) {
+	if (st->ac->ac.srate == 8000) {
+#ifdef AMR_NB
+		Decoder_Interface_Decode(st->dec, st->ac->dec_arr, speech, 0);
+#endif
+	} else if (st->ac->ac.srate == 16000) {
 #ifdef AMR_WB
-static int encode_wb(struct auenc_state *st,
-		     bool *marker, uint8_t *buf, size_t *len,
-		     int fmt, const void *sampv, size_t sampc)
+		IF2D_IF_decode(st->dec, st->ac->dec_arr, speech, 0);
+#endif
+	}
+}
+
+static int decode_be(struct audec_state *st, const uint8_t *buf, size_t const len, uint32_t const samps_per_frame, const int * frame_size_tbl, void *sampv, size_t *sampc)
 {
+	const struct amr_aucodec *amr_ac;
+	signed int i;
+	int num_frames = 0;
+	uint32_t toc_bit_pos, speech_bit_pos, eof_bit_pos;
+	uint8_t temp, FT;
+	bool more_toc = 1;
+	uint8_t *p_in;
+	int16_t *p_out;
+
+	amr_ac = (struct amr_aucodec *)st->ac;
+	p_out = sampv;
+
+	/*
+	 * Example AMR header for a payload that contains 6 AMR speech frames:
+	 *  0                   1                   2                   3
+	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9
+	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	 * | CMR=1 |F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|F|   FT  |Q|
+	 *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	*/
+	/* Start unpacking after the CMR field */
+	toc_bit_pos = 4;
+	/* Loop through TOC until we find an F=0 entry while counting number of frames
+	 * and bytes required to hold the unpacked payload */
+	while (more_toc) {
+		/*
+		 * Unpack TOC entry into left aligned temp variable:
+		 *         0 1 2 3 4 5 6 7
+		 *         +-+-+-+-+-+-+-+
+		 * temp = |F|   FT  |Q|X|X|
+		 *         +-+-+-+-+-+-+-+
+		*/
+		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) | (buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
+		more_toc = !!(temp & 0x80);
+		FT = (temp & 0x78) >> 3;
+		if (FT >= 16 || frame_size_tbl[FT] < 0 || toc_bit_pos / 8 > len-1)
+			return EPROTO;
+		num_frames++;
+		/* Increment bit_pos past this TOC entry */
+		toc_bit_pos += 6;
+	}
+
+	/* Reset the toc "pointer" back to the beginning and keep track of the beginning of the speech bits */
+	speech_bit_pos = toc_bit_pos;
+	toc_bit_pos = 4;
+
+	/* Iterate through all the speech frames, converting bandwidth-effecient data into octet-aligned data
+	 * stored in dec_arr before passing it to the decoder */
+	for (i = 0; i < num_frames; i++) {
+		/* Convert TOC to octet-aligned version and place at beginning of buffer */
+		temp = (buf[toc_bit_pos/8] << (toc_bit_pos % 8)) | (buf[(toc_bit_pos+6)/8] >> (8 - (toc_bit_pos % 8)));
+		FT = (temp & 0x78) >> 3;
+		toc_bit_pos += 6;
+		p_in = amr_ac->dec_arr;
+		*p_in++ = temp & 0x7C;
+
+		/* Find the end of this speech frame and iterate through it unpacking 8 bits at a time */
+		eof_bit_pos = speech_bit_pos + frame_size_tbl[FT];
+		if (eof_bit_pos / 8 > len)
+			return EPROTO;
+		while (speech_bit_pos < eof_bit_pos) {
+			/* Unpack all of the LSBs in the payload byte up to the current speech bit "pointer".
+			 * Any bits past the end of the frame will be masked later. */
+			uint8_t shift = speech_bit_pos % 8;
+			*p_in = buf[speech_bit_pos/8] << shift;
+
+			if (speech_bit_pos + 8 < eof_bit_pos) {
+				/* If there were more than 8 bits remaining, unpack the MSBs of the next payload byte */
+				speech_bit_pos += (8-shift);
+				if (shift) {
+					/* If shift==0, then we're already on a byte boundary and don't need to shift in the
+					 * rest of the bits from the next payload byte */
+					*p_in |= buf[speech_bit_pos/8] >> (8 - shift);
+					/* Don't need to check for overflow here because we already made sure we needed
+					 * more than 8 bits */
+					speech_bit_pos += shift;
+				}
+			} else {
+				uint8_t mask;
+				/* Unpack bits from the next payload byte if we're not at the end of the frame yet */
+				if (speech_bit_pos + (8-shift) < eof_bit_pos) {
+					speech_bit_pos += (8-shift);
+					*p_in |= buf[speech_bit_pos/8] >> (8 - shift);
+				}
+				/* At this point it's possible the unpacked buffer has some bits from the next speech frame.  Mask them off. */
+				mask = ~((1<<(8-(eof_bit_pos - speech_bit_pos))) - 1);
+				*p_in &= mask;
+				speech_bit_pos = eof_bit_pos;
+			}
+			p_in++;
+		}
+		decode_wrapper(st, p_out);
+		*sampc += samps_per_frame;
+		p_out += samps_per_frame;
+	}
+
+	return 0;
+}
+
+static int encode_wrapper(struct auenc_state *st, const int16_t *speech) {
+	int n = 0;
+	if (st->ac->ac.srate == 8000) {
+#ifdef AMR_NB
+		n = Encoder_Interface_Encode(st->enc, NB_MODE, speech, st->ac->enc_arr, 0);
+#endif
+	} else if (st->ac->ac.srate == 16000) {
+#ifdef AMR_WB
+		n = IF2E_IF_encode(st->enc, WB_MODE, speech, st->ac->enc_arr, 0);
+#endif
+	}
+	return n;
+}
+
+
+static int encode_be(struct auenc_state *st, const int16_t *p_in, uint32_t const frame_cnt, uint32_t const samps_per_frame, const int * frame_size_tbl, uint8_t *buf, size_t *len) {
+	const uint8_t CMR_BITS = 4;
+	const uint8_t F_BITS = 1;
+	const uint8_t FT_BITS = 4;
+	const uint8_t Q_BITS = 1;
+
 	const struct amr_aucodec *amr_ac = (struct amr_aucodec *)st->ac;
+	uint32_t frame_num = 0;
+	uint32_t toc_bit_pos, speech_bit_pos, eof_bit_pos = 0;
+	uint8_t bits_remaining;
+	int encoded_bytes;
+	int i;
+
+	/* Clear buffer to make bitmasking a little less complicated */
+	memset(buf, 0, *len);
+	/* Set CMR field */
+	buf[0] = 15<<CMR_BITS;
+	toc_bit_pos = CMR_BITS;
+
+	speech_bit_pos = CMR_BITS + frame_cnt * (F_BITS + FT_BITS + Q_BITS);
+	while (frame_num < frame_cnt) {
+		uint8_t FT;
+
+		encoded_bytes = encode_wrapper(st, p_in);
+		if (encoded_bytes < 0)
+			return EPROTO;
+
+		/* Set F field for TOC entry */
+		if (frame_num != frame_cnt-1)
+			buf[toc_bit_pos/8] |= 1 << (8 - ((toc_bit_pos % 8) + F_BITS));
+		toc_bit_pos++;
+
+		/* Extract FT and use it to determine the bit position of the next frame */
+		FT = (amr_ac->enc_arr[0] >> 3) & 0x0F;
+		if (FT >= 16 || frame_size_tbl[FT] < 0)
+			return EPROTO;
+		eof_bit_pos = speech_bit_pos + frame_size_tbl[FT];
+
+		/* Determine if FT field will span an octet boundary */
+		bits_remaining = 8 - (toc_bit_pos % 8);
+		if (bits_remaining >= FT_BITS) {
+			buf[toc_bit_pos/8] |= FT << (bits_remaining - FT_BITS);
+		} else {
+			uint32_t idx = toc_bit_pos/8;
+			buf[idx] |= FT >> (FT_BITS - bits_remaining);
+			/*           |<---    Mask FT bits in prev byte   --->|  |<---  Shift into MSb  --->| */
+			buf[idx+1] |= (FT & ((1 << (FT_BITS-bits_remaining))-1))<<(8-(FT_BITS-bits_remaining));
+		}
+		toc_bit_pos += FT_BITS;
+		buf[toc_bit_pos/8] |= (amr_ac->enc_arr[0]>>2 & 0x01) << (8 - ((toc_bit_pos % 8) + Q_BITS));
+		toc_bit_pos++;
+
+		for (i=1; i<encoded_bytes; i++) {
+			uint32_t idx = speech_bit_pos/8;
+			bits_remaining = 8 - (speech_bit_pos % 8);
+			buf[idx] |= amr_ac->enc_arr[i] >> (8 - bits_remaining);
+			speech_bit_pos += bits_remaining;
+			if (speech_bit_pos < eof_bit_pos) {
+				buf[idx+1] = (amr_ac->enc_arr[i] & ((1 << (8-bits_remaining))-1))<<bits_remaining;
+			}
+			speech_bit_pos += (8-bits_remaining);
+		}
+		speech_bit_pos = eof_bit_pos;
+
+		p_in += samps_per_frame;
+		frame_num++;
+	}
+
+	*len = (speech_bit_pos+7)/8;
+	return 0;
+}
+
+static int encode_handler(struct auenc_state *st, bool *marker, uint8_t *buf, size_t *len, int fmt, const void *sampv, size_t sampc)
+{
+	const struct amr_aucodec *amr_ac;
+	const int16_t *p = sampv;
+	const int * frame_size_tbl;
+	uint32_t num_frames, frame_idx, samps_per_frame;
 	int n;
 	(void)marker;
 
-	if (sampc != L_FRAME16k)
-		return EINVAL;
-
-	if (*len < (1+NB_SERIAL_MAX))
-		return ENOMEM;
-
-	if (fmt != AUFMT_S16LE)
-		return ENOTSUP;
-
-	n = IF2E_IF_encode(st->enc, 8, sampv, &buf[1], 0);
-	if (n <= 0)
-		return EPROTO;
-
-	if (amr_ac->aligned) {
-		/* CMR value 15 indicates that no mode request is present */
-		buf[0] = 15 << 4;
-		*len = (1 + n);
-	}
-	else {
-		pack_be(buf, n);
-		*len = n;
-	}
-
-	return 0;
-}
-
-
-static int decode_wb(struct audec_state *st,
-		     int fmt, void *sampv, size_t *sampc,
-		     bool marker, const uint8_t *buf, size_t len)
-{
-	const struct amr_aucodec *amr_ac = (struct amr_aucodec *)st->ac;
-	(void)marker;
-
-	if (*sampc < L_FRAME16k)
-		return ENOMEM;
-	if (len > (1+NB_SERIAL_MAX))
+	if (!st || !buf || !len || !sampv)
 		return EINVAL;
 
 	if (fmt != AUFMT_S16LE)
 		return ENOTSUP;
-
-	if (amr_ac->aligned) {
-		IF2D_IF_decode(st->dec, &buf[1], sampv, 0);
-	}
-	else {
-		unpack_be(amr_ac->be_dec_arr, buf, len);
-		IF2D_IF_decode(st->dec, amr_ac->be_dec_arr, sampv, 0);
-	}
-
-	*sampc = L_FRAME16k;
-
-	return 0;
-}
-#endif
-
-
-#ifdef AMR_NB
-static int encode_nb(struct auenc_state *st, bool *marker, uint8_t *buf,
-		     size_t *len, int fmt, const void *sampv, size_t sampc)
-{
-	const struct amr_aucodec *amr_ac;
-	int r;
-	(void)marker;
-
-	if (!st || !buf || !len || !sampv || sampc != FRAMESIZE_NB)
-		return EINVAL;
 
 	amr_ac = (struct amr_aucodec *)st->ac;
 
-	if (*len < NB_SERIAL_MAX)
-		return ENOMEM;
+	switch (amr_ac->ac.srate) {
+#ifdef AMR_NB
+	case 8000:
+		samps_per_frame = NB_SAMPS_PER_FRAME;
+		frame_size_tbl = frame_size_nb;
+		break;
+#endif
 
-	if (fmt != AUFMT_S16LE)
-		return ENOTSUP;
+#ifdef AMR_WB
+	case 16000:
+		samps_per_frame = WB_SAMPS_PER_FRAME;
+		frame_size_tbl = frame_size_wb;
+		break;
+#endif
+	default:
+		samps_per_frame = 0;
+		frame_size_tbl = frame_size_nb;
+	}
 
-	r = Encoder_Interface_Encode(st->enc, MR122, sampv, &buf[1], 0);
-	if (r <= 0)
-		return EPROTO;
+	if (!samps_per_frame || sampc % samps_per_frame)
+		return EINVAL;
+
+	num_frames = sampc / samps_per_frame;
+	frame_idx = 0;
 
 	if (amr_ac->aligned) {
+		/* Speech data starts after CMR header and TOC bytes for each frame */
+		uint32_t payload_idx = 1 + num_frames;
+
 		/* CMR value 15 indicates that no mode request is present */
 		buf[0] = 15 << 4;
-		*len = (1 + r);
+		*len = 1;
+		while (frame_idx < num_frames) {
+			n = encode_wrapper(st, p);
+			if (n <= 0)
+				return EPROTO;
+			/* Move header byte into TOC and set F bit if more frames are expected */
+			if (frame_idx == num_frames-1)
+				buf[1+frame_idx] = amr_ac->enc_arr[0];
+			else
+				buf[1+frame_idx] = amr_ac->enc_arr[0] | 0x80;
+			frame_idx++;
+			memcpy(&buf[payload_idx], &amr_ac->enc_arr[1], n);
+			payload_idx += (n-1);
+			*len += n;
+			p += samps_per_frame;
+		}
+		return 0;
 	}
 	else {
-		pack_be(buf, r);
-		*len = r;
+		return encode_be(st, p, num_frames, samps_per_frame, frame_size_tbl, buf, len);
 	}
-
-	return 0;
 }
 
-
-static int decode_nb(struct audec_state *st, int fmt, void *sampv,
+static int decode_handler(struct audec_state *st, int fmt, void *sampv,
 		     size_t *sampc,
 		     bool marker, const uint8_t *buf, size_t len)
 {
 	const struct amr_aucodec *amr_ac;
+	const int * frame_size_tbl;
+	int16_t *p = sampv;
+	uint32_t frame_num, frame_cnt, samps_per_frame;
 	(void)marker;
 
 	if (!st || !sampv || !sampc || !buf)
@@ -377,30 +525,60 @@ static int decode_nb(struct audec_state *st, int fmt, void *sampv,
 
 	amr_ac = (struct amr_aucodec *)st->ac;
 
-	if (len > NB_SERIAL_MAX)
-		return EPROTO;
+	switch (amr_ac->ac.srate) {
+#ifdef AMR_NB
+	case 8000:
+		samps_per_frame = NB_SAMPS_PER_FRAME;
+		frame_size_tbl = frame_size_nb;
+		break;
+#endif
 
-	if (*sampc < L_FRAME16k)
-		return ENOMEM;
+#ifdef AMR_WB
+	case 16000:
+		samps_per_frame = WB_SAMPS_PER_FRAME;
+		frame_size_tbl = frame_size_wb;
+		break;
+#endif
+	default:
+		samps_per_frame = 0;
+		frame_size_tbl = frame_size_nb;
+	}
+
+	if (!samps_per_frame)
+		return EINVAL;
 
 	if (fmt != AUFMT_S16LE)
 		return ENOTSUP;
 
+	frame_num = 0;
+	frame_cnt = 0;
+	*sampc = 0;
+
 	if (amr_ac->aligned) {
-		Decoder_Interface_Decode(st->dec, &buf[1], sampv, 0);
+		uint32_t payload_idx;
+		/* Iterate through all the TOC bytes to count the number of frames. First byte is CMR so skip that. */
+		while( (buf[1+(frame_cnt++)] & 0x80) && frame_cnt < len-1);
+		/* First frame payload starts after the TOC. */
+		payload_idx = 1+frame_cnt;
+		while (frame_num < frame_cnt) {
+			/* Extract frame type */
+			uint8_t FT = (buf[1+frame_num] >> 3) & 0x0F;
+			if (FT >= 16 || frame_size_tbl[FT] < 0 || (frame_size_tbl[FT]+7)/8 + payload_idx > len)
+				return EPROTO;
+			/* Opencore AMR decoder wrapper expects frame type in first byte followed by AMR speech frame */
+			amr_ac->dec_arr[0] = buf[1 + frame_num];
+			memcpy(&amr_ac->dec_arr[1], &buf[payload_idx], (frame_size_nb[FT]+7)/8);
+			decode_wrapper(st, p);
+			p += samps_per_frame;
+			*sampc += samps_per_frame;
+			frame_num++;
+			payload_idx += (frame_size_tbl[FT]+7)/8;
+		}
+		return 0;
+	} else {
+		return decode_be(st, buf, len, samps_per_frame, frame_size_tbl, sampv, sampc);
 	}
-	else {
-		unpack_be(amr_ac->be_dec_arr, buf, len);
-		Decoder_Interface_Decode(
-			st->dec, amr_ac->be_dec_arr, sampv, 0);
-	}
-
-	*sampc = FRAMESIZE_NB;
-
-	return 0;
 }
-#endif
-
 
 #ifdef AMR_WB
 static struct amr_aucodec amr_wb = {
@@ -411,13 +589,14 @@ static struct amr_aucodec amr_wb = {
 		.ch        = 1,
 		.pch       = 1,
 		.encupdh   = encode_update,
-		.ench      = encode_wb,
+		.ench      = encode_handler,
 		.decupdh   = decode_update,
-		.dech      = decode_wb,
+		.dech      = decode_handler,
 		.fmtp_ench = amr_fmtp_enc
 	},
 	.aligned = false,
-	.be_dec_arr = NULL
+	.dec_arr = NULL,
+	.enc_arr = NULL
 };
 #endif
 #ifdef AMR_NB
@@ -429,13 +608,14 @@ static struct amr_aucodec amr_nb = {
 		.ch        = 1,
 		.pch       = 1,
 		.encupdh   = encode_update,
-		.ench      = encode_nb,
+		.ench      = encode_handler,
 		.decupdh   = decode_update,
-		.dech      = decode_nb,
+		.dech      = decode_handler,
 		.fmtp_ench = amr_fmtp_enc
 	},
 	.aligned = false,
-	.be_dec_arr = NULL
+	.dec_arr = NULL,
+	.enc_arr = NULL
 };
 #endif
 

--- a/modules/amr/amr.h
+++ b/modules/amr/amr.h
@@ -7,7 +7,9 @@
 struct amr_aucodec {
 	struct aucodec ac;
 	bool aligned;
-	uint8_t *be_dec_arr;
+	uint8_t *dec_arr;
+	uint8_t *enc_arr;
+
 };
 
 bool amr_octet_align(const char *fmtp);

--- a/src/audio.c
+++ b/src/audio.c
@@ -55,7 +55,7 @@
 enum {
 	MAX_SRATE       = 48000,  /* Maximum sample rate in [Hz] */
 	MAX_CHANNELS    =     2,  /* Maximum number of channels  */
-	MAX_PTIME       =    60,  /* Maximum packet time in [ms] */
+	MAX_PTIME       =   120,  /* Maximum packet time in [ms] */
 
 	AUDIO_SAMPSZ    = MAX_SRATE * MAX_CHANNELS * MAX_PTIME / 1000,
 
@@ -1368,6 +1368,8 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 				   "minptime", "%u", minptime);
 	err |= sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 				   "ptime", "%u", ptime);
+	err |= sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
+				   "maxptime", "%u", MAX_PTIME);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
Modified the AMR RTP depayloader to inspect the TOC entries for multiple AMR frames instead of assuming there is only a single 20ms frame in each packet.
Modified the payloader to encode multiple frames when handed more than 20ms worth of samples.

I've validated both the bandwidth-efficient and octet-aligned payload types with AMR-NB since that's all my client supports. AMRWB should probably be validated before merging this into the mainline, but I don't have a reference client to support that.