### PR TITLE
avcodec: Enable pass-through for more codecs

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -101,6 +101,7 @@ static struct vidcodec h264_1 = {
 	.dech      = avcodec_decode_h264,
 	.fmtp_ench = avcodec_h264_fmtp_enc,
 	.fmtp_cmph = avcodec_h264_fmtp_cmp,
+	.packetizeh= avcodec_packetize,
 };
 
 static struct vidcodec h263 = {
@@ -111,6 +112,7 @@ static struct vidcodec h263 = {
 	.decupdh   = avcodec_decode_update,
 	.dech      = avcodec_decode_h263,
 	.fmtp_ench = h263_fmtp_enc,
+	.packetizeh= avcodec_packetize,
 };
 
 static struct vidcodec h265 = {
@@ -120,6 +122,7 @@ static struct vidcodec h265 = {
 	.ench      = avcodec_encode,
 	.decupdh   = avcodec_decode_update,
 	.dech      = avcodec_decode_h265,
+	.packetizeh= avcodec_packetize,
 };
 
 


### PR DESCRIPTION
On initial submisson of "video passthrough", see https://github.com/baresip/baresip/pull/1418 `packetizeh()` call-back was added to only 1 codec: `h265_1`, while `avcodec_packetize()` itself supports much more (not to mention both h264 flavors): h263, h264 & h265.

That makes the current implementation to fail on a default configuration like that:
```shell
video: Skipping Packet as Copy Handler not initialized ..
video: Skipping Packet as Copy Handler not initialized ..
video: Skipping Packet as Copy Handler not initialized ..
```

Fix that by properly initializing all call-backs, though I haven't tested h263 & h265 since I don't have such sources handy.