### PR TITLE
menu: filter for the correct call state in menu_selcall

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -769,7 +769,7 @@ void menu_selcall(struct call *call)
 	if (!call) {
 		/* select another call */
 		for (i = ARRAY_SIZE(state)-1; i >= 0; --i) {
-			fa.state = i;
+			fa.state = state[i];
 			uag_filter_calls(find_first_call, filter_call, &fa);
 
 			if (fa.call)


### PR DESCRIPTION
State array enumeration is not equal to the call_state enum definition.
Use loop counter to access the state of the array.