### PR TITLE
sip: add optional TCP source port

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -36,6 +36,7 @@
 #    ;stunuser=STUN/TURN/ICE-username
 #    ;stunpass=STUN/TURN/ICE-password
 #    ;stunserver=stun:[user:pass]@host[:port]
+#    ;tcpsrcport=6060
 #    ;video_codecs=h264,h263,...
 #
 # Examples:

--- a/src/account.c
+++ b/src/account.c
@@ -409,7 +409,7 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 	u32  = 0;
 	err |= param_u32(&u32, &aor->params, "tcpsrcport");
 	if (u32) {
-		if (u32 <= 0xffff)
+		if (u32 <= 65535)
 			acc->tcpsrcport = u32;
 		else
 			warning("account: invalid tcpsrcport\n");

--- a/src/account.c
+++ b/src/account.c
@@ -386,6 +386,7 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 {
 	struct pl auth_user, tmp;
 	size_t i;
+	uint32_t u32;
 	int err = 0;
 	char *value;
 
@@ -405,6 +406,14 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 	err |= param_u32(&acc->fbregint, &aor->params, "fbregint");
 	acc->pubint = 0;
 	err |= param_u32(&acc->pubint, &aor->params, "pubint");
+	u32  = 0;
+	err |= param_u32(&u32, &aor->params, "tcpsrcport");
+	if (u32) {
+		if (u32 <= 0xffff)
+			acc->tcpsrcport = u32;
+		else
+			warning("account: invalid tcpsrcport\n");
+	}
 
 	err |= param_dstr(&acc->regq, &aor->params, "regq");
 

--- a/src/core.h
+++ b/src/core.h
@@ -62,6 +62,7 @@ struct account {
 	uint32_t rwait;              /**< R. Int. in [%] from proxy expiry   */
 	uint32_t pubint;             /**< Publication interval in [seconds]  */
 	uint32_t prio;               /**< Prio for serial registration       */
+	uint16_t tcpsrcport;         /**< TCP source port for SIP            */
 	char *regq;                  /**< Registration Q-value               */
 	char *sipnat;                /**< SIP Nat mechanism                  */
 	char *stun_user;             /**< STUN Username                      */

--- a/src/reg.c
+++ b/src/reg.c
@@ -230,7 +230,7 @@ int reg_register(struct reg *reg, const char *reg_uri, const char *params,
 		err = sipreg_set_fbregint(reg->sipreg, acc->fbregint);
 
 	if (acc && acc->tcpsrcport)
-		err = sipreg_set_srcport(reg->sipreg, acc->tcpsrcport);
+		sipreg_set_srcport(reg->sipreg, acc->tcpsrcport);
 
 	if (failed)
 		sipreg_incfailc(reg->sipreg);

--- a/src/reg.c
+++ b/src/reg.c
@@ -209,7 +209,7 @@ int reg_register(struct reg *reg, const char *reg_uri, const char *params,
 
 	failed = sipreg_failed(reg->sipreg);
 	reg->sipreg = mem_deref(reg->sipreg);
-	err = sipreg_register(&reg->sipreg, uag_sip(), reg_uri,
+	err = sipreg_alloc(&reg->sipreg, uag_sip(), reg_uri,
 			      account_aor(acc),
 			      acc ? acc->dispname : NULL, account_aor(acc),
 			      regint, ua_local_cuser(reg->ua),
@@ -229,10 +229,18 @@ int reg_register(struct reg *reg, const char *reg_uri, const char *params,
 	if (acc && acc->fbregint)
 		err = sipreg_set_fbregint(reg->sipreg, acc->fbregint);
 
+	if (acc && acc->tcpsrcport)
+		err = sipreg_set_srcport(reg->sipreg, acc->tcpsrcport);
+
 	if (failed)
 		sipreg_incfailc(reg->sipreg);
 
-	return err;
+	if (err) {
+		reg->sipreg = mem_deref(reg->sipreg);
+		return err;
+	}
+
+	return sipreg_send(reg->sipreg);
 }
 
 


### PR DESCRIPTION
related to: https://github.com/baresip/re/pull/198

Adds a new account related parameter for the SIP TCP source port.

Some Session Border Controller (SBC) or other SIP components require the
ability to set a static source port at a UAC for SIP TCP connections. If the
new setting `sip_tcpsrcport` is not used, the source port still is
randomly chosen from the ephemeral ports range.

UDP source port can already be set by `sip_listen` setting.

SIP devices that have such a configuration setting: Konftel 800, Mitel 6800/6900

