### PR TITLE
test: fix warning on mingw32

### DIFF
--- a/test/account.c
+++ b/test/account.c
@@ -148,7 +148,7 @@ int test_account_uri_complete(void)
 
 	struct sip_addr addr[2];
 	struct pl pl;
-	struct mbuf *mb[2];
+	struct mbuf *mb[2] = {NULL, NULL};
 	struct account *acc = NULL;
 	int err = 0;
 	int i, j;


### PR DESCRIPTION
test/account.c:182:14: warning: 'mb[0]' may be used uninitialized in this function [-Wmaybe-uninitialized]