### PR TITLE
module auresamp

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -108,6 +108,7 @@ module			g711.so
 #module			ilbc.so
 
 # Audio filter Modules (in encoding order)
+module			auresamp.so
 #module			vumeter.so
 #module			sndfile.so
 #module			plc.so

--- a/mk/modules.mk
+++ b/mk/modules.mk
@@ -176,6 +176,7 @@ endif # MOD_AUTODETECT
 ifneq ($(BASIC_MODULES),no)
 MODULES   += account
 MODULES   += auconv
+MODULES   += auresamp
 MODULES   += contact
 MODULES   += ctrl_tcp
 MODULES   += debug_cmd

--- a/modules/auresamp/auresamp.c
+++ b/modules/auresamp/auresamp.c
@@ -1,0 +1,234 @@
+/**
+ * @file auresamp.c  A filter module that inserts a resampler into the audio
+ *                   pipeline if needed
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+
+enum {
+	MAX_PTIME       =    60,  /* Maximum packet time in [ms] */
+};
+
+/**
+ *  The auresamp module is one of the audio filters. The order of the filters
+ *  is specified by the order in the config file.
+ *
+ *  .    .-------.   .----------.   .-------.   .---------.
+ *  |    |       |   |          |   |       |   |         |
+ *  |O-->| ausrc |-->| auresamp |-->| aubuf |-->| encoder |--> RTP
+ *  |    |       |   |          |   |       |   |         |
+ *  '    '-------'   '----------'   '-------'   '---------'
+ *
+ *       .--------.   .-------.   .----------.   .--------.
+ * |\    |        |   |       |   |          |   |        |
+ * | |<--| auplay |<--| aubuf |<--| auresamp |<--| decode |<-- RTP
+ * |/    |        |   |       |   |          |   |        |
+ *       '--------'   '-------'   '----------'   '--------'
+ */
+
+struct auresamp_st {
+	union {
+		struct aufilt_enc_st eaf;
+		struct aufilt_dec_st daf;
+	};                       /* inheritance              */
+
+	int16_t *sampv;          /* s16le audio data buffer  */
+	int16_t *rsampv;         /* resampled data           */
+	struct auresamp resamp;  /* resampler                */
+	struct aufilt_prm oprm;  /* filter output parameters */
+};
+
+
+static void destructor(void *arg)
+{
+	struct auresamp_st *st = arg;
+
+	mem_deref(st->rsampv);
+	mem_deref(st->sampv);
+}
+
+
+static int sampv_alloc(struct auresamp_st *st, struct auframe *af)
+{
+	size_t psize;
+
+	psize = MAX_PTIME * af->srate * af->ch * sizeof(int16_t) / 1000;
+	st->sampv = mem_zalloc(psize, NULL);
+
+	if (!st->sampv)
+		return ENOMEM;
+
+	return 0;
+}
+
+
+static int resamp_setup(struct auresamp_st *st, struct auframe *af)
+{
+	int err = 0;
+	size_t psize;
+
+	err = auresamp_setup(&st->resamp, af->srate, af->ch,
+			     st->oprm.srate, st->oprm.ch);
+	if (err) {
+		warning("resample: auresamp_setup error (%m)\n", err);
+		return err;
+	}
+
+	psize = MAX_PTIME * st->oprm.srate * st->oprm.ch * 2 / 1000;
+
+	st->rsampv = mem_deref(st->rsampv);
+	st->rsampv = mem_zalloc(psize, NULL);
+	if (!st->rsampv)
+		return ENOMEM;
+
+	return 0;
+}
+
+
+static int common_update(struct auresamp_st **stp, struct aufilt_prm *oprm)
+{
+	struct auresamp_st *st;
+	if (!stp || !oprm)
+		return EINVAL;
+
+	if (*stp)
+		return 0;
+
+	st = mem_zalloc(sizeof(*st), destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->oprm = *oprm;
+	auresamp_init(&st->resamp);
+
+	*stp = st;
+	return 0;
+}
+
+
+static int common_resample(struct auresamp_st *st, struct auframe *af)
+{
+	size_t outc;
+	int16_t *sampv = af->sampv;
+	int err = 0;
+
+	if (st->oprm.srate == af->srate && st->oprm.ch == af->ch)
+		return 0;
+
+	if (af->fmt != AUFMT_S16LE) {
+		if (!st->sampv)
+			err = sampv_alloc(st, af);
+
+		if (err)
+			return err;
+
+		auconv_to_s16(st->sampv, af->fmt, af->sampv, af->sampc);
+		sampv = st->sampv;
+	}
+
+	if (st->resamp.irate != af->srate || st->resamp.ich != af->ch)
+		err = resamp_setup(st, af);
+
+	if (err)
+		return err;
+
+	err = auresamp(&st->resamp, st->rsampv, &outc, sampv, af->sampc);
+	if (err) {
+		warning("resample: auresamp error (%m)\n", err);
+		return err;
+	}
+
+	af->sampc = outc;
+	af->fmt = st->oprm.fmt;
+	if (st->oprm.fmt != AUFMT_S16LE) {
+		auconv_from_s16(st->oprm.fmt, st->sampv, st->rsampv, outc);
+		af->sampv = st->sampv;
+	}
+	else {
+		af->sampv = st->rsampv;
+	}
+
+	return err;
+}
+
+
+static int encode_update(struct aufilt_enc_st **stp, void **ctx,
+			 const struct aufilt *af, struct aufilt_prm *oprm,
+			 const struct audio *au)
+{
+	struct auresamp_st **cstp = (struct auresamp_st **) stp;
+	int err;
+	(void)af;
+	(void)ctx;
+	(void)au;
+
+	err = common_update(cstp, oprm);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+
+static int decode_update(struct aufilt_dec_st **stp, void **ctx,
+			 const struct aufilt *af, struct aufilt_prm *oprm,
+			 const struct audio *au)
+{
+	struct auresamp_st **cstp = (struct auresamp_st **) stp;
+	int err;
+	(void)af;
+	(void)ctx;
+	(void)au;
+
+	err = common_update(cstp, oprm);
+	if (err)
+		return err;
+
+	return 0;
+}
+
+
+static int encode(struct aufilt_enc_st *aufilt_enc_st, struct auframe *af)
+{
+	struct auresamp_st *st = (struct auresamp_st *) aufilt_enc_st;
+	return common_resample(st, af);
+}
+
+
+static int decode(struct aufilt_dec_st *aufilt_dec_st, struct auframe *af)
+{
+	struct auresamp_st *st = (struct auresamp_st *) aufilt_dec_st;
+	return common_resample(st, af);
+}
+
+
+static struct aufilt resample = {
+	LE_INIT, "auresamp", encode_update, encode, decode_update, decode
+};
+
+
+static int module_init(void)
+{
+	aufilt_register(baresip_aufiltl(), &resample);
+
+	return 0;
+}
+
+
+static int module_close(void)
+{
+	aufilt_unregister(&resample);
+	return 0;
+}
+
+
+EXPORT_SYM const struct mod_export DECL_EXPORTS(auresamp) = {
+	"auresamp",
+	"filter",
+	module_init,
+	module_close
+};

--- a/modules/auresamp/module.mk
+++ b/modules/auresamp/module.mk
@@ -1,0 +1,10 @@
+#
+# module.mk
+#
+# Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+#
+
+MOD		:= auresamp
+$(MOD)_SRCS	+= auresamp.c
+
+include mk/mod.mk

--- a/src/audio.c
+++ b/src/audio.c
@@ -1608,6 +1608,13 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
 	aufilt_param_set(&decprm, rx->ac, rx->dec_fmt);
+	if (a->cfg.srate_play && a->cfg.srate_play != decprm.srate) {
+		decprm.srate = a->cfg.srate_play;
+	}
+
+	if (a->cfg.channels_play && a->cfg.channels_play != decprm.ch) {
+		decprm.ch = a->cfg.channels_play;
+	}
 
 	/* Audio filters */
 	for (le = list_head(aufiltl); le; le = le->next) {

--- a/src/audio.c
+++ b/src/audio.c
@@ -456,6 +456,12 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	if (!tx->ac || !tx->ac->ench)
 		return;
 
+	if (tx->ac->srate != af->srate || tx->ac->ch != af->ch) {
+		warning("audio: srate/ch does not match. Use module auresamp"
+			"\n");
+		return;
+	}
+
 	tx->mb->pos = tx->mb->end = STREAM_PRESZ;
 
 	if (a->level_enabled || bundled) {

--- a/src/config.c
+++ b/src/config.c
@@ -937,6 +937,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module\t\t\t" "codec2" MOD_EXT "\n");
 
 	(void)re_fprintf(f, "\n# Audio filter Modules (in encoding order)\n");
+	(void)re_fprintf(f, "module\t\t\t"  "auresamp" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "vumeter" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "sndfile" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "plc" MOD_EXT "\n");


### PR DESCRIPTION
Moves resample code from audio.c to a new module `auresamp`.

Proposed by @alfredh here: https://github.com/baresip/baresip/pull/1443

More discussions in this issue: https://github.com/baresip/baresip/issues/1699

TODOs:
- Not sure if the `struct auresamp_st` should have an "optional" inheritance by means of union.