### PR TITLE
stream: only call rtp_clear for audio

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -1139,7 +1139,8 @@ void stream_flush(struct stream *s)
 	if (s->rx.jbuf)
 		jbuf_flush(s->rx.jbuf);
 
-	rtp_clear(s->rtp);
+	if (s->type == MEDIA_AUDIO)
+		rtp_clear(s->rtp);
 }
 
 


### PR DESCRIPTION
Ref: https://github.com/baresip/baresip/issues/1676

the reason for this is that the first ~50 video packets are dropped during call setup,
causing the decoder to request a new keyframe and the video start to be delayed.

@cspiel1 could you please have a look why it was added ?