### PR TITLE
gtk: Avoid duplicate call_timer registration

### DIFF
--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -603,13 +603,20 @@ void call_window_ringing(struct call_window *win)
 	call_window_set_status(win, "ringing");
 }
 
+static void register_call_timer(struct call_window *win)
+{
+	if (!win->duration_timer_tag) {
+		win->duration_timer_tag = g_timeout_add_seconds(
+			1, call_timer, win);
+	}
+}
 
 void call_window_progress(struct call_window *win)
 {
 	if (!win)
 		return;
 
-	win->duration_timer_tag = g_timeout_add_seconds(1, call_timer, win);
+	register_call_timer(win);
 	pthread_mutex_lock(&last_data_mut);
 	last_call_win = win;
 	pthread_mutex_unlock(&last_data_mut);
@@ -624,10 +631,7 @@ void call_window_established(struct call_window *win)
 
 	call_window_update_duration(win);
 
-	if (!win->duration_timer_tag) {
-		win->duration_timer_tag = g_timeout_add_seconds(1, call_timer,
-								win);
-	}
+	register_call_timer(win);
 
 	pthread_mutex_lock(&last_data_mut);
 	last_call_win = win;


### PR DESCRIPTION
There were cases where the call_window_progress function was called
twice before the call was established.

- call: SIP Progress: 183 Session Progress (application/sdp)
- call: SIP Progress: 181 Call Is Being Forwarded (application/sdp)

This caused multiple registrations of the call_timer function. But
only the last one was later removed in call_window_destructor.

When this happens the call_timer function is called with an already
freed call_window parameter. It then crashed when accessing the
poisoned pointer value call in the structure:

Thread 2 "baresip" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff50da700 (LWP 27424)]
0x0000555555571fc0 in call_duration (call=0xb5b5b5b5b5b5b5b5) at src/call.c:2260
2260        if (!call || !call->time_start)

Adding a new function register_call_timer to avoid code duplication
in call_window_progress and call_window_established.

This fixes issue #1708.