### PR TITLE
menu: exclude given call when searching for active call

### DIFF
--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -59,6 +59,6 @@ void dial_menu_unregister(void);
 /*Generic menu funtions*/
 void menu_update_callstatus(bool incall);
 int  menu_param_decode(const char *prm, const char *name, struct pl *val);
-struct call *menu_find_call(call_match_h *matchh);
+struct call *menu_find_call(call_match_h *matchh, const struct call *exclude);
 struct call *menu_find_call_state(enum call_state st);
 enum sdp_dir decode_sdp_enum(const struct pl *pl);


### PR DESCRIPTION
When a UA event occurs menu needs to search for other active calls to decide
which tone should be played.
E.g. on UA_EVENT_CALL_CLOSED menu is looking for another active call while the
closed call may still be in CALL_STATE_ESTABLISHED. In this case the closed
call should be excluded from the search.

This fixes resume of ringback tone for multiple parallel outgoing calls, when
the first peer declines the call.
