### PR TITLE
audio use module auconv

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -108,6 +108,7 @@ module			g711.so
 #module			ilbc.so
 
 # Audio filter Modules (in encoding order)
+module			auconv.so
 module			auresamp.so
 #module			vumeter.so
 #module			sndfile.so

--- a/src/audio.c
+++ b/src/audio.c
@@ -1440,6 +1440,7 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 	err = re_hprintf(pf, "audio tx pipeline:  %10s",
 			 autx->as ? autx->as->name : "(src)");
 
+	err |= re_hprintf(pf, " ---> aubuf");
 	for (le = list_head(&autx->filtl); le; le = le->next) {
 		struct aufilt_enc_st *st = le->data;
 
@@ -1465,6 +1466,7 @@ static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *aurx)
 	err = re_hprintf(pf, "audio rx pipeline:  %10s",
 			 aurx->ap ? aurx->ap->name : "(play)");
 
+	err |= re_hprintf(pf, " <--- aubuf");
 	for (le = list_head(&aurx->filtl); le; le = le->next) {
 		struct aufilt_dec_st *st = le->data;
 

--- a/src/config.c
+++ b/src/config.c
@@ -937,6 +937,7 @@ int config_write_template(const char *file, const struct config *cfg)
 	(void)re_fprintf(f, "#module\t\t\t" "codec2" MOD_EXT "\n");
 
 	(void)re_fprintf(f, "\n# Audio filter Modules (in encoding order)\n");
+	(void)re_fprintf(f, "module\t\t\t"  "auconv" MOD_EXT "\n");
 	(void)re_fprintf(f, "module\t\t\t"  "auresamp" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "vumeter" MOD_EXT "\n");
 	(void)re_fprintf(f, "#module\t\t\t" "sndfile" MOD_EXT "\n");


### PR DESCRIPTION
- audio: use module auconv for optional tx format conversion
- audio: use module auconv for optional rx format conversion
- config: add auconv as default module

TODO:
The print pipeline shows that the filters are processed in different order.
```
audio tx pipeline:       pulse ---> auconv ---> auresamp ---> opus
audio rx pipeline:       pulse <--- auconv <--- auresamp <--- opus
```
We want auconv to be processed always first. Otherwise auresamp has to do extra conversion internally if rx decoder works with float. Should we change the filter processing order to be head to top for tx and rx?