### PR TITLE
audio: allocate aubuf before ausrc_alloc (fixes data race)

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1772,7 +1772,6 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 				return err;
 		}
 
-
 		tx->as = ausrc_find(ausrcl, tx->module);
 
 		switch (a->cfg.txmode) {

--- a/src/audio.c
+++ b/src/audio.c
@@ -1762,6 +1762,8 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 		}
 
 		/* recalculate and resize aubuf if ausrc_alloc changes prm */
+		tx->src_fmt = prm.fmt;
+		sz = aufmt_sample_size(tx->src_fmt);
 		tx->psize = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 		if (psize_alloc != tx->psize) {
 			tx->ausrc_prm = prm;

--- a/src/audio.c
+++ b/src/audio.c
@@ -1738,8 +1738,6 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 
 		sz = aufmt_sample_size(tx->src_fmt);
 
-		tx->ausrc_prm = prm;
-
 		psize_alloc = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 		tx->psize = psize_alloc;
 		tx->aubuf_maxsz = tx->psize * 30;
@@ -1761,6 +1759,8 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			return err;
 		}
 
+		tx->ausrc_prm = prm;
+
 		/* recalculate and resize aubuf if ausrc_alloc changes prm */
 		tx->psize = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 		if (psize_alloc != tx->psize) {
@@ -1770,6 +1770,7 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			if (err)
 				return err;
 		}
+
 
 		tx->as = ausrc_find(ausrcl, tx->module);
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1736,6 +1736,8 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 		prm.ptime      = tx->ptime;
 		prm.fmt        = tx->src_fmt;
 
+		tx->ausrc_prm = prm;
+
 		sz = aufmt_sample_size(tx->src_fmt);
 
 		psize_alloc = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
@@ -1759,11 +1761,10 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			return err;
 		}
 
-		tx->ausrc_prm = prm;
-
 		/* recalculate and resize aubuf if ausrc_alloc changes prm */
 		tx->psize = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 		if (psize_alloc != tx->psize) {
+			tx->ausrc_prm = prm;
 			tx->aubuf_maxsz = tx->psize * 30;
 			err = aubuf_resize(tx->aubuf, tx->psize,
 					   tx->aubuf_maxsz);

--- a/src/audio.c
+++ b/src/audio.c
@@ -1737,16 +1737,6 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 
 		sz = aufmt_sample_size(tx->src_fmt);
 
-		err = ausrc_alloc(&tx->ausrc, ausrcl,
-				  tx->module,
-				  &prm, tx->device,
-				  ausrc_read_handler, ausrc_error_handler, a);
-		if (err) {
-			warning("audio: start_source failed (%s.%s): %m\n",
-				tx->module, tx->device, err);
-			return err;
-		}
-
 		tx->ausrc_prm = prm;
 		tx->psize = sz * calc_nsamp(prm.srate, prm.ch, prm.ptime);
 
@@ -1757,6 +1747,16 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 					  tx->aubuf_maxsz);
 			if (err)
 				return err;
+		}
+
+		err = ausrc_alloc(&tx->ausrc, ausrcl,
+				  tx->module,
+				  &prm, tx->device,
+				  ausrc_read_handler, ausrc_error_handler, a);
+		if (err) {
+			warning("audio: start_source failed (%s.%s): %m\n",
+				tx->module, tx->device, err);
+			return err;
 		}
 
 		tx->as = ausrc_find(ausrcl, tx->module);


### PR DESCRIPTION
WARNING: ThreadSanitizer: data race (pid=59549)
  Read of size 8 at 0x7b3800003ed8 by thread T2 (mutexes: read M1643):
    #0 aubuf_cur_size /rem/src/aubuf/aubuf.c:392:11 (baresip+0x205044)
    #1 ausrc_read_handler /baresip/src/audio.c:886:6 (baresip+0x11d6ac)
    #2 read_thread /baresip/modules/alsa/alsa_src.c:88:3 (baresip+0x16a193)

  Previous write of size 8 at 0x7b3800003ed8 by main thread (mutexes: write M1554):
    #0 memset <null> (baresip+0xcc85d)
    #1 mem_zalloc /re/src/mem/mem.c:178:2 (baresip+0x1f4273)
    #2 aubuf_alloc /rem/src/aubuf/aubuf.c:78:7 (baresip+0x20453a)
    #3 start_source /baresip/src/audio.c:1756:10 (baresip+0x11bb77)
    #4 audio_start /baresip/src/audio.c:1823:9 (baresip+0x11b148)
    #5 audio_encoder_set /baresip/src/audio.c:1982:10 (baresip+0x11c44b)
    #6 start_audio /baresip/src/call.c:146:10 (baresip+0x126b01)
    #7 menc_event_handler /baresip/src/call.c:488:10 (baresip+0x121f10)
    #8 dtls_estab_handler /baresip/modules/dtls_srtp/dtls_srtp.c:269:4 (baresip+0x17545a)
    #9 conn_recv /re/src/tls/openssl/tls_udp.c:402:4 (baresip+0x1e819d)
    #10 recv_handler /re/src/tls/openssl/tls_udp.c:772:3 (baresip+0x1e819d)
    #11 udp_read /re/src/udp/udp.c:237:10 (baresip+0x1debc5)
    #12 udp_read_handler /re/src/udp/udp.c:255:2 (baresip+0x1de541)
    #13 fd_poll /re/src/main/main.c:885:4 (baresip+0x1f2fe6)
    #14 re_main /re/src/main/main.c:1023:9 (baresip+0x1f2fe6)
    #15 main /baresip/src/main.c:299:8 (baresip+0x145524)

  Location is heap block of size 216 at 0x7b3800003e20 allocated by main thread:
    #0 malloc <null> (baresip+0x8f12e)
    #1 mem_alloc /re/src/mem/mem.c:141:6 (baresip+0x1f409d)
    #2 mem_zalloc /re/src/mem/mem.c:174:6 (baresip+0x1f425e)
    #3 aubuf_alloc /rem/src/aubuf/aubuf.c:78:7 (baresip+0x20453a)
    #4 start_source /baresip/src/audio.c:1756:10 (baresip+0x11bb77)
    #5 audio_start /baresip/src/audio.c:1823:9 (baresip+0x11b148)
    #6 audio_encoder_set /baresip/src/audio.c:1982:10 (baresip+0x11c44b)
    #7 start_audio /baresip/src/call.c:146:10 (baresip+0x126b01)
    #8 menc_event_handler /baresip/src/call.c:488:10 (baresip+0x121f10)