### PR TITLE
Multicast identical condition and fmt string fix

### DIFF
--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -173,7 +173,7 @@ static const struct aucodec *pt2codec(const struct rtp_header *hdr)
 
 		default:
 			warning ("multicast receiver: RTP Payload "
-				"Type %d not found.\n");
+				"Type %d not found.\n", hdr->pt);
 			break;
 	}
 

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -187,7 +187,7 @@ static void poll_aubuf_tx(struct mcsource *src)
 	num_bytes = src->psize;
 	sampc = num_bytes / sz;
 
-	if (src->enc_fmt == AUFMT_S16LE) {
+	if (src->src_fmt == AUFMT_S16LE) {
 		aubuf_read(src->aubuf, (uint8_t *)sampv, num_bytes);
 	}
 	else if (src->enc_fmt == AUFMT_S16LE) {


### PR DESCRIPTION
* Fix identical condition: Issue #1750 fix.
* Fix missing argument in warning with format string