### PR TITLE
call: send supported header for 200 answering/ok

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1259,10 +1259,16 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 	if (err)
 		return err;
 
-	err = sipsess_answer(call->sess, scode, "Answering", desc,
-			     "Allow: %H\r\n"
-			     "%H", ua_print_allowed, call->ua,
-			     ua_print_supported, call->ua);
+	if (scode >= 200 && scode < 300) {
+		err = sipsess_answer(call->sess, scode, "Answering", desc,
+				"Allow: %H\r\n"
+				"%H", ua_print_allowed, call->ua,
+				ua_print_supported, call->ua);
+	}
+	else {
+		err = sipsess_answer(call->sess, scode, "Answering", desc,
+				"Allow: %H\r\n", ua_print_allowed, call->ua);
+	}
 
 	call->answered = true;
 

--- a/src/call.c
+++ b/src/call.c
@@ -1260,7 +1260,9 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 		return err;
 
 	err = sipsess_answer(call->sess, scode, "Answering", desc,
-			     "Allow: %H\r\n", ua_print_allowed, call->ua);
+			     "Allow: %H\r\n"
+			     "%H", ua_print_allowed, call->ua,
+			     ua_print_supported, call->ua);
 
 	call->answered = true;
 


### PR DESCRIPTION
* Add supported header into 200 Answering/OK sip package: Fix for #1746
* Traced with wireshark. Now Supported header is included in 200 package.