### PR TITLE
event: check if media line is present for encoding audio/video dir

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -137,7 +137,10 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 		      struct call *call, const char *prm)
 {
 	const char *event_str = uag_event_str(ev);
+	struct sdp_media *amedia;
+	struct sdp_media *vmedia;
 	enum sdp_dir ardir;
+	enum sdp_dir vrdir;
 	int err = 0;
 
 	if (!od)
@@ -178,10 +181,20 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 						   call_identifier);
 		}
 
-		ardir = sdp_media_rdir(
-				stream_sdpmedia(audio_strm(call_audio(call))));
+		amedia = stream_sdpmedia(audio_strm(call_audio(call)));
+		ardir = sdp_media_rdir(amedia);
+		if (!sa_isset(sdp_media_raddr(amedia), SA_ADDR))
+			ardir = SDP_INACTIVE;
+
+		vmedia = stream_sdpmedia(video_strm(call_video(call)));
+		vrdir = sdp_media_rdir(vmedia);
+		if (!sa_isset(sdp_media_raddr(vmedia), SA_ADDR))
+			vrdir = SDP_INACTIVE;
+
 		err |= odict_entry_add(od, "remoteaudiodir", ODICT_STRING,
 				sdp_dir_name(ardir));
+		err |= odict_entry_add(od, "remotevideodir", ODICT_STRING,
+				sdp_dir_name(vrdir));
 
 		if (err)
 			goto out;


### PR DESCRIPTION
Adds remotevideodir and fixes remoteaudiodir. If the media line is not present
we want to report "inactive" instead of "sendrecv" in the UA event.
