### PR TITLE
Stop audio_alert on UA_EVENT_CALL_CLOSED

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -650,6 +650,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			play_resume(call);
 		}
 
+		menu_stop_play();
 		hash_apply(menu.ovaufile->ht, ovaufile_del, call);
 		break;
 


### PR DESCRIPTION
Fix for https://github.com/baresip/baresip/issues/1733