### PR TITLE
menu select other call on hangup

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -59,12 +59,10 @@ static int menu_set_incall(bool incall)
 
 static void tmrstat_handler(void *arg)
 {
-	struct call *call;
 	(void)arg;
 
-	/* the UI will only show the current active call */
-	call = menu_callcur();
-	if (!call)
+	/* the UI will only show the current current call */
+	if (!menu.curcall)
 		return;
 
 	tmr_start(&menu.tmr_stat, 100, tmrstat_handler, 0);
@@ -73,7 +71,7 @@ static void tmrstat_handler(void *arg)
 		return;
 
 	if (STATMODE_OFF != menu.statmode) {
-		(void)re_fprintf(stderr, "%H\r", call_status, call);
+		(void)re_fprintf(stderr, "%H\r", call_status, menu.curcall);
 	}
 }
 
@@ -81,7 +79,7 @@ static void tmrstat_handler(void *arg)
 void menu_update_callstatus(bool incall)
 {
 	/* if there are any active calls, enable the call status view */
-	if (incall)
+	if (incall && menu_callcur())
 		tmr_start(&menu.tmr_stat, 100, tmrstat_handler, 0);
 	else
 		tmr_cancel(&menu.tmr_stat);
@@ -307,7 +305,7 @@ static void play_ringback(const struct call *call)
 
 static void play_resume(const struct call *closed)
 {
-	struct call *call = uag_call_find(menu.callid);
+	struct call *call = menu_callcur();
 
 	switch (call_state(call)) {
 	case CALL_STATE_INCOMING:
@@ -645,7 +643,8 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			menu.xfer_targ = NULL;
 		}
 
-		if (!str_cmp(call_id(call), menu.callid)) {
+		if (call == menu.curcall) {
+			menu.curcall = NULL;
 			if (count==1)
 				menu_play_closed(call);
 
@@ -768,7 +767,7 @@ static bool filter_call(const struct call *call, void *arg)
 {
 	struct filter_arg *fa = arg;
 
-	if (call_state(call) != fa->state)
+	if (fa->state != CALL_STATE_UNKNOWN && call_state(call) != fa->state)
 		return false;
 
 	if (call == fa->exclude)
@@ -782,23 +781,19 @@ static bool filter_call(const struct call *call, void *arg)
 
 
 /**
- * Selects the given call to be the active call.
+ * Selects the given call to be the current call.
  *
  * @param call The call
  */
 void menu_selcall(struct call *call)
 {
-	menu.callid = mem_deref(menu.callid);
-
-	if (call) {
-		str_dup(&menu.callid, call_id(call));
-		call_set_current(ua_calls(call_get_ua(call)), call);
-	}
+	menu.curcall = call;
+	call_set_current(ua_calls(call_get_ua(call)), call);
 }
 
 
 /**
- * Chooses a new active call.
+ * Chooses a new current call.
  * Prefer call state established before early, ringing, outgoing and incoming
  */
 static void menu_sel_other(struct call *exclude)
@@ -833,7 +828,13 @@ static void menu_sel_other(struct call *exclude)
  */
 struct call *menu_callcur(void)
 {
-	return uag_call_find(menu.callid);
+	struct filter_arg fa = {CALL_STATE_UNKNOWN, NULL, menu.curcall, NULL};
+
+	if (!menu.curcall)
+		return NULL;
+
+	uag_filter_calls(find_first_call, filter_call, &fa);
+	return fa.call;
 }
 
 
@@ -1035,7 +1036,6 @@ static int module_close(void)
 
 	tmr_cancel(&menu.tmr_stat);
 	menu.dialbuf = mem_deref(menu.dialbuf);
-	menu.callid = mem_deref(menu.callid);
 	menu.ovaufile = mem_deref(menu.ovaufile);
 	menu.ansval = mem_deref(menu.ansval);
 	menu_stop_play();

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -29,6 +29,7 @@ enum {
 struct filter_arg {
 	enum call_state state;
 	const struct call *exclude;
+	const struct call *match;
 	struct call *call;
 };
 
@@ -165,7 +166,7 @@ struct call *menu_find_call_state(enum call_state st)
  */
 struct call *menu_find_call(call_match_h *matchh, const struct call *exclude)
 {
-	struct filter_arg fa = {CALL_STATE_UNKNOWN, exclude, NULL};
+	struct filter_arg fa = {CALL_STATE_UNKNOWN, exclude, NULL, NULL};
 
 	uag_filter_calls(find_first_call, matchh, &fa);
 	return fa.call;
@@ -773,6 +774,9 @@ static bool filter_call(const struct call *call, void *arg)
 	if (call == fa->exclude)
 		return false;
 
+	if (fa->match && call != fa->match)
+		return false;
+
 	return true;
 }
 
@@ -800,7 +804,7 @@ void menu_selcall(struct call *call)
 static void menu_sel_other(struct call *exclude)
 {
 	int i;
-	struct filter_arg fa = {CALL_STATE_UNKNOWN, exclude, NULL};
+	struct filter_arg fa = {CALL_STATE_UNKNOWN, exclude, NULL, NULL};
 	enum call_state state[] = {
 		CALL_STATE_INCOMING,
 		CALL_STATE_OUTGOING,

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -647,6 +647,8 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 			menu.curcall = NULL;
 			if (count==1)
 				menu_play_closed(call);
+			else
+				menu_stop_play();
 
 			menu_sel_other(call);
 			play_resume(call);

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -18,7 +18,7 @@ struct menu{
 	struct mbuf *dialbuf;         /**< Buffer for dialled number      */
 	struct call *xfer_call;       /**< Attended transfer call         */
 	struct call *xfer_targ;       /**< Transfer target call           */
-	char *callid;                 /**< Call-id of active call         */
+	const struct call *curcall;   /**< Call-id of current call        */
 	bool ringback_disabled;       /**< no ringback on sip 180 respons */
 	bool ringback;                /**< Ringback played currently      */
 	struct tmr tmr_redial;        /**< Timer for auto-reconnect       */


### PR DESCRIPTION
- menu: fix current call selection on `CALL_STATE_CLOSED` (#1733)
- menu: add call pointer match to `filter_arg` (#1733)
- menu: replace current call-id by pointer (#1733)

In some setups it is possible to receive multiple incoming calls with equal
call-id. This PR solves tracking of the current call if there are multiple
calls with identical call-id.
