### PR TITLE
audio: fix rx_thread (adaptive jitter buffer)

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -735,14 +735,17 @@ static void *rx_thread(void *arg)
 {
 	struct audio *a = arg;
 	struct timespec ts;
-	uint64_t ms;
+	static const uint16_t ms = 500;
 	int err = 0;
 
 	while (a->rx.thr.run) {
-
-		ms = tmr_jiffies() + 500;
-		ts.tv_sec = (time_t)(ms / 1000);
-		ts.tv_nsec = (ms % 1000) * 1000000UL;
+		clock_gettime(CLOCK_REALTIME, &ts);
+		ts.tv_sec += ms / 1000;
+		ts.tv_nsec += (ms % 1000) * 1000000;
+		if (ts.tv_nsec >= 1000000000L) {
+			ts.tv_sec++;
+			ts.tv_nsec -= 1000000000L;
+		}
 
 		err = pthread_mutex_lock(&a->rx.thr.mutex);
 		if (err)

--- a/src/audio.c
+++ b/src/audio.c
@@ -14,6 +14,9 @@
 #ifdef HAVE_PTHREAD
 #include <pthread.h>
 #endif
+#if defined(HAVE_PTHREAD) && defined(WIN32)
+#include <pthread_time.h> /* needs mingw-w64 winpthreads */
+#endif
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>


### PR DESCRIPTION
tmr_jiffies should only be used to compare/measure time in ms. But pthread_cond_timedwait relies on a REALTIME value.

fixes #1768 