### PR TITLE
test: refactoring of test_account_uri_complete

### DIFF
--- a/test/account.c
+++ b/test/account.c
@@ -77,110 +77,77 @@ int test_account(void)
 }
 
 
-static int sip_addr_check(const struct sip_addr *a1, const struct sip_addr *a2,
-		const char *uri)
-{
-	int err;
-	char *uri1 = NULL;
-	char *uri2 = NULL;
-
-	ASSERT_PLEQ(&a2->dname,  &a1->dname);
-	ASSERT_PLEQ(&a2->auri,   &a1->auri);
-	ASSERT_PLEQ(&a2->params, &a1->params);
-
-	err = re_sdprintf(&uri1, "%H", uri_encode, &a1->uri);
-	TEST_ERR(err);
-
-	err = re_sdprintf(&uri2, "%H", uri_encode, &a2->uri);
-	TEST_ERR(err);
-
-	ASSERT_STREQ(uri2, uri1);
-	ASSERT_STREQ(uri, uri1);
-out:
-	mem_deref(uri1);
-	mem_deref(uri2);
-	return err;
-}
-
-
 int test_account_uri_complete(void)
 {
-	/* compare odd URIs with even URIs */
-	const char *uri[] = {
-		"192.168.1.2",
-		"sip:192.168.1.2",
+	static const struct test {
+		const char *in;
+		const char *out;
+	} testv[] = {
 
-		"192.168.1.2:5677",
-		"sip:192.168.1.2:5677",
+		{ "192.168.1.2",
+		  "sip:192.168.1.2" },
+
+		{ "192.168.1.2:5677",
+		  "sip:192.168.1.2:5677", },
+
+		{ "user",
+		  "sip:user@proxy.com" },
+
+		{ "user@domain.com",
+		  "sip:user@domain.com" },
+
+		{ "user@domain.com:5677",
+		  "sip:user@domain.com:5677" },
+
+		{ "sip:user",
+		  "sip:user@proxy.com" },
+
+		{ "sip:user@domain.com",
+		  "sip:user@domain.com" },
+
 #if HAVE_INET6
-		"[2113:1470:1f1b:24b::2]",
-		"sip:[2113:1470:1f1b:24b::2]",
+		{"[2113:1470:1f1b:24b::2]",
+		 "sip:[2113:1470:1f1b:24b::2]"},
 
-		"[fe80::b62e:99ff:feee:268f]",
-		"sip:[fe80::b62e:99ff:feee:268f]",
+		{"[fe80::b62e:99ff:feee:268f]",
+		 "sip:[fe80::b62e:99ff:feee:268f]"},
 
-		"x@[2113:1470:1f1b:24b::2]",
-		"sip:x@[2113:1470:1f1b:24b::2]",
+		{"x@[2113:1470:1f1b:24b::2]",
+		 "sip:x@[2113:1470:1f1b:24b::2]"},
 
-		"[2113:1470:1f1b:24b::2]:5677",
-		"sip:[2113:1470:1f1b:24b::2]:5677",
+		{"[2113:1470:1f1b:24b::2]:5677",
+		 "sip:[2113:1470:1f1b:24b::2]:5677"},
 
-		"x@[2113:1470:1f1b:24b::2]:5677",
-		"sip:x@[2113:1470:1f1b:24b::2]:5677",
+		{"x@[2113:1470:1f1b:24b::2]:5677",
+		 "sip:x@[2113:1470:1f1b:24b::2]:5677"},
 #endif
-		"user",
-		"sip:user@proxy.com",
-
-		"user@domain.com",
-		"sip:user@domain.com",
-
-		"user@domain.com:5677",
-		"sip:user@domain.com:5677",
-
-		"sip:user",
-		"sip:user@proxy.com",
-
-		"sip:user@domain.com",
-		"sip:user@domain.com",
-
-		NULL
 	};
 
-	struct sip_addr addr[2];
-	struct pl pl;
-	struct mbuf *mb[2] = {NULL, NULL};
+	struct mbuf *mb = NULL;
 	struct account *acc = NULL;
 	int err = 0;
-	int i, j;
 
 	err = account_alloc(&acc, "\"A\" <sip:A@proxy.com>");
 	TEST_ERR(err);
-	ASSERT_TRUE(acc != NULL);
 
-	mb[0] = mbuf_alloc(1);
-	ASSERT_TRUE(mb[0] != NULL);
-	mb[1] = mbuf_alloc(1);
-	ASSERT_TRUE(mb[1] != NULL);
+	mb = mbuf_alloc(256);
+	ASSERT_TRUE(mb != NULL);
 
-	for (i = 0; uri[i]; ++i) {
-		j = i % 2;
-		mbuf_reset(mb[j]);
-		err = account_uri_complete(acc, mb[j], uri[i]);
-		TEST_ERR_TXT(err, uri[i]);
+	for (size_t i=0; i<ARRAY_SIZE(testv); i++) {
 
-		mbuf_set_pos(mb[j], 0);
-		pl_set_mbuf(&pl, mb[j]);
-		err = sip_addr_decode(&addr[j], &pl);
-		TEST_ERR_TXT(err, uri[i]);
+		const struct test *test = &testv[i];
 
-		if (i % 2 == 1) {
-			err = sip_addr_check(&addr[0], &addr[1], uri[i]);
-			TEST_ERR_TXT(err, uri[i - 1]);
-		}
+		err = account_uri_complete(acc, mb, test->in);
+		TEST_ERR_TXT(err, test->in);
+
+		TEST_STRCMP(test->out, str_len(test->out), mb->buf, mb->end);
+
+		mbuf_rewind(mb);
 	}
-out:
-	mem_deref(mb[0]);
-	mem_deref(mb[1]);
+
+ out:
+	mem_deref(mb);
 	mem_deref(acc);
+
 	return err;
 }


### PR DESCRIPTION
rewrite the test so that each array entry is a pair of input string and expected output string.
reduces complexity, not sure if the explicit compare function was needed ?

@cspiel1 please review
