### PR TITLE
menu: support audio file config value "none"

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -251,7 +251,7 @@ static bool menu_play(const struct call *call,
 	if (!pl_isset(&pl))
 		pl_set_str(&pl, fname);
 
-	if (!pl_isset(&pl))
+	if (!pl_isset(&pl) || !pl_strcmp(&pl, "none"))
 		return false;
 
 	pl_strdup(&file, &pl);


### PR DESCRIPTION
E.g. suppresses the ringtone.
```
ring_aufile		none
```

E.g. can be used in combination with
```c
        module_event("intercom", "override-aufile", ua, call, "ring_aufile:icring_aufile");
```
```
icring_aufile		none
```
in order to suppress the ringtone.