### PR TITLE
Added API function call_diverteruri

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -217,6 +217,7 @@ const char   *call_peeruri(const struct call *call);
 const char   *call_peername(const struct call *call);
 const char   *call_localuri(const struct call *call);
 const char   *call_alerturi(const struct call *call);
+const char   *call_diverteruri(const struct call *call);
 struct audio *call_audio(const struct call *call);
 struct video *call_video(const struct call *call);
 struct list  *call_streaml(const struct call *call);

--- a/src/call.c
+++ b/src/call.c
@@ -724,7 +724,8 @@ static void call_decode_diverter(struct call *call, const struct sip_msg *msg)
 
 	err = sip_addr_decode(&addr, &hdr->val);
 	if (err) {
-		warning("call: error parsing diverter address: %r\n", &hdr->val);
+		warning("call: error parsing diverter address: %r\n",
+			&hdr->val);
 		return;
 	}
 


### PR DESCRIPTION
Added API function `call_diverteruri` taken from History-Info or Diversion header.  Needed in order to be able to show to user who (if any) has diverted the incoming call.  Even though Diversion header has officially been replaced by History-Info, Diversion is still widely used.  Both have worked fine in my tests.