### PR TITLE
Avoid undeclared 'CLOCK_REALTIME' on RHEL/CentOS 7 (fixes #1781)

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -6,6 +6,7 @@
  */
 #define _DEFAULT_SOURCE 1
 #define _BSD_SOURCE 1
+#define _POSIX_C_SOURCE 199309L
 #include <string.h>
 #include <stdlib.h>
 #ifdef HAVE_UNISTD_H
@@ -17,6 +18,7 @@
 #if defined(HAVE_PTHREAD) && defined(WIN32)
 #include <pthread_time.h> /* needs mingw-w64 winpthreads */
 #endif
+#include <time.h>
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>


### PR DESCRIPTION
Build-time failure without this patch:

```
src/audio.c: In function 'rx_thread':
src/audio.c:746:3: warning: implicit declaration of function 'clock_gettime'; did you mean 'calc_ptime'? [-Wimplicit-function-declaration]
   clock_gettime(CLOCK_REALTIME, &ts);
   ^~~~~~~~~~~~~
   calc_ptime
src/audio.c:746:3: warning: nested extern declaration of 'clock_gettime' [-Wnested-externs]
src/audio.c:746:17: error: 'CLOCK_REALTIME' undeclared (first use in this function)
   clock_gettime(CLOCK_REALTIME, &ts);
                 ^~~~~~~~~~~~~~
```