### PR TITLE
aubuf adaptive jitter buffer

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -50,6 +50,7 @@ auplay_format		s16		# s16, float, ..
 auenc_format		s16		# s16, float, ..
 audec_format		s16		# s16, float, ..
 audio_buffer		20-160		# ms
+audio_buffer_mode	fixed		# fixed, adaptive
 audio_telev_pt		101		# payload type for telephone-event
 
 # Video

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -51,6 +51,7 @@ auenc_format		s16		# s16, float, ..
 audec_format		s16		# s16, float, ..
 audio_buffer		20-160		# ms
 audio_buffer_mode	fixed		# fixed, adaptive
+audio_silence		-35.0		# in [dB]
 audio_telev_pt		101		# payload type for telephone-event
 
 # Video

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -277,6 +277,7 @@ int  conf_get_vidsz(const struct conf *conf, const char *name,
 		    struct vidsz *sz);
 int  conf_get_sa(const struct conf *conf, const char *name, struct sa *sa);
 enum jbuf_type conf_get_jbuf_type(const struct pl *pl);
+bool conf_aubuf_adaptive(const struct pl *pl);
 void conf_close(void);
 struct conf *conf_cur(void);
 int conf_loadfile(struct mbuf **mbp, const char *filename);
@@ -338,6 +339,7 @@ struct config_audio {
 	int enc_fmt;            /**< Audio encoder sample format    */
 	int dec_fmt;            /**< Audio decoder sample format    */
 	struct range buffer;    /**< Audio receive buffer in [ms]   */
+	bool adaptive;          /**< Enable adaptive audio buffer   */
 	uint32_t telev_pt;      /**< Payload type for tel.-event    */
 };
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -363,7 +363,6 @@ struct config_avt {
 	bool rtcp_mux;          /**< RTP/RTCP multiplexing          */
 	enum jbuf_type jbtype;  /**< Jitter buffer type             */
 	struct range jbuf_del;  /**< Delay, number of frames        */
-	uint32_t jbuf_wish;     /**< Startup wish delay of frames   */
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 	bool bundle;            /**< Media Multiplexing (BUNDLE)    */

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -340,6 +340,7 @@ struct config_audio {
 	int dec_fmt;            /**< Audio decoder sample format    */
 	struct range buffer;    /**< Audio receive buffer in [ms]   */
 	bool adaptive;          /**< Enable adaptive audio buffer   */
+	double silence;         /**< Silence volume in [dB]         */
 	uint32_t telev_pt;      /**< Payload type for tel.-event    */
 };
 

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -537,7 +537,8 @@ int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac)
 			goto out;
 		}
 
-		aubuf_set_mode(player->aubuf, AUBUF_ADAPTIVE);
+		aubuf_set_mode(player->aubuf, cfg->adaptive ?
+			       AUBUF_ADAPTIVE : AUBUF_FIXED);
 	}
 
 	err = aufilt_setup(baresip_aufiltl());

--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -536,6 +536,8 @@ int mcplayer_start(struct jbuf *jbuf, const struct aucodec *ac)
 				err);
 			goto out;
 		}
+
+		aubuf_set_mode(player->aubuf, AUBUF_ADAPTIVE);
 	}
 
 	err = aufilt_setup(baresip_aufiltl());

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -685,7 +685,6 @@ int mcreceiver_alloc(struct sa *addr, uint8_t prio)
 	struct mcreceiver *mcreceiver = NULL;
 	struct config_avt *cfg = &conf_config()->avt;
 	struct range jbuf_del;
-	uint32_t jbuf_wish;
 	enum jbuf_type jbtype;
 	struct pl pl;
 
@@ -722,16 +721,13 @@ int mcreceiver_alloc(struct sa *addr, uint8_t prio)
 	mcreceiver->state = LISTENING;
 
 	jbuf_del  = cfg->jbuf_del;
-	jbuf_wish = cfg->jbuf_wish;
 	jbtype = cfg->jbtype;
 	(void)conf_get_range(conf_cur(), "multicast_jbuf_delay", &jbuf_del);
 	if (0 == conf_get(conf_cur(), "multicast_jbuf_type", &pl))
 		jbtype = conf_get_jbuf_type(&pl);
-	(void)conf_get_u32(conf_cur(), "multicast_jbuf_wish", &jbuf_wish);
 
 	err = jbuf_alloc(&mcreceiver->jbuf, jbuf_del.min, jbuf_del.max);
 	err |= jbuf_set_type(mcreceiver->jbuf, jbtype);
-	err |= jbuf_set_wish(mcreceiver->jbuf, jbuf_wish);
 	if (err)
 		goto out;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -777,6 +777,7 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 	if (!rx->ac)
 		return 0;
 
+	/* TODO: PLC */
 	if (lostc && rx->ac->plch) {
 
 		err = rx->ac->plch(rx->dec,
@@ -877,6 +878,7 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	bool drop = *ignore;
 	size_t i;
 	int wrap;
+	(void) lostc;
 
 	MAGIC_CHECK(a);
 
@@ -939,8 +941,12 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	}
 
  out:
-	if (lostc)
-		(void)aurx_stream_decode(&a->rx, hdr, mb, lostc, drop);
+	/* TODO:  what if lostc > 1 ?*/
+	/* PLC should generate lostc frames here. Not only one.
+	 * aubuf should replace PLC frames with late arriving real frames.
+	 * It should use timestamp to decide if a frame should be replaced. */
+/*        if (lostc)*/
+/*                (void)aurx_stream_decode(&a->rx, hdr, mb, lostc, drop);*/
 
 	(void)aurx_stream_decode(&a->rx, hdr, mb, 0, drop);
 }

--- a/src/audio.c
+++ b/src/audio.c
@@ -855,7 +855,9 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 		goto out;
 
 	lock_write_get(rx->lock);
-	rx->aubuf_started = true;
+	if (!rx->aubuf_started &&
+	    (rx->aubuf_minsz >= aubuf_cur_size(rx->aubuf)))
+		rx->aubuf_started = true;
 	lock_rel(rx->lock);
 
  out:

--- a/src/audio.c
+++ b/src/audio.c
@@ -898,32 +898,8 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 
 	/* Save timestamp for incoming RTP packets */
 
-	if (rx->ts_recv.is_set) {
-
-		uint64_t ext_last, ext_now;
-
-		ext_last = timestamp_calc_extended(rx->ts_recv.num_wraps,
-						   rx->ts_recv.last);
-
-		ext_now = timestamp_calc_extended(rx->ts_recv.num_wraps,
-						  hdr->ts);
-
-		if (ext_now <= ext_last) {
-			uint64_t delta;
-
-			delta = ext_last - ext_now;
-
-			warning("audio: [time=%.3f]"
-				" discard old frame (%.3f seconds old)\n",
-				aurx_calc_seconds(rx),
-				timestamp_calc_seconds(delta, rx->ac->crate));
-
-			discard = true;
-		}
-	}
-	else {
+	if (!rx->ts_recv.is_set)
 		timestamp_set(&rx->ts_recv, hdr->ts);
-	}
 
 	wrap = timestamp_wrap(hdr->ts, rx->ts_recv.last);
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -806,9 +806,6 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 		sampc = 0;
 	}
 
-	if (drop)
-		goto out;
-
 	auframe_init(&af, rx->dec_fmt, rx->sampv, sampc,
 		     rx->ac->srate, rx->ac->ch);
 	af.timestamp = hdr->ts;
@@ -846,6 +843,11 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 			aufmt_name(af.fmt), aufmt_name(rx->play_fmt),
 			rx->play_fmt == AUFMT_S16LE ? "Use module auconv!" : ""
 			);
+	}
+
+	if (drop) {
+		aubuf_drop_auframe(rx->aubuf, &af);
+		goto out;
 	}
 
 	err = aubuf_write_auframe(rx->aubuf, &af);

--- a/src/audio.c
+++ b/src/audio.c
@@ -1424,7 +1424,8 @@ static int start_player(struct aurx *rx, struct audio *a,
 				return err;
 			}
 
-			aubuf_set_mode(rx->aubuf, AUBUF_ADAPTIVE);
+			aubuf_set_mode(rx->aubuf, a->cfg.adaptive ?
+				       AUBUF_ADAPTIVE : AUBUF_FIXED);
 			rx->aubuf_minsz = min_sz;
 			rx->aubuf_maxsz = max_sz;
 		}

--- a/src/audio.c
+++ b/src/audio.c
@@ -630,18 +630,6 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	struct aurx *rx = &a->rx;
 	size_t num_bytes = auframe_size(af);
 
-	if (af->fmt != rx->play_fmt) {
-		warning("audio: write format mismatch: exp=%s, actual=%s\n",
-			aufmt_name(rx->play_fmt), aufmt_name(af->fmt));
-	}
-
-	if (rx->auplay_prm.srate != af->srate || rx->auplay_prm.ch != af->ch) {
-		warning("audio: srate/ch of frame %u/%u vs player %u/%u. Use "
-			"module auresamp!\n",
-			af->srate, af->ch,
-			rx->auplay_prm.srate, rx->auplay_prm.ch);
-	}
-
 	lock_read_get(rx->lock);
 	if (rx->aubuf_started && aubuf_cur_size(rx->aubuf) < num_bytes) {
 
@@ -842,6 +830,13 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 		debug("audio: rx aubuf overrun (total %llu)\n",
 		      rx->stats.aubuf_overrun);
 #endif
+	}
+
+	if (rx->auplay_prm.srate != af.srate || rx->auplay_prm.ch != af.ch) {
+		warning("audio: srate/ch of frame %u/%u vs player %u/%u. Use "
+			"module auresamp!\n",
+			af.srate, af.ch,
+			rx->auplay_prm.srate, rx->auplay_prm.ch);
 	}
 
 	if (af.fmt != rx->play_fmt) {

--- a/src/audio.c
+++ b/src/audio.c
@@ -1426,6 +1426,7 @@ static int start_player(struct aurx *rx, struct audio *a,
 
 			aubuf_set_mode(rx->aubuf, a->cfg.adaptive ?
 				       AUBUF_ADAPTIVE : AUBUF_FIXED);
+			aubuf_set_silence(rx->aubuf, a->cfg.silence);
 			rx->aubuf_minsz = min_sz;
 			rx->aubuf_maxsz = max_sz;
 		}

--- a/src/conf.c
+++ b/src/conf.c
@@ -337,6 +337,16 @@ enum jbuf_type conf_get_jbuf_type(const struct pl *pl)
 }
 
 
+bool conf_aubuf_adaptive(const struct pl *pl)
+{
+	if (0 == pl_strcasecmp(pl, "fixed"))    return false;
+	if (0 == pl_strcasecmp(pl, "adaptive")) return true;
+
+	warning("unsupported audio buffer mode (%r)\n", pl);
+	return false;
+}
+
+
 /**
  * Configure the system with default settings
  *

--- a/src/conf.c
+++ b/src/conf.c
@@ -331,6 +331,7 @@ enum jbuf_type conf_get_jbuf_type(const struct pl *pl)
 	if (0 == pl_strcasecmp(pl, "off"))      return JBUF_OFF;
 	if (0 == pl_strcasecmp(pl, "fixed"))    return JBUF_FIXED;
 	if (0 == pl_strcasecmp(pl, "adaptive")) return JBUF_ADAPTIVE;
+	if (0 == pl_strcasecmp(pl, "minimize")) return JBUF_MINIMIZE;
 
 	warning("unsupported jitter buffer type (%r)\n", pl);
 	return JBUF_FIXED;

--- a/src/conf.c
+++ b/src/conf.c
@@ -331,7 +331,6 @@ enum jbuf_type conf_get_jbuf_type(const struct pl *pl)
 	if (0 == pl_strcasecmp(pl, "off"))      return JBUF_OFF;
 	if (0 == pl_strcasecmp(pl, "fixed"))    return JBUF_FIXED;
 	if (0 == pl_strcasecmp(pl, "adaptive")) return JBUF_ADAPTIVE;
-	if (0 == pl_strcasecmp(pl, "minimize")) return JBUF_MINIMIZE;
 
 	warning("unsupported jitter buffer type (%r)\n", pl);
 	return JBUF_FIXED;

--- a/src/config.c
+++ b/src/config.c
@@ -61,6 +61,7 @@ static struct config core_config = {
 		AUFMT_S16LE,
 		AUFMT_S16LE,
 		{20, 160},
+		false,
 		101
 	},
 
@@ -395,6 +396,9 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 		return EINVAL;
 	}
 
+	if (0 == conf_get(conf, "audio_buffer_mode", &pl))
+		cfg->audio.adaptive = conf_aubuf_adaptive(&pl);
+
 	(void)conf_get_u32(conf, "audio_telev_pt", &cfg->audio.telev_pt);
 
 	/* Video */
@@ -500,6 +504,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "auenc_format\t\t%s\n"
 			 "audec_format\t\t%s\n"
 			 "audio_buffer\t\t%H\t\t# ms\n"
+			 "audio_buffer_mode\t%s\t\t# fixed, adaptive\n"
 			 "audio_telev_pt\t\t%u\n"
 			 "\n"
 			 "# Video\n"
@@ -553,6 +558,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 aufmt_name(cfg->audio.enc_fmt),
 			 aufmt_name(cfg->audio.dec_fmt),
 			 range_print, &cfg->audio.buffer,
+			 cfg->audio.adaptive ? "adaptive" : "fixed",
 			 cfg->audio.telev_pt,
 
 			 cfg->video.src_mod, cfg->video.src_dev,
@@ -722,6 +728,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "auenc_format\t\ts16\t\t# s16, float, ..\n"
 			  "audec_format\t\ts16\t\t# s16, float, ..\n"
 			  "audio_buffer\t\t%H\t\t# ms\n"
+			  "audio_buffer_mode\t%s\t\t# fixed, adaptive\n"
 			  "audio_telev_pt\t\t%u\t\t"
 			  "# payload type for telephone-event\n"
 			  ,
@@ -733,6 +740,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  default_audio_device(),
 			  default_audio_device(),
 			  range_print, &cfg->audio.buffer,
+			  cfg->audio.adaptive ? "adaptive" : "fixed",
 			  cfg->audio.telev_pt);
 
 	err |= re_hprintf(pf,

--- a/src/config.c
+++ b/src/config.c
@@ -774,7 +774,6 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#file_srate\t\t16000\n"
 			  "#file_channels\t\t1\n",
 			  cfg->avt.jbuf_del.min, cfg->avt.jbuf_del.max,
-			  cfg->avt.jbuf_del.min + 1,
 			  default_interface_print, NULL);
 
 	return err;

--- a/src/config.c
+++ b/src/config.c
@@ -231,6 +231,8 @@ static const char *jbuf_type_str(enum jbuf_type jbtype)
 		return "fixed";
 	case JBUF_ADAPTIVE:
 		return "adaptive";
+	case JBUF_MINIMIZE:
+		return "minimize";
 	}
 
 	return "?";
@@ -764,7 +766,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#rtp_bandwidth\t\t512-1024 # [kbit/s]\n"
 			  "rtcp_mux\t\tno\n"
 			  "jitter_buffer_type\tfixed\t\t# off, fixed,"
-				" adaptive\n"
+				" adaptive, minimize\n"
 			  "jitter_buffer_delay\t%u-%u\t\t# frames\n"
 			  "#jitter_buffer_wish\t%u\t\t# frames for start\n"
 			  "rtp_stats\t\tno\n"
@@ -1189,7 +1191,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "#multicast_call_prio\t0\n"
 			 "#multicast_ttl\t1\n"
 			 "#multicast_jbuf_type\tfixed\t\t"
-				"# off, fixed, adaptive\n"
+				"# off, fixed, adaptive, minimize\n"
 			 "#multicast_jbuf_delay\t5-10\t\t# frames\n"
 			 "#multicast_jbuf_wish\t6\t\t# frames for start\n"
 			 "#multicast_listener\t224.0.2.21:50000\n"

--- a/src/config.c
+++ b/src/config.c
@@ -62,6 +62,7 @@ static struct config core_config = {
 		AUFMT_S16LE,
 		{20, 160},
 		false,
+		-35.0,
 		101
 	},
 
@@ -399,6 +400,7 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	if (0 == conf_get(conf, "audio_buffer_mode", &pl))
 		cfg->audio.adaptive = conf_aubuf_adaptive(&pl);
 
+	(void)conf_get_float(conf, "audio_silence", &cfg->audio.silence);
 	(void)conf_get_u32(conf, "audio_telev_pt", &cfg->audio.telev_pt);
 
 	/* Video */
@@ -505,6 +507,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "audec_format\t\t%s\n"
 			 "audio_buffer\t\t%H\t\t# ms\n"
 			 "audio_buffer_mode\t%s\t\t# fixed, adaptive\n"
+			 "audio_silence\t\t%.1lf\t\t# in [dB]\n"
 			 "audio_telev_pt\t\t%u\n"
 			 "\n"
 			 "# Video\n"
@@ -559,6 +562,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 aufmt_name(cfg->audio.dec_fmt),
 			 range_print, &cfg->audio.buffer,
 			 cfg->audio.adaptive ? "adaptive" : "fixed",
+			 cfg->audio.silence,
 			 cfg->audio.telev_pt,
 
 			 cfg->video.src_mod, cfg->video.src_dev,
@@ -729,6 +733,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "audec_format\t\ts16\t\t# s16, float, ..\n"
 			  "audio_buffer\t\t%H\t\t# ms\n"
 			  "audio_buffer_mode\t%s\t\t# fixed, adaptive\n"
+			  "audio_silence\t\t%.1lf\t\t# in [dB]\n"
 			  "audio_telev_pt\t\t%u\t\t"
 			  "# payload type for telephone-event\n"
 			  ,
@@ -741,6 +746,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  default_audio_device(),
 			  range_print, &cfg->audio.buffer,
 			  cfg->audio.adaptive ? "adaptive" : "fixed",
+			  cfg->audio.silence,
 			  cfg->audio.telev_pt);
 
 	err |= re_hprintf(pf,

--- a/src/config.c
+++ b/src/config.c
@@ -84,7 +84,6 @@ static struct config core_config = {
 		false,
 		JBUF_FIXED,
 		{5, 10},
-		0,
 		false,
 		0,
 		false
@@ -231,8 +230,6 @@ static const char *jbuf_type_str(enum jbuf_type jbtype)
 		return "fixed";
 	case JBUF_ADAPTIVE:
 		return "adaptive";
-	case JBUF_MINIMIZE:
-		return "minimize";
 	}
 
 	return "?";
@@ -435,8 +432,6 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 
 	(void)conf_get_range(conf, "jitter_buffer_delay",
 			     &cfg->avt.jbuf_del);
-	(void)conf_get_u32(conf, "jitter_buffer_wish",
-			     &cfg->avt.jbuf_wish);
 	(void)conf_get_bool(conf, "rtp_stats", &cfg->avt.rtp_stats);
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
@@ -525,7 +520,6 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtcp_mux\t\t%s\n"
 			 "jitter_buffer_type\t%s\n"
 			 "jitter_buffer_delay\t%H\n"
-			 "jitter_buffer_wish\t%u\n"
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "\n"
@@ -575,7 +569,6 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->avt.rtcp_mux ? "yes" : "no",
 			 jbuf_type_str(cfg->avt.jbtype),
 			 range_print, &cfg->avt.jbuf_del,
-			 cfg->avt.jbuf_wish,
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 
@@ -766,9 +759,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#rtp_bandwidth\t\t512-1024 # [kbit/s]\n"
 			  "rtcp_mux\t\tno\n"
 			  "jitter_buffer_type\tfixed\t\t# off, fixed,"
-				" adaptive, minimize\n"
+				" adaptive\n"
 			  "jitter_buffer_delay\t%u-%u\t\t# frames\n"
-			  "#jitter_buffer_wish\t%u\t\t# frames for start\n"
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "\n# Network\n"
@@ -1191,9 +1183,8 @@ int config_write_template(const char *file, const struct config *cfg)
 			 "#multicast_call_prio\t0\n"
 			 "#multicast_ttl\t1\n"
 			 "#multicast_jbuf_type\tfixed\t\t"
-				"# off, fixed, adaptive, minimize\n"
+				"# off, fixed, adaptive\n"
 			 "#multicast_jbuf_delay\t5-10\t\t# frames\n"
-			 "#multicast_jbuf_wish\t6\t\t# frames for start\n"
 			 "#multicast_listener\t224.0.2.21:50000\n"
 			 "#multicast_listener\t224.0.2.21:50002\n");
 

--- a/src/core.h
+++ b/src/core.h
@@ -321,7 +321,6 @@ int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 
 /* Receive */
 void stream_flush(struct stream *s);
-void stream_silence_on(struct stream *s, bool on);
 int  stream_decode(struct stream *s);
 int  stream_ssrc_rx(const struct stream *strm, uint32_t *ssrc);
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -416,7 +416,7 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 		}
 
 		if (s->type == MEDIA_VIDEO ||
-			s->cfg.jbtype == JBUF_FIXED) {
+			s->cfg.jbtype != JBUF_ADAPTIVE) {
 
 			if (stream_decode(s) == EAGAIN)
 				(void) stream_decode(s);
@@ -719,8 +719,7 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		goto out;
 
 	/* Jitter buffer */
-	if (prm->use_rtp && cfg->jbtype != JBUF_OFF &&
-			cfg->jbuf_del.min && cfg->jbuf_del.max) {
+	if (prm->use_rtp && cfg->jbtype != JBUF_OFF && cfg->jbuf_del.max) {
 
 		err  = jbuf_alloc(&s->rx.jbuf, cfg->jbuf_del.min,
 				cfg->jbuf_del.max);

--- a/src/stream.c
+++ b/src/stream.c
@@ -415,12 +415,9 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 			s->rx.metric.n_err++;
 		}
 
-		if (s->type == MEDIA_VIDEO ||
-			s->cfg.jbtype != JBUF_ADAPTIVE) {
 
-			if (stream_decode(s) == EAGAIN)
-				(void) stream_decode(s);
-		}
+		if (stream_decode(s) == EAGAIN)
+			(void) stream_decode(s);
 	}
 	else {
 		(void)handle_rtp(s, hdr, mb, 0);

--- a/src/stream.c
+++ b/src/stream.c
@@ -276,11 +276,11 @@ static inline int lostcalc(struct receiver *rx, uint16_t seq)
 
 
 static int handle_rtp(struct stream *s, const struct rtp_header *hdr,
-		       struct mbuf *mb, unsigned lostc)
+		       struct mbuf *mb, unsigned lostc, bool drop)
 {
 	struct rtpext extv[8];
 	size_t extc = 0;
-	bool ignore = false;
+	bool ignore = drop;
 
 	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
 	if (hdr->ext && hdr->x.len && mb) {
@@ -420,7 +420,7 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 			(void) stream_decode(s);
 	}
 	else {
-		(void)handle_rtp(s, hdr, mb, 0);
+		(void)handle_rtp(s, hdr, mb, 0, false);
 	}
 }
 
@@ -455,7 +455,7 @@ int stream_decode(struct stream *s)
 
 	lostc = lostcalc(&s->rx, hdr.seq);
 
-	err2 = handle_rtp(s, &hdr, mb, lostc > 0 ? lostc : 0);
+	err2 = handle_rtp(s, &hdr, mb, lostc > 0 ? lostc : 0, err == EAGAIN);
 	mem_deref(mb);
 
 	if (err2 == EAGAIN)

--- a/src/stream.c
+++ b/src/stream.c
@@ -465,15 +465,6 @@ int stream_decode(struct stream *s)
 }
 
 
-void stream_silence_on(struct stream *s, bool on)
-{
-	if (!s)
-		return;
-
-	jbuf_silence(s->rx.jbuf, on);
-}
-
-
 static void rtcp_handler(const struct sa *src, struct rtcp_msg *msg, void *arg)
 {
 	struct stream *s = arg;
@@ -721,7 +712,6 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		err  = jbuf_alloc(&s->rx.jbuf, cfg->jbuf_del.min,
 				cfg->jbuf_del.max);
 		err |= jbuf_set_type(s->rx.jbuf, cfg->jbtype);
-		err |= jbuf_set_wish(s->rx.jbuf, cfg->jbuf_wish);
 		if (err)
 			goto out;
 	}


### PR DESCRIPTION
Relates to https://github.com/baresip/rem/pull/33
Discussion: https://github.com/baresip/re/discussions/184

- audio: adapt to adaptive aubuf, adaptive jbuf becomes obsolete
- audio: do not drop reordered packets
- config,stream: support for new jbuf type "minimize"
- stream: also for JBUF_ADAPTIVE decode immediately 

This makes JBUF_ADAPTIVE completely obsolete what is the final goal
of the current PR. This is necessary because otherwise no decoding
would be done if `jitter_buffer_type   adaptive` is configured.

An alternative would be to keep all the JBUF_ADAPTIVE functions in
stream.c and audio.c for a deprecation period.

@sreimers, @alfredh, @juha-h 
I suppose that nobody uses JBUF_ADAPTIVE except my company, thus I would prefer to directly drop all the obsolete code in baresip and also in `re/src/jbuf`. Let me know what you would prefer!
- A jbuf adaptive deprecation period, or
- immediate cleanup? This would/should not change the JBUF_FIXED behavior.