### PR TITLE
test: check the correct stream in UA_EVENT_CALL_MENC

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -154,7 +154,7 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 	struct fixture *f = arg;
 	struct call *call2 = NULL;
 	struct agent *ag;
-	struct audio *au;
+	struct stream *strm = NULL;
 	char curi[256];
 	int err = 0;
 	(void)prm;
@@ -357,9 +357,14 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_CALL_MENC:
 		++ag->n_mediaenc;
-		au = call_audio(call);
-		if (au) {
-			ASSERT_TRUE(stream_is_secure(audio_strm(au)));
+
+		if (strstr(prm, "audio"))
+			strm = audio_strm(call_audio(call));
+		else if (strstr(prm, "video"))
+			strm = video_strm(call_video(call));
+
+		if (strm) {
+			ASSERT_TRUE(stream_is_secure(strm));
 		}
 		break;
 


### PR DESCRIPTION
the current code was causing occational errors:

```
[ RUN      ] test_call_webrtc
[31mselftest: ASSERT_TRUE: test/call.c:362:
[;m[31merror in event-handler (Invalid argument)
[;m[31mTEST_ERR: test/call.c:1561: (Invalid argument)
[;m[31mtest_call_webrtc: test failed (Invalid argument)
[;m[31mtest failed (Invalid argument)
[;mre main loop:
  maxfds:  2048
  nfds:    25
  method:  2 (select)
```
