### PR TITLE
mc: mcplayer stream fade-out and fade-in

### DIFF
--- a/modules/multicast/multicast.c
+++ b/modules/multicast/multicast.c
@@ -19,11 +19,13 @@
 struct mccfg {
 	uint32_t callprio;
 	uint32_t ttl;
+	uint32_t tfade;
 };
 
 static struct mccfg mccfg = {
 	0,
 	1,
+	125,
 };
 
 
@@ -120,6 +122,17 @@ uint8_t multicast_callprio(void)
 uint8_t multicast_ttl(void)
 {
 	return mccfg.ttl;
+}
+
+
+/**
+ * Getter for configurable multicast fade in/out time
+ *
+ * @return uint32_t multicast fade time
+ */
+uint32_t multicast_fade_time(void)
+{
+	return mccfg.tfade;
 }
 
 
@@ -591,6 +604,10 @@ static int module_read_config(void)
 	(void)conf_get_u32(conf_cur(), "multicast_ttl", &mccfg.ttl);
 	if (mccfg.ttl > 255)
 		mccfg.ttl = 255;
+
+	(void)conf_get_u32(conf_cur(), "multicast_fade_time", &mccfg.tfade);
+	if (mccfg.tfade > 2000)
+		mccfg.tfade = 2000;
 
 	sa_init(&laddr, AF_INET);
 	err = conf_apply(conf_cur(), "multicast_listener",

--- a/modules/multicast/multicast.h
+++ b/modules/multicast/multicast.h
@@ -20,6 +20,7 @@ enum {
 
 uint8_t multicast_callprio(void);
 uint8_t multicast_ttl(void);
+uint32_t multicast_fade_time(void);
 
 
 /* Sender */
@@ -48,6 +49,7 @@ void mcreceiver_print(struct re_printf *pf);
 /* Player <exchangable player> */
 int mcplayer_start(const struct aucodec *ac);
 void mcplayer_stop(void);
+void mcplayer_fadeout(void);
 int mcplayer_decode(const struct rtp_header *hdr, struct mbuf *mb);
 
 int  mcplayer_init(void);

--- a/modules/multicast/receiver.c
+++ b/modules/multicast/receiver.c
@@ -210,7 +210,7 @@ static void resume_uag_state(void)
  */
 static int player_stop_start(struct mcreceiver *mcreceiver)
 {
-	mcplayer_stop();
+	mcplayer_fadeout();
 	jbuf_flush(mcreceiver->jbuf);
 	return mcplayer_start(mcreceiver->ac);
 }
@@ -288,9 +288,12 @@ static int prio_handling(struct mcreceiver *mcreceiver, uint32_t ssrc)
 
 	le = list_apply(&mcreceivl, true, mcreceiver_running, NULL);
 	if (!le) {
+		err = player_stop_start(mcreceiver);
+		if (err)
+			goto out;
+
 		mcreceiver->state = RUNNING;
 		mcreceiver->ssrc = ssrc;
-		err = player_stop_start(mcreceiver);
 
 		info ("multicast receiver: start addr=%J prio=%d enabled=%d "
 			"state=%s\n", &mcreceiver->addr, mcreceiver->prio,
@@ -310,11 +313,14 @@ static int prio_handling(struct mcreceiver *mcreceiver, uint32_t ssrc)
 	}
 
 	if (hprio->prio == mcreceiver->prio && mcreceiver->ssrc != ssrc) {
+		err = player_stop_start(mcreceiver);
+		if (err)
+			goto out;
+
 		if (hprio->state == IGNORED)
 			hprio->state = RUNNING;
 
 		mcreceiver->ssrc = ssrc;
-		err = player_stop_start(mcreceiver);
 
 		info ("multicast receiver: restart addr=%J prio=%d enabled=%d "
 			"state=%s\n", &mcreceiver->addr, mcreceiver->prio,
@@ -331,11 +337,14 @@ static int prio_handling(struct mcreceiver *mcreceiver, uint32_t ssrc)
 		goto out;
 	}
 
+	err = player_stop_start(mcreceiver);
+	if (err)
+		goto out;
+
 	hprio->state = RECEIVING;
 	mcreceiver->state = RUNNING;
 	mcreceiver->ssrc = ssrc;
 
-	err = player_stop_start(mcreceiver);
 
 	info ("multicast receiver: start addr=%J prio=%d enabled=%d "
 		"state=%s\n", &mcreceiver->addr, mcreceiver->prio,


### PR DESCRIPTION
+ add small statemachine to the multicast player to allow
  fadein and fadeout at stream start and stream switching
+ configurable fade time via multicast_fade_time config parameter
+ default time is 125ms, disable the fade by setting the config to 0