### PR TITLE
call: allow optional leading space in SIP INFO for dtmf-relay

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1837,8 +1837,10 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 
 		pl_set_mbuf(&body, msg->mb);
 
-		err  = re_regex(body.p, body.l, "Signal=[ ]*[0-9*#a-d]+", NULL, &sig);
-		err |= re_regex(body.p, body.l, "Duration=[ ]*[0-9]+", NULL, &dur);
+		err  = re_regex(body.p, body.l, 
+		       "Signal=[ ]*[0-9*#a-d]+", NULL, &sig);
+		err |= re_regex(body.p, body.l, 
+		       "Duration=[ ]*[0-9]+", NULL, &dur);
 
 		if (err || !pl_isset(&sig) || sig.l == 0) {
 			(void)sip_reply(sip, msg, 400, "Bad Request");

--- a/src/call.c
+++ b/src/call.c
@@ -1837,8 +1837,8 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 
 		pl_set_mbuf(&body, msg->mb);
 
-		err  = re_regex(body.p, body.l, "Signal=[0-9*#a-d]+", &sig);
-		err |= re_regex(body.p, body.l, "Duration=[0-9]+", &dur);
+		err  = re_regex(body.p, body.l, "Signal=[ ]*[0-9*#a-d]+", NULL, &sig);
+		err |= re_regex(body.p, body.l, "Duration=[ ]*[0-9]+", NULL, &dur);
 
 		if (err || !pl_isset(&sig) || sig.l == 0) {
 			(void)sip_reply(sip, msg, 400, "Bad Request");

--- a/src/call.c
+++ b/src/call.c
@@ -1837,9 +1837,9 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 
 		pl_set_mbuf(&body, msg->mb);
 
-		err  = re_regex(body.p, body.l, 
+		err  = re_regex(body.p, body.l,
 		       "Signal=[ ]*[0-9*#a-d]+", NULL, &sig);
-		err |= re_regex(body.p, body.l, 
+		err |= re_regex(body.p, body.l,
 		       "Duration=[ ]*[0-9]+", NULL, &dur);
 
 		if (err || !pl_isset(&sig) || sig.l == 0) {


### PR DESCRIPTION
Good day, 

I have seen SIP INFO messages containing an extra space character before the actual signal and duration in combination with a Mitel SIP server. 
As I'm not aware of any standard, it might be good to ignore leading spaces.

[traces.zip](https://github.com/baresip/baresip/files/8510719/traces.zip)
I attached 2 traces for reference - one of a failing SIP INFO from a working project ("mitel.pcap") and one from my test system with the code change already included ("test.pcap"). In the trace "test.pcap" you can see two SIP INFO messages, one with and one without leading space. Both result in the same message "call: received SIP INFO DTMF: '#' (duration=100)" printed on command line now:

> 1234@test.com: account match for 1234
> ua: using origin address 192.168.0.41 of SDP offer
> sip:1234@test.com: Incoming call from:  sip:4444@192.168.0.24 - audio-video: sendrecv-inactive - (press 'a' to accept)
> call: answering call on line 1 from sip:4444@192.168.0.24 with 200
> stream: update 'audio'
> stream: receive: setting SSRC: 44125d9f
> audio: Set audio decoder: PCMU 8000Hz 1ch
> audio: Set audio encoder: PCMU 8000Hz 1ch
> audio tx pipeline:       (src) ---> aubuf ---> auconv ---> auresamp ---> PCMU
> audio rx pipeline:      (play) <--- aubuf <--- auconv <--- auresamp <--- PCMU
> 1234@test.com: Call established: sip:4444@192.168.0.24
> stream: update 'audio'
> call: got re-INVITE (SDP Offer) audio-video: sendrecv-inactive
> stream: incoming rtp for 'audio' established, receiving from 192.168.0.41:10000
> call: received SIP INFO DTMF: '#' (duration=100)
> call: received SIP INFO DTMF: '#' (duration=100)
> sip:4444@192.168.0.24: session closed: Connection reset by peer
> sip:1234@192.168.0.24: Call with sip:4444@192.168.0.24 terminated (duration: 1 min 33 secs)

What do you think?

Many thanks in advance!