### PR TITLE
Updated debian version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+baresip (2.0.2) unstable; urgency=medium
+
+  * version 2.0.2
+
+ -- Juha Heinanen <jh@tutpro.com>  Mon, 25 Apr 2022 11:54:35 +0300
+
 baresip (1.0.0) unstable; urgency=medium
 
   * version 1.0.0


### PR DESCRIPTION
I noticed that debian changelog version was still 1.0.0, but that latest tag was 2.0.2.  So I went and updated debian changelog accordingly.

In the future, should this be done each time a new tag is created?

How come macos tests take MUCH longer time than all other tests altogether?

Looks like macos check was not able to download something.