### PR TITLE
menu ringback for parallel call

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -312,6 +312,7 @@ static void play_resume(const struct call *closed)
 		play_incoming(call);
 		break;
 	case CALL_STATE_RINGING:
+	case CALL_STATE_EARLY:
 		if (!menu.ringback && !menu_find_call(active_call_test,
 						      closed))
 			play_ringback(call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -647,13 +647,16 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 		if (call == menu.curcall) {
 			menu.curcall = NULL;
-			if (count==1)
+			if (count == 1) {
 				menu_play_closed(call);
-			else
-				menu_stop_play();
-
-			menu_sel_other(call);
-			play_resume(call);
+			}
+			else {
+				menu_sel_other(call);
+				if (menu.ringback)
+					play_resume(call);
+				else
+					menu_stop_play();
+			}
 		}
 
 		hash_apply(menu.ovaufile->ht, ovaufile_del, call);


### PR DESCRIPTION
Some fixes for ringback tone during multiple parallel outgoing calls.

- menu: resume ringback also if call is in CALL_STATE_EARLY
- menu: instead of restart ringback proceed playing for parallel call
