### PR TITLE
use RTP clock rate for timestamp calculation

### DIFF
--- a/modules/multicast/player.c
+++ b/modules/multicast/player.c
@@ -191,7 +191,7 @@ int mcplayer_decode(const struct rtp_header *hdr, struct mbuf *mb, bool drop)
 	auframe_init(&af, player->dec_fmt, player->sampv, sampc,
 		     player->ac->srate, player->ac->ch);
 	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE /
-		(player->ac->srate * player->ac->ch);
+		       player->ac->crate;
 
 	for (le = player->filterl.tail; le; le = le->prev) {
 		struct aufilt_dec_st *st = le->data;

--- a/src/audio.c
+++ b/src/audio.c
@@ -796,8 +796,7 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 	}
 
 	auframe_init(&af, rx->dec_fmt, rx->sampv, sampc, ac->srate, ac->ch);
-	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE /
-		(ac->srate * ac->ch);
+	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
 
 	/* Process exactly one audio-frame in reverse list order */
 	for (le = rx->filtl.tail; le; le = le->prev) {


### PR DESCRIPTION
- audio: use RTP clock rate for timestamp calculation
- multicast: use RTP clock rate for timestamp calculation

Realized that for G.722 timestamps had been 10,20,30, ... instead of 20,40,60.
Further: If stereo or mono makes no difference for the RTP timestamps.