### PR TITLE
stream,audio: flush RX buffers if marker bit is set

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -844,6 +844,9 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 
 		rx->ssrc = hdr->ssrc;
 	}
+	else if (hdr->m) {
+		aubuf_flush(rx->aubuf);
+	}
 
 	err = aubuf_write_auframe(rx->aubuf, &af);
 	if (err)

--- a/src/stream.c
+++ b/src/stream.c
@@ -388,6 +388,10 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 		s->rx.pseq = hdr->seq - 1;
 		flush = true;
 	}
+	else if (hdr->m && s->type == MEDIA_AUDIO) {
+		/* The marker bit indicates the beginning of a talkspurt. */
+		flush = true;
+	}
 
 	/* payload-type changed? */
 	err = s->pth(hdr->pt, mb, s->arg);


### PR DESCRIPTION
We had audio artefacts in playback of the RX stream after periods of silence, in which no RTP packets are transmitted by the sender.

I am pretty sure that the RX buffers have to be flushed, if the RTP marker bit is set. Due to RFC-3551 and to an already removed code snippet of @alfredh the marker bit indicates the beginning of a new talkspurt. 

When searching the git log I found this commit:
```
commit fdb22bc3725483a9500323df85627e223435b38e
Author: Alfred E. Heggestad <alfred.heggestad@gmail.com>
Date:   Sun Dec 1 11:21:44 2019 +0100

    aucodec: add marker bit -- ref #852

diff --git a/src/stream.c b/src/stream.c
index 9e434feec..6e6a75904 100644
--- a/src/stream.c
+++ b/src/stream.c
@@ -260,9 +260,11 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
        if (!(sdp_media_ldir(s->sdp) & SDP_RECVONLY))
                return;
 
+#if 0
        /* The marker bit indicates the beginning of a talkspurt. */
        if (hdr->m && s->type == MEDIA_AUDIO)
                flush = true;
+#endif
```
And then this issue with this comment:
https://github.com/baresip/baresip/issues/852#issuecomment-560089704

@alfredh At least for G.722 this PR seems to be the right solution. How should we proceed here?

