### PR TITLE
audio: add optional decoding buffer

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1449,7 +1449,7 @@ static int rx_filter_thread(void *arg)
 
 		if (af.sampc && sampc != af.sampc) {
 			sampc = af.sampc;
-			ptime = sampc * 1000 / (ac->srate * ac->ch);
+			ptime = (uint32_t) (sampc*1000 / (ac->srate * ac->ch));
 		}
 
 		(void)rx_push_aubuf(rx, &af);

--- a/src/audio.c
+++ b/src/audio.c
@@ -1320,27 +1320,30 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 }
 
 
-static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *aurx)
+static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 {
 	struct le *le;
 	int err;
 
-	if (!aurx)
+	if (!rx)
 		return 0;
 
 	err = re_hprintf(pf, "audio rx pipeline:  %10s",
-			 aurx->ap ? aurx->ap->name : "(play)");
+			 rx->ap ? rx->ap->name : "(play)");
 
 	err |= re_hprintf(pf, " <--- aubuf");
-	for (le = list_head(&aurx->filtl); le; le = le->next) {
+	for (le = list_head(&rx->filtl); le; le = le->next) {
 		struct aufilt_dec_st *st = le->data;
 
 		if (st->af->dech)
 			err |= re_hprintf(pf, " <--- %s", st->af->name);
 	}
 
+	if (rx->aubufdec)
+		err |= re_hprintf(pf, " <--- aubufdec");
+
 	err |= re_hprintf(pf, " <--- %s\n",
-			  aurx->ac ? aurx->ac->name : "(decoder)");
+			  rx->ac ? rx->ac->name : "(decoder)");
 
 	return err;
 }

--- a/src/audio.c
+++ b/src/audio.c
@@ -2220,7 +2220,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	size_t sztx, szrx;
+	size_t sztx, szrx, szrxdec;
 	int err;
 
 	if (!a)
@@ -2231,6 +2231,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	sztx = aufmt_sample_size(tx->src_fmt);
 	szrx = aufmt_sample_size(rx->play_fmt);
+	szrxdec = aufmt_sample_size(rx->dec_fmt);
 
 	err  = re_hprintf(pf, "\n--- Audio stream ---\n");
 
@@ -2271,6 +2272,13 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 			  rx->stats.aubuf_overrun,
 			  rx->stats.aubuf_underrun
 			  );
+	if (rx->aubufdec)
+		err |= re_hprintf(pf, "       aubufdec: %H"
+			  " (cur %.2fms)\n",
+			  aubuf_debug, rx->aubufdec,
+			  calc_ptime(aubuf_cur_size(rx->aubufdec)/szrxdec,
+				     rx->ac->srate,
+				     rx->ac->ch));
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,


### PR DESCRIPTION
This is only for discussion so far.
```
       If an AEC is in the filter list aufilt, then the aubuf should be
       constant and small. A second audio buffer aubufdec should be added via
       config if network jitter is expected.

       .--------.   .-------.   .--------.   .----------.   .--------.
 |\    |        |   |       |   |        |   |  opt.    |   |        |
 | |<--| auplay |<--| aubuf |<--| aufilt |<--| aubufdec |<--| decode |<--- RTP
 |/    |        |   |       |   |        |   |          |   |        |
       '--------'   '-------'   '--------'   '----------'   '--------'

```

The aubufdec makes mostly sense, if it runs in adaptive mode to handle changing network jitter best. If running in adaptive mode, an extra thread might not be required.