### PR TITLE
conf: missing pointer initialization found by clang analyzer

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -107,12 +107,15 @@ int conf_loadfile(struct mbuf **mbp, const char *filename)
 int conf_parse(const char *filename, confline_h *ch, void *arg)
 {
 	struct pl pl, val;
-	struct mbuf *mb;
+	struct mbuf *mb = NULL;
 	int err;
 
 	err = conf_loadfile(&mb, filename);
 	if (err)
 		return err;
+
+	if (!mb)
+		return EINVAL;
 
 	pl.p = (const char *)mb->buf;
 	pl.l = mb->end;


### PR DESCRIPTION
Fixes:
```c
src/conf.c:117:23: warning: Access to field 'buf' results in a dereference of an undefined pointer value (loaded from variable 'mb') [core.NullDereference]
        pl.p = (const char *)mb->buf;
```