### PR TITLE
dns: add query cache

### DIFF
--- a/test/ua.c
+++ b/test/ua.c
@@ -524,7 +524,7 @@ static int reg_auth_dns(enum sip_transp tp)
 
 	memset(&t, 0, sizeof(t));
 
-	dnsc_set_cache(net_dnsc(net), false);
+	dnsc_cache_max(net_dnsc(net), 0);
 
 	/*
 	 * Setup server-side mocks:

--- a/test/ua.c
+++ b/test/ua.c
@@ -524,6 +524,8 @@ static int reg_auth_dns(enum sip_transp tp)
 
 	memset(&t, 0, sizeof(t));
 
+	dnsc_set_cache(net_dnsc(net), false);
+
 	/*
 	 * Setup server-side mocks:
 	 */


### PR DESCRIPTION
The dns test checks for rotating entries and so these cannot be cached.

depends on: https://github.com/baresip/re/pull/369