### PR TITLE
aufile/play: fix run data race

### DIFF
--- a/modules/aufile/aufile_play.c
+++ b/modules/aufile/aufile_play.c
@@ -6,6 +6,7 @@
 #define _DEFAULT_SOURCE 1
 #define _BSD_SOURCE 1
 #include <string.h>
+#include <re_atomic.h>
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
@@ -17,7 +18,7 @@ struct auplay_st {
 	struct auplay_prm prm;
 
 	thrd_t thread;
-	volatile bool run;
+	RE_ATOMIC bool run;
 	void *sampv;
 	size_t sampc;
 	size_t num_bytes;


### PR DESCRIPTION
Fixes:
```bash
$ ./selftest test_call_mediaenc
WARNING: ThreadSanitizer: data race (pid=200111)
  Write of size 1 at 0x7b3c00000748 by main thread:
    #0 destructor /baresip/modules/aufile/aufile_play.c:35:11 (selftest+0x1d0083)
    #1 mem_deref /re/src/mem/mem.c:314:3 (selftest+0x2c3141)
    #2 stop_rx /baresip/src/audio.c:293:15 (selftest+0x15629a)
    #3 audio_stop /baresip/src/audio.c:1661:2 (selftest+0x15607d)
    #4 call_stream_stop /baresip/src/call.c:224:2 (selftest+0x162dba)
    #5 call_destructor /baresip/src/call.c:400:2 (selftest+0x15fceb)
    #6 mem_deref /re/src/mem/mem.c:314:3 (selftest+0x2c3141)
    #7 list_flush /re/src/list/list.c:51:3 (selftest+0x2b1849)
    #8 ua_destructor /baresip/src/ua.c:57:2 (selftest+0x18aa40)
    #9 mem_deref /re/src/mem/mem.c:314:3 (selftest+0x2c3141)
    #10 test_call_mediaenc /baresip/test/call.c:1105:2 (selftest+0x128799)
    #11 run_one_test /baresip/test/main.c:78:8 (selftest+0x14a416)
    #12 main /baresip/test/main.c:261:11 (selftest+0x149ffc)

  Previous read of size 1 at 0x7b3c00000748 by thread T2:
    #0 write_thread /baresip/modules/aufile/aufile_play.c:53:13 (selftest+0x1d01cd)
    #1 thrd_handler /re/src/thread/posix.c:26:27 (selftest+0x2c5ece)
```