### PR TITLE
av1: add packetize handler

### DIFF
--- a/modules/av1/av1.c
+++ b/modules/av1/av1.c
@@ -26,6 +26,7 @@ static struct vidcodec av1 = {
 	.ench      = av1_encode_packet,
 	.decupdh   = av1_decode_update,
 	.dech      = av1_decode,
+	.packetizeh = av1_encode_packetize,
 };
 
 

--- a/modules/av1/av1.h
+++ b/modules/av1/av1.h
@@ -11,6 +11,8 @@ int av1_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      videnc_packet_h *pkth, void *arg);
 int av1_encode_packet(struct videnc_state *ves, bool update,
 		      const struct vidframe *frame, uint64_t timestamp);
+int av1_encode_packetize(struct videnc_state *ves,
+			 const struct vidpacket *packet);
 
 
 /* Decode */

--- a/modules/av1/encode.c
+++ b/modules/av1/encode.c
@@ -295,31 +295,31 @@ int av1_encode_packet(struct videnc_state *ves, bool update,
 int av1_encode_packetize(struct videnc_state *ves,
 			 const struct vidpacket *packet)
 {
-	struct mbuf *mb2;
+	struct mbuf *mb_pkt;
 	uint64_t rtp_ts;
 	int err;
 
 	if (!ves || !packet)
 		return EINVAL;
 
-	mb2 = mbuf_alloc(packet->size);
-	if (!mb2)
+	mb_pkt = mbuf_alloc(packet->size);
+	if (!mb_pkt)
 		return ENOMEM;
 
-	err = copy_obus(mb2, packet->buf, packet->size);
+	err = copy_obus(mb_pkt, packet->buf, packet->size);
 	if (err)
 		goto out;
 
 	rtp_ts = video_calc_rtp_timestamp_fix(packet->timestamp);
 
 	err = av1_packetize(&ves->new, true, rtp_ts,
-			    mb2->buf, mb2->end, ves->pktsize,
+			    mb_pkt->buf, mb_pkt->end, ves->pktsize,
 			    ves->pkth, ves->arg);
 	if (err)
 		goto out;
 
  out:
-	mem_deref(mb2);
+	mem_deref(mb_pkt);
 
 	return err;
 }


### PR DESCRIPTION
this enables support for avformat pass through of AV1

1. avformat module can enable pass_through mode
2. the mediafile read can contain AV1 bitstream
3. the bitstream will not be decoded by avformat, but passed raw to av1.so codec module
4. the av1 packetize handler will convert the bitstream to RTP packets
