### PR TITLE
vp8: add packetize handler

### DIFF
--- a/modules/vp8/vp8.c
+++ b/modules/vp8/vp8.c
@@ -33,6 +33,7 @@ static struct vp8_vidcodec vp8 = {
 		.decupdh   = vp8_decode_update,
 		.dech      = vp8_decode,
 		.fmtp_ench = vp8_fmtp_enc,
+		.packetizeh = vp8_encode_packetize,
 	},
 	.max_fs   = 3600,
 };

--- a/modules/vp8/vp8.h
+++ b/modules/vp8/vp8.h
@@ -15,6 +15,8 @@ int vp8_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      videnc_packet_h *pkth, void *arg);
 int vp8_encode(struct videnc_state *ves, bool update,
 	       const struct vidframe *frame, uint64_t timestamp);
+int vp8_encode_packetize(struct videnc_state *ves,
+			 const struct vidpacket *packet);
 
 
 /* Decode */


### PR DESCRIPTION
This enables streaming of mediafiles with VP8 codec, without any re-encoding using avformat.so "pass through" mode.