### PR TITLE
audiounit,coreaudio: fix kAudioObjectPropertyElementMaster deprecation

### DIFF
--- a/modules/audiounit/recorder.c
+++ b/modules/audiounit/recorder.c
@@ -199,7 +199,7 @@ int audiounit_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	AudioObjectPropertyAddress auAddress = {
 		kAudioHardwarePropertyDefaultInputDevice,
 		kAudioObjectPropertyScopeGlobal,
-		kAudioObjectPropertyElementMaster };
+		kAudioObjectPropertyElementMain };
 #endif
 	Float64 hw_srate = 0.0;
 	UInt32 hw_size = sizeof(hw_srate);

--- a/modules/coreaudio/coreaudio.c
+++ b/modules/coreaudio/coreaudio.c
@@ -27,7 +27,7 @@ int coreaudio_enum_devices(const char *name, struct list *dev_list,
 	AudioObjectPropertyAddress propertyAddress = {
 		kAudioHardwarePropertyDevices,
 		kAudioObjectPropertyScopeGlobal,
-		kAudioObjectPropertyElementMaster
+		kAudioObjectPropertyElementMain
 	};
 
 	AudioDeviceID *audioDevices = NULL;


### PR DESCRIPTION
```
modules/audiounit/recorder.c:202:3: warning: 'kAudioObjectPropertyElementMaster' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
                kAudioObjectPropertyElementMaster };
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                kAudioObjectPropertyElementMain
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudio.framework/Headers/AudioHa
rdwareBase.h:208:5: note: 'kAudioObjectPropertyElementMaster' has been explicitly marked deprecated here
    kAudioObjectPropertyElementMaster API_DEPRECATED_WITH_REPLACEMENT("kAudioObjectPropertyElementMain", macos(10.0, 12.0), ios(2.0, 15.0), watchos(1.0, 8.0
), tvos(9.0, 15.0)) = kAudioObjectPropertyElementMain
    ^                                
  OC [m]  build-x86_64/modules/avcapture/avcapture.o
1 warning generated. 
```

```
modules/coreaudio/coreaudio.c:30:3: warning: 'kAudioObjectPropertyElementMaster' is deprecated: first deprecated in macOS 12.0 [-Wdeprecated-declarations]
                kAudioObjectPropertyElementMaster
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                kAudioObjectPropertyElementMain
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreAudio.framework/Headers/AudioHa
rdwareBase.h:208:5: note: 'kAudioObjectPropertyElementMaster' has been explicitly marked deprecated here
    kAudioObjectPropertyElementMaster API_DEPRECATED_WITH_REPLACEMENT("kAudioObjectPropertyElementMain", macos(10.0, 12.0), ios(2.0, 15.0), watchos(1.0, 8.0
), tvos(9.0, 15.0)) = kAudioObjectPropertyElementMain
    ^                                                                         
1 warning generated.                                                          
```

