### PR TITLE
audio: make rx.filtl thread-safe

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -331,7 +331,6 @@ static void audio_destructor(void *arg)
 	mem_deref(a->rx.device);
 
 	list_flush(&a->tx.filtl);
-	list_flush(&a->rx.filtl);
 
 	mem_deref(a->strm);
 	mem_deref(a->telev);


### PR DESCRIPTION
Involved threads are:
- global re main thread
- rx_filter_thread (only used if config contains: `decode_buffer_mode`)

commits
- audio: rename lock to mtx
- audio: make rx.filtl thread-safe
