### PR TITLE
Do not destroy register client when it is unregistered

### DIFF
--- a/src/reg.c
+++ b/src/reg.c
@@ -249,10 +249,7 @@ void reg_unregister(struct reg *reg)
 	if (!reg)
 		return;
 
-	reg->scode = 0;
-	reg->af    = 0;
-
-	reg->sipreg = mem_deref(reg->sipreg);
+	sipreg_unregister(reg->sipreg);
 }
 
 


### PR DESCRIPTION
This PR changes behavior of `reg_unregister` API function so that it does not anymore destroy register client, but just un-registers it.  `reg_unregister` is currently used only by `ua_unregister` API function, which in turn us used by `menu` module `uareg` command and by `serreg` module.

If these usages require that in addition to un-registering, register client is also destroyed, I can instead of changing the behavior of `reg_unregister` function, create a new API function `reg_unregister_only`.  Based on my tests, menu module `uareg` command works fine with the modified `reg_unregister` function of this PR.  Also, quit command works the same way as before.