### PR TITLE
Un-subscribe mwi at un-register

### DIFF
--- a/modules/mwi/mwi.c
+++ b/modules/mwi/mwi.c
@@ -155,7 +155,9 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		    (str_casecmp(account_mwi(acc), "yes") == 0))
 			mwi_subscribe(ua);
 	}
-	else if (ev == UA_EVENT_SHUTDOWN || ev == UA_EVENT_UNREGISTERING) {
+	else if (ev == UA_EVENT_SHUTDOWN ||
+		 (ev == UA_EVENT_UNREGISTERING &&
+		  str_cmp(account_sipnat(acc), "outbound") == 0)) {
 
 		struct mwi *mwi = mwi_find(ua);
 

--- a/modules/mwi/mwi.c
+++ b/modules/mwi/mwi.c
@@ -155,13 +155,14 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		    (str_casecmp(account_mwi(acc), "yes") == 0))
 			mwi_subscribe(ua);
 	}
-	else if (ev == UA_EVENT_SHUTDOWN) {
+	else if (ev == UA_EVENT_SHUTDOWN || ev == UA_EVENT_UNREGISTERING) {
 
 		struct mwi *mwi = mwi_find(ua);
 
 		if (mwi) {
 
 			info("mwi: shutdown of %s\n", account_aor(acc));
+
 			mwi->shutdown = true;
 
 			if (mwi->sub) {


### PR DESCRIPTION
When UNREGISTERING event is received, un-SUBSCRIBE possible MWI subscription, because at least when outbound is used, SIP proxy cannot anymore route NOTIFY requests to baresip based on gruu.