### PR TITLE
call: update media on session progress.

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2204,18 +2204,14 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 		break;
 	}
 
-	call_stream_stop(call);
-
-	if (media)
-		call_stream_start(call, false);
-
-	if (media)
+	if (media) {
 		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
-	else
-		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
-
-	if (media)
 		update_media(call);
+	}
+	else {
+		call_stream_stop(call);
+		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
+	}
 }
 
 


### PR DESCRIPTION
While handling a session progress, the media streams were always stopped and restarted. Now the streams are updated according to the media information received in the session progress message. 