### PR TITLE
call, menu: make selective early media RFC-3261 conform

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -238,7 +238,7 @@ int call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
-bool          call_need_reinvite(const struct call *call);
+bool          call_need_modify(const struct call *call);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -236,6 +236,7 @@ void call_set_current(struct list *calls, struct call *call);
 const struct list *call_get_custom_hdrs(const struct call *call);
 int call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
+int call_set_media_ansdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -238,7 +238,6 @@ int call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
-bool          call_need_modify(const struct call *call);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -238,6 +238,7 @@ int call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
+bool          call_need_reinvite(const struct call *call);
 
 
 /*

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -372,7 +372,9 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 		return EINVAL;
 
 	err  = call_set_media_ansdir(call, adir, vdir);
-	err |= call_set_media_direction(call, adir, vdir);
+	if (call_state(call) == CALL_STATE_ESTABLISHED)
+		err |= call_set_media_direction(call, adir, vdir);
+
 	return err;
 }
 

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -408,6 +408,9 @@ static int set_video_dir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
+	if (call_state(call) != CALL_STATE_ESTABLISHED)
+		return EINVAL;
+
 	if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_INACTIVE))) {
 		err = call_set_video_dir(call, SDP_INACTIVE);
 	}

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -330,6 +330,7 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	struct pl callid = PL_INIT;
 	char *cid = NULL;
 	bool ok = false;
+	int err;
 
 	const char *usage = "usage: /medialdir"
 			" audio=<inactive, sendonly, recvonly, sendrecv>"
@@ -370,7 +371,9 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	return call_set_media_direction(call, adir, vdir);
+	err  = call_set_media_ansdir(call, adir, vdir);
+	err |= call_set_media_direction(call, adir, vdir);
+	return err;
 }
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -606,6 +606,9 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		   established */
 		redial_reset();
 		uag_hold_others(call);
+
+		if (call_need_reinvite(call))
+			call_modify(call);
 		break;
 
 	case UA_EVENT_CALL_CLOSED:

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -606,9 +606,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		   established */
 		redial_reset();
 		uag_hold_others(call);
-
-		if (call_need_modify(call))
-			call_modify(call);
 		break;
 
 	case UA_EVENT_CALL_CLOSED:

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -607,7 +607,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		redial_reset();
 		uag_hold_others(call);
 
-		if (call_need_reinvite(call))
+		if (call_need_modify(call))
 			call_modify(call);
 		break;
 

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -157,7 +157,7 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 
-	(void)call_set_media_direction(call, adir, vdir);
+	(void)call_set_media_ansdir(call, adir, vdir);
 	err = answer_call(ua, call);
 	if (err)
 		re_hprintf(pf, "could not answer call (%m)\n", err);

--- a/src/call.c
+++ b/src/call.c
@@ -1270,7 +1270,7 @@ out:
 }
 
 
-bool call_need_reinvite(const struct call *call)
+bool call_need_modify(const struct call *call)
 {
 	enum sdp_dir adir;
 	enum sdp_dir vdir;

--- a/src/call.c
+++ b/src/call.c
@@ -1124,8 +1124,7 @@ int call_modify(struct call *call)
 
 	debug("call: modify\n");
 
-	err  = call_set_media_direction(call, call->ansadir, call->ansvdir);
-	err |= call_sdp_get(call, &desc, true);
+	err = call_sdp_get(call, &desc, true);
 	if (!err) {
 		err = sipsess_modify(call->sess, desc);
 		if (err)
@@ -1808,8 +1807,10 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 		(void)call_notify_sipfrag(call, 200, "OK");
 	}
 
-	if (call_need_modify(call))
+	if (call_need_modify(call)) {
+		call_set_media_direction(call, call->ansadir, call->ansvdir);
 		call_modify(call);
+	}
 
 	/* must be done last, the handler might deref this call */
 	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);

--- a/src/call.c
+++ b/src/call.c
@@ -1271,7 +1271,7 @@ out:
 }
 
 
-bool call_need_modify(const struct call *call)
+static bool call_need_modify(const struct call *call)
 {
 	enum sdp_dir adir;
 	enum sdp_dir vdir;
@@ -1814,6 +1814,8 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 
 	/* must be done last, the handler might deref this call */
 	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);
+	if (call_need_modify(call))
+		call_modify(call);
 }
 
 

--- a/src/call.c
+++ b/src/call.c
@@ -1270,6 +1270,20 @@ out:
 }
 
 
+bool call_need_reinvite(const struct call *call)
+{
+	enum sdp_dir adir;
+	enum sdp_dir vdir;
+
+	if (!call)
+		return false;
+
+	adir = stream_ldir(audio_strm(call_audio(call)));
+	vdir = stream_ldir(video_strm(call_video(call)));
+	return adir != call->ansadir || vdir != call->ansvdir;
+}
+
+
 /**
  * Answer an incoming call
  *
@@ -1303,7 +1317,6 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 
 	if (call->got_offer) {
 
-		call_set_media_direction(call, call->ansadir, call->ansvdir);
 		err = update_media(call);
 		if (err)
 			return err;

--- a/src/call.c
+++ b/src/call.c
@@ -1122,7 +1122,8 @@ int call_modify(struct call *call)
 
 	debug("call: modify\n");
 
-	err = call_sdp_get(call, &desc, true);
+	err  = call_set_media_direction(call, call->ansadir, call->ansvdir);
+	err |= call_sdp_get(call, &desc, true);
 	if (!err) {
 		err = sipsess_modify(call->sess, desc);
 		if (err)

--- a/src/call.c
+++ b/src/call.c
@@ -962,6 +962,8 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 		    || NULL != vidisp_find(baresip_vidispl(), NULL));
 
 	debug("call: use_video=%d\n", call->use_video);
+	if (!call->use_video)
+		call->ansvdir = SDP_INACTIVE;
 
 	/* inherit certain properties from original call */
 	if (xcall) {
@@ -1812,10 +1814,11 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 		(void)call_notify_sipfrag(call, 200, "OK");
 	}
 
-	/* must be done last, the handler might deref this call */
-	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);
 	if (call_need_modify(call))
 		call_modify(call);
+
+	/* must be done last, the handler might deref this call */
+	call_event_handler(call, CALL_EVENT_ESTABLISHED, call->peer_uri);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1090,7 +1090,8 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 		call_set_custom_hdrs(call, &ua->custom_hdrs);
 
 	if (adir != SDP_SENDRECV || vdir != SDP_SENDRECV) {
-		err = call_set_media_direction(call, adir, vdir);
+		err  = call_set_media_ansdir(call, adir, vdir);
+		err |= call_set_media_direction(call, adir, vdir);
 		if (err) {
 			mem_deref(call);
 			goto out;


### PR DESCRIPTION
Due to RFC-3261 the SDP in the 183 Session Progress has to be equal to the SDP
in the 200 Ok. The correct solution is to answer the call with same SDP and
send immediately a re-INVITE if needed. E.g. in case of early video send
re-INVITE in order to activate the audio stream.

RFC-3261 13.2.1 Creating the Initial INVITE, Page 80
```
The UAC MUST treat the first session description it receives as the answer, and MUST ignore any
session descriptions in subsequent responses to the initial INVITE.
```