### PR TITLE
config: add flag to enable/disable linklocal

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -381,6 +381,7 @@ struct config_net {
 		bool fallback;
 	} nsv[NET_MAX_NS];      /**< Configured DNS nameservers     */
 	size_t nsc;             /**< Number of DNS nameservers      */
+	bool use_linklocal;     /**< Use v4/v6 link-local addresses */
 };
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -97,6 +97,7 @@ static struct config core_config = {
 		"",
 		{ {"",0} },
 		0,
+		true,
 	},
 };
 

--- a/src/net.c
+++ b/src/net.c
@@ -622,6 +622,9 @@ bool net_ifaddr_filter(const struct network *net, const char *ifname,
 	if (!sa_isset(sa, SA_ADDR))
 		return false;
 
+	if (sa_is_linklocal(sa) && !cfg->use_linklocal)
+		return false;
+
 	if (str_isset(cfg->ifname) && 0 == sa_set_str(&ip, cfg->ifname, 0) &&
 			sa_cmp(&ip, sa, SA_ADDR))
 		return true;


### PR DESCRIPTION
IPv4/IPv6 link local addresses is by default enabled.

In my application I wish to disable link-local, so adding a flag in `struct config_net`