### PR TITLE
audio: update filters if codec changes

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1908,6 +1908,9 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 		/* Audio source must be stopped first */
 		if (reset) {
 			tx->ausrc = mem_deref(tx->ausrc);
+			mtx_lock(a->tx.mtx);
+			list_flush(&tx->filtl);
+			mtx_unlock(a->tx.mtx);
 			aubuf_flush(tx->aubuf);
 		}
 


### PR DESCRIPTION
When the codec is changed, filters have to updated because parameters like
sample rate may change. E.g. auresamp needs the new configuration.
