### PR TITLE
sip: add RFC 3311 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ zrtp          ZRTP media encryption module
 * RFC 2429  RTP Payload Format for 1998 ver of ITU-T Rec. H.263 Video (H.263+)
 * RFC 3016  RTP Payload Format for MPEG-4 Audio/Visual Streams
 * RFC 3262  Reliability of Provisional Responses for SIP
+* RFC 3311  SIP UPDATE Method
 * RFC 3428  SIP Extension for Instant Messaging
 * RFC 3711  The Secure Real-time Transport Protocol (SRTP)
 * RFC 3640  RTP Payload Format for Transport of MPEG-4 Elementary Streams

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -164,6 +164,7 @@ enum call_state {
 	CALL_STATE_OUTGOING,
 	CALL_STATE_RINGING,
 	CALL_STATE_EARLY,
+	CALL_STATE_EARLY_CONFIRMED,
 	CALL_STATE_ESTABLISHED,
 	CALL_STATE_TERMINATED,
 	CALL_STATE_TRANSFER,
@@ -203,6 +204,7 @@ int  call_send_digit(struct call *call, char key);
 bool call_has_audio(const struct call *call);
 bool call_has_video(const struct call *call);
 bool call_early_video_available(const struct call *call);
+bool call_target_refresh_allowed(const struct call *call);
 int  call_transfer(struct call *call, const char *uri);
 int  call_replace_transfer(struct call *target_call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -408,8 +408,10 @@ static int set_video_dir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	if (call_state(call) != CALL_STATE_ESTABLISHED)
+	if (!call_target_refresh_allowed(call)) {
+		(void)re_hprintf(pf, "video update not allowed currently");
 		return EINVAL;
+	}
 
 	if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_INACTIVE))) {
 		err = call_set_video_dir(call, SDP_INACTIVE);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -313,6 +313,7 @@ static void play_resume(const struct call *closed)
 		play_incoming(call);
 		break;
 	case CALL_STATE_RINGING:
+	case CALL_STATE_EARLY_CONFIRMED:
 	case CALL_STATE_EARLY:
 		if (!menu.ringback && !menu_find_call(active_call_test,
 						      closed))
@@ -812,6 +813,7 @@ static void menu_sel_other(struct call *exclude)
 		CALL_STATE_INCOMING,
 		CALL_STATE_OUTGOING,
 		CALL_STATE_RINGING,
+		CALL_STATE_EARLY_CONFIRMED,
 		CALL_STATE_EARLY,
 		CALL_STATE_ESTABLISHED,
 	};

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -804,7 +804,8 @@ static void hangup_callstate(enum call_state state)
  * @param arg  Command arguments (carg)
  *             carg->prm Can optionally set to "out", "in", "all".
  *             - out ... Hangup calls in state CALL_STATE_OUTGOING,
- *                       CALL_STATE_RINGING, CALL_STATE_EARLY
+ *                       CALL_STATE_RINGING, CALL_STATE_EARLY_CONFIRMED,
+ *                       CALL_STATE_EARLY
  *             - in  ... Hangup calls in state CALL_STATE_INCOMING
  *             - all ... Hangup all calls (default).
  *
@@ -838,6 +839,7 @@ static int cmd_hangupall(struct re_printf *pf, void *arg)
 	else if (!pl_strcmp(&pldir, "out")) {
 		hangup_callstate(CALL_STATE_OUTGOING);
 		hangup_callstate(CALL_STATE_RINGING);
+		hangup_callstate(CALL_STATE_EARLY_CONFIRMED);
 		hangup_callstate(CALL_STATE_EARLY);
 	}
 	else if (!pl_strcmp(&pldir, "in")) {

--- a/src/call.c
+++ b/src/call.c
@@ -58,6 +58,7 @@ struct call {
 	bool answered;            /**< True if call has been answered       */
 	bool got_offer;           /**< Got SDP Offer from Peer              */
 	bool on_hold;             /**< True if call is on hold (local)      */
+	bool peer_100rel;         /**< True if peer supports RFC 3262       */
 	struct mnat_sess *mnats;  /**< Media NAT session                    */
 	bool mnat_wait;           /**< Waiting for MNAT to establish        */
 	struct menc_sess *mencs;  /**< Media encryption session state       */
@@ -89,16 +90,17 @@ static const char *state_name(enum call_state st)
 {
 	switch (st) {
 
-	case CALL_STATE_IDLE:        return "IDLE";
-	case CALL_STATE_INCOMING:    return "INCOMING";
-	case CALL_STATE_OUTGOING:    return "OUTGOING";
-	case CALL_STATE_RINGING:     return "RINGING";
-	case CALL_STATE_EARLY:       return "EARLY";
-	case CALL_STATE_ESTABLISHED: return "ESTABLISHED";
-	case CALL_STATE_TERMINATED:  return "TERMINATED";
-	case CALL_STATE_TRANSFER:    return "TRANSFER";
-	case CALL_STATE_UNKNOWN:     return "UNKNOWN";
-	default:                return "???";
+	case CALL_STATE_IDLE:		 return "IDLE";
+	case CALL_STATE_INCOMING:	 return "INCOMING";
+	case CALL_STATE_OUTGOING:	 return "OUTGOING";
+	case CALL_STATE_RINGING:	 return "RINGING";
+	case CALL_STATE_EARLY_CONFIRMED: return "EARLY_CONFIRMED";
+	case CALL_STATE_EARLY:		 return "EARLY";
+	case CALL_STATE_ESTABLISHED:	 return "ESTABLISHED";
+	case CALL_STATE_TERMINATED:	 return "TERMINATED";
+	case CALL_STATE_TRANSFER:	 return "TRANSFER";
+	case CALL_STATE_UNKNOWN:	 return "UNKNOWN";
+	default:			 return "???";
 	}
 }
 
@@ -1435,6 +1437,25 @@ int call_sdp_get(const struct call *call, struct mbuf **descp, bool offer)
 
 
 /**
+ * Check if a target refresh (re-INVITE or UPDATE) is currently allowed
+ *
+ * @param call  Call object
+ *
+ * @return True if a target refresh is currently allowed, otherwise false
+ */
+bool call_target_refresh_allowed(const struct call *call)
+{
+	if (!call)
+		return false;
+
+	return call_state(call) == CALL_STATE_ESTABLISHED
+	       || call_state(call) == CALL_STATE_EARLY_CONFIRMED
+	       || (call_state(call) == CALL_STATE_INCOMING
+		   && call->peer_100rel && account_rel100_mode(call->acc));
+}
+
+
+/**
  * Get the session call-id for the call
  *
  * @param call Call object
@@ -1579,6 +1600,7 @@ int call_status(struct re_printf *pf, const struct call *call)
 
 	switch (call->state) {
 
+	case CALL_STATE_EARLY_CONFIRMED:
 	case CALL_STATE_EARLY:
 	case CALL_STATE_ESTABLISHED:
 		break;
@@ -1733,9 +1755,9 @@ static int sipsess_offer_handler(struct mbuf **descp,
 		vrdir = sdp_media_rdir(vmedia);
 	}
 
-	info("call: got re-INVITE%s audio-video: %s-%s\n"
-		, got_offer ? " (SDP Offer)" : "",
-		sdp_dir_name(ardir), sdp_dir_name(vrdir));
+	info("call: got %r%s audio-video: %s-%s\n", &msg->met,
+	     got_offer ? " (SDP Offer)" : "", sdp_dir_name(ardir),
+	     sdp_dir_name(vrdir));
 
 	/* Encode SDP Answer */
 	return sdp_encode(descp, call->sdp, !got_offer);
@@ -1755,7 +1777,8 @@ static int sipsess_answer_handler(const struct sip_msg *msg, void *arg)
 		call->supported |= REPLACES;
 
 	call->got_offer = false;
-	call_event_handler(call, CALL_EVENT_ANSWERED, call->peer_uri);
+	if (!pl_strcmp(&msg->cseq.met, "INVITE"))
+		call_event_handler(call, CALL_EVENT_ANSWERED, call->peer_uri);
 
 	if (msg_ctype_cmp(&msg->ctyp, "multipart", "mixed"))
 		(void)sdp_decode_multipart(&msg->ctyp.params, msg->mb);
@@ -2155,6 +2178,9 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 		return err;
 
 	set_state(call, CALL_STATE_INCOMING);
+	call->peer_100rel =
+		sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel")
+		|| sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel");
 
 	/* New call */
 	if (call->config_call.local_timeout) {
@@ -2182,6 +2208,7 @@ static void delayed_answer_handler(void *arg)
 static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 {
 	struct call *call = arg;
+	bool rel100;
 	bool media;
 
 	MAGIC_CHECK(call);
@@ -2213,6 +2240,9 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	else
 		media = false;
 
+	rel100 = sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel")
+		 && account_rel100_mode(call->acc);
+
 	switch (msg->scode) {
 
 	case 180:
@@ -2220,7 +2250,11 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 		break;
 
 	case 183:
-		set_state(call, CALL_STATE_EARLY);
+		if (rel100)
+			set_state(call, CALL_STATE_EARLY_CONFIRMED);
+		else
+			set_state(call, CALL_STATE_EARLY);
+
 		break;
 	}
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1617,7 +1617,7 @@ int ua_print_allowed(struct re_printf *pf, const struct ua *ua)
 
 	err = re_hprintf(pf,
 			 "INVITE,ACK,BYE,CANCEL,OPTIONS,"
-			 "NOTIFY,SUBSCRIBE,INFO,MESSAGE");
+			 "NOTIFY,SUBSCRIBE,INFO,MESSAGE,UPDATE");
 
 	if (ua->acc->rel100_mode)
 		err |= re_hprintf(pf, ",PRACK");


### PR DESCRIPTION
This PR adds support for [RFC 3311](https://datatracker.ietf.org/doc/html/rfc3311) - the SIP UPDATE method.

Specifically, in concert with [RFC 3262](https://datatracker.ietf.org/doc/html/rfc3262) this allows session modifications in the early media state if the early media session is established through reliable 1xx responses. As outlined in [RFC 6337](https://datatracker.ietf.org/doc/html/rfc6337) ([section 3.2](https://datatracker.ietf.org/doc/html/rfc6337#section-3.2)), this is the only way to do session modification while in the early media state.

Related:
- https://github.com/baresip/re/pull/425