### PR TITLE
audio: fix SEGV if stream_alloc() fails

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -306,9 +306,12 @@ static void stop_rx(struct aurx *rx)
 	rx->auplay = mem_deref(rx->auplay);
 	rx->aubuf  = mem_deref(rx->aubuf);
 	rx->aubufdec  = mem_deref(rx->aubufdec);
-	mtx_lock(rx->mtx);
+	if (rx->mtx)
+		mtx_lock(rx->mtx);
+
 	list_flush(&rx->filtl);
-	mtx_unlock(rx->mtx);
+	if (rx->mtx)
+		mtx_unlock(rx->mtx);
 }
 
 


### PR DESCRIPTION
`mtx_lock(NULL)` crashes on linux

```
stream: rtp_listen failed: af=AF_INET ports=1024-49152 (Address already in use)
stream: failed to create socket for media 'audio' (Address already in use)

Thread 1 "baresip" received signal SIGSEGV, Segmentation fault.
___pthread_mutex_lock (mutex=0x0) at pthread_mutex_lock.c:76
76	pthread_mutex_lock.c: No such file or directory.
(gdb) bt
#0  ___pthread_mutex_lock (mutex=0x0) at pthread_mutex_lock.c:76
#1  0x00007ffff7d4c60d in __mtx_lock (mutex=<optimized out>) at ../sysdeps/pthread/mtx_lock.c:25
#2  0x0000555555567b6b in stop_rx (rx=0x5555556675e0) at src/audio.c:309
#3  0x0000555555567c0c in audio_destructor (arg=0x555555667508) at src/audio.c:322
#4  0x00007ffff7f8099e in mem_deref (data=0x555555667508) at src/mem/mem.c:335
#5  0x0000555555569f14 in audio_alloc
    (ap=0x555555668e00, streaml=0x555555668df0, stream_prm=0x7fffffffd0a0, cfg=0x5555555a6020 <core_config>, acc=0x55555564a638, sdp_sess=0x555555668368, mnat=0x0, mnat_sess=0x0, menc=0x0, menc_sess=0x0, ptime=20, aucodecl=0x5555555a6a08 <baresip+72>, offerer=true, eventh=0x55555556f1a6 <audio_event_handler>, levelh=0x55555556f266 <audio_level_handler>, errh=0x55555556f301 <audio_error_handler>, arg=0x555555668d88)
    at src/audio.c:1212
```