### PR TITLE
audio: remove unused aubuf for decoding

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -130,16 +130,6 @@ struct autx {
  |/    |        |   |       |   |        |   |        |
        '--------'   '-------'   '--------'   '--------'
 
-       If an AEC is in the filter list aufilt, then the aubuf should be
-       constant and small. A second audio buffer aubufdec should be added via
-       config if network jitter is expected.
-
-       .--------.   .-------.   .--------.   .----------.   .--------.
- |\    |        |   |       |   |        |   |  opt.    |   |        |
- | |<--| auplay |<--| aubuf |<--| aufilt |<--| aubufdec |<--| decode |<--- RTP
- |/    |        |   |       |   |        |   |          |   |        |
-       '--------'   '-------'   '--------'   '----------'   '--------'
-
  \endverbatim
  */
 struct aurx {
@@ -149,7 +139,6 @@ struct aurx {
 	const struct aucodec *ac;     /**< Current audio decoder           */
 	struct audec_state *dec;      /**< Audio decoder state (optional)  */
 	struct aubuf *aubuf;          /**< Audio buffer before auplay      */
-	struct aubuf *aubufdec;       /**< Audio buffer after decoder      */
 	uint32_t ssrc;                /**< Incoming synchronization source */
 	size_t aubuf_minsz;           /**< Minimum aubuf size in [bytes]   */
 	size_t aubuf_maxsz;           /**< Maximum aubuf size in [bytes]   */
@@ -167,8 +156,6 @@ struct aurx {
 	enum aufmt dec_fmt;           /**< Sample format for decoder       */
 	struct timestamp_recv ts_recv;/**< Receive timestamp state         */
 
-	void *sampvf;                 /**< Sample buffer for filter thread */
-	size_t fsize;                 /**< Size of sampvf                  */
 	size_t last_sampc;
 
 	struct {
@@ -181,10 +168,6 @@ struct aurx {
 	volatile int32_t wcnt;       /**< Write handler call count         */
 
 	mtx_t *mtx;
-	struct {
-		thrd_t thrd;         /**< Audio RX filter thread           */
-		RE_ATOMIC bool run;  /**< Audio RX filter thread running   */
-	} thr;
 
 };
 
@@ -297,15 +280,9 @@ static void stop_rx(struct aurx *rx)
 	if (!rx)
 		return;
 
-	if (rx->thr.run) {
-		rx->thr.run = false;
-		thrd_join(rx->thr.thrd, NULL);
-	}
-
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
 	rx->aubuf  = mem_deref(rx->aubuf);
-	rx->aubufdec  = mem_deref(rx->aubufdec);
 	if (rx->mtx)
 		mtx_lock(rx->mtx);
 
@@ -330,7 +307,6 @@ static void audio_destructor(void *arg)
 	mem_deref(a->tx.mb);
 	mem_deref(a->tx.sampv);
 	mem_deref(a->rx.sampv);
-	mem_deref(a->rx.sampvf);
 	mem_deref(a->rx.aubuf);
 	mem_deref(a->tx.module);
 	mem_deref(a->tx.device);
@@ -889,7 +865,6 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
 
 	if (drop) {
-		aubuf_drop_auframe(rx->aubufdec, &af);
 		aubuf_drop_auframe(rx->aubuf, &af);
 		goto out;
 	}
@@ -897,25 +872,14 @@ static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
 	if (flush)
 		aubuf_flush(rx->aubuf);
 
-	if (rx->aubufdec) {
-		if (flush)
-			aubuf_flush(rx->aubufdec);
+	err = process_decfilt(rx, &af);
+	if (err)
+		goto out;
 
-		err = aubuf_write_auframe(rx->aubufdec, &af);
-		if (err)
-			goto out;
-	}
-	else {
+	if (!rx->aubuf)
+		goto out;
 
-		err = process_decfilt(rx, &af);
-		if (err)
-			goto out;
-
-		if (!rx->aubuf)
-			goto out;
-
-		err = rx_push_aubuf(rx, &af);
-	}
+	err = rx_push_aubuf(rx, &af);
  out:
 	return err;
 }
@@ -1336,9 +1300,6 @@ static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 	}
 
 	mtx_unlock(rx->mtx);
-	if (rx->aubufdec)
-		err |= re_hprintf(pf, " <--- aubufdec");
-
 	err |= re_hprintf(pf, " <--- %s\n",
 			  rx->ac ? rx->ac->name : "(decoder)");
 
@@ -1430,133 +1391,6 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 }
 
 
-static int rx_frame_read(struct aurx *rx, struct auframe *af)
-{
-	const struct aucodec *ac = rx->ac;
-	size_t size = rx->last_sampc * aufmt_sample_size(rx->dec_fmt);
-
-	if (!size)
-		return EINVAL;
-
-	if (size != rx->fsize) {
-		rx->sampvf = mem_deref(rx->sampvf);
-		rx->sampvf = mem_zalloc(size, NULL);
-		if (rx->sampvf)
-			rx->fsize = size;
-		else
-			rx->fsize = 0;
-	}
-
-	if (!rx->sampvf)
-		return ENOMEM;
-
-	auframe_init(af, rx->dec_fmt, rx->sampvf, rx->last_sampc,
-		     ac->srate, ac->ch);
-	aubuf_read_auframe(rx->aubufdec, af);
-	return 0;
-}
-
-
-static int rx_filter_thread(void *arg)
-{
-	struct audio *a = arg;
-	struct aurx *rx = &a->rx;
-	struct autx *tx = &a->tx;
-	struct auframe af;
-	uint64_t now, ts = tmr_jiffies();
-	uint32_t ptime = rx->ptime;
-	size_t sampc = 0;
-
-	while (rx->thr.run) {
-		int err;
-
-		sys_msleep(4);
-		if (!rx->thr.run)
-			break;
-
-		now = tmr_jiffies();
-		if (ts > now)
-			continue;
-
-		if (!tx->ac || !rx->ac)
-			goto wait;
-
-		if (!rx->last_sampc)
-			goto wait;
-
-		if (rx_frame_read(rx, &af))
-			goto wait;
-
-		err = process_decfilt(rx, &af);
-		if (err)
-			continue;
-
-		(void)rx_push_aubuf(rx, &af);
-
-		if (af.sampc && sampc != af.sampc) {
-			sampc = af.sampc;
-			ptime = (uint32_t) af.sampc*1000 / (af.srate * af.ch);
-		}
-
-wait:
-		ts += ptime;
-	}
-
-	return 0;
-}
-
-
-static int config_aubufdec(struct audio *a)
-{
-	struct aurx *rx = &a->rx;
-	const struct aucodec *ac = rx->ac;
-	size_t sz;
-	struct pl pl;
-	size_t min_sz;
-	size_t max_sz;
-	int err = 0;
-
-	if (0 == conf_get(conf_cur(), "decode_buffer_mode", &pl) &&
-	    pl_strcasecmp(&pl, "off")) {
-		struct range decbuf = {20, 160};
-		sz = aufmt_sample_size(rx->dec_fmt);
-		conf_get_range(conf_cur(), "decode_buffer", &decbuf);
-
-		if (!decbuf.min || !decbuf.max)
-			return EINVAL;
-
-		min_sz = sz*calc_nsamp(ac->srate, ac->ch, decbuf.min);
-		max_sz = sz*calc_nsamp(ac->srate, ac->ch, decbuf.max);
-
-		debug("audio: create decode buffer"
-		      " [%zu - %zu ms]"
-		      " [%zu - %zu bytes]\n",
-		      decbuf.min, decbuf.max, min_sz, max_sz);
-
-		err = aubuf_alloc(&rx->aubufdec, min_sz, max_sz);
-		if (err) {
-			warning("audio: aubuf alloc error (%m)\n",
-				err);
-			return err;
-		}
-
-		aubuf_set_mode(rx->aubufdec, conf_aubuf_adaptive(&pl) ?
-			       AUBUF_ADAPTIVE : AUBUF_FIXED);
-		aubuf_set_silence(rx->aubufdec, a->cfg.silence);
-
-		if (!rx->thr.run) {
-			rx->thr.run = true;
-			err = thread_create_name(&rx->thr.thrd, "RX filter",
-					       rx_filter_thread, a);
-			if (err)
-				rx->thr.run = false;
-		}
-	}
-
-	return err;
-}
-
-
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
@@ -1621,12 +1455,6 @@ static int start_player(struct aurx *rx, struct audio *a,
 			rx->aubuf_maxsz = max_sz;
 		}
 
-		if (!rx->aubufdec) {
-			err = config_aubufdec(a);
-			if (err)
-				goto out;
-		}
-
 		rx->auplay_prm = prm;
 		err = auplay_alloc(&rx->auplay, auplayl,
 				   rx->module,
@@ -1646,10 +1474,8 @@ static int start_player(struct aurx *rx, struct audio *a,
 	}
 
 out:
-	if (err) {
+	if (err)
 		rx->aubuf    = mem_deref(rx->aubuf);
-		rx->aubufdec = mem_deref(rx->aubufdec);
-	}
 
 	return 0;
 }
@@ -1988,7 +1814,6 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 	if (reset || ac != rx->ac) {
 		rx->auplay = mem_deref(rx->auplay);
 		aubuf_flush(rx->aubuf);
-		aubuf_flush(rx->aubufdec);
 		stream_flush(a->strm);
 
 		/* Reset audio filter chain */
@@ -2256,7 +2081,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	size_t sztx, szrx, szrxdec;
+	size_t sztx, szrx;
 	int err;
 
 	if (!a)
@@ -2267,7 +2092,6 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	sztx = aufmt_sample_size(tx->src_fmt);
 	szrx = aufmt_sample_size(rx->play_fmt);
-	szrxdec = aufmt_sample_size(rx->dec_fmt);
 
 	err  = re_hprintf(pf, "\n--- Audio stream ---\n");
 
@@ -2308,13 +2132,6 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 			  rx->stats.aubuf_overrun,
 			  rx->stats.aubuf_underrun
 			  );
-	if (rx->aubufdec)
-		err |= re_hprintf(pf, "       aubufdec: %H"
-			  " (cur %.2fms)\n",
-			  aubuf_debug, rx->aubufdec,
-			  calc_ptime(aubuf_cur_size(rx->aubufdec)/szrxdec,
-				     rx->ac->srate,
-				     rx->ac->ch));
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,


### PR DESCRIPTION
The aubuf for decoding and the rx_filter_thread was introduced in order to
combine the benefits of an adaptive audio buffer with an AEC as audio filter.
If a sound daemon like pulseaudio is used, the AEC should be integrated into
this daemon. But if baresip directly connects to ALSA the aubuf between the
filters and the audio player has to be fixed and as short as possible.

We think that the rx_filter_thread with the decoding aubuf has not enough
benefits for the lots of extra code that was necessary. Instead one could use
a modified ALSA module which integrates an AEC solution, like we did. Then the
AEC runs in the auplay thread.

So this commit is a cleanup for unused code parts.

---
We don't think that anybody uses the `rx_filter_thread`. But this should only be for discussion for now.

Notes for further cleanup / different solution:
- @sreimers You proposed ones that the filters may ran also in the auplay thread. We could make configurable if the dec-filters are running in the main thread (default) or in the auplay thread. But so far I don't think that there is any need for this, except there is somebody who wants to run an AEC as baresip filter and to have the adaptive aubuf.
- If we let the dec-filters run in the main-thread on all cases, we could also remove the lots of `mtx_lock` around `rx.filtl`. Presumed, that we don't plan another try for the RX RTP real-time thread.

Should we remove also the mutex locks?
