### PR TITLE
audio: always start reading in TX poll mode

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -686,10 +686,10 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 		return;
 
 	for (i=0; i<16; i++) {
+		poll_aubuf_tx(a);
+
 		if (aubuf_cur_size(tx->aubuf) < tx->psize)
 			break;
-
-		poll_aubuf_tx(a);
 	}
 
 	/* Exact timing: send Telephony-Events from here */


### PR DESCRIPTION
This fixes TX poll mode.

With the new `started` flag in aubuf, commit https://github.com/baresip/rem/commit/0a91a77201ecb9af10ed2761eb70e901ab0d198d and the `if` in audio.c the `psize` had to be reached exactly once.
