### PR TITLE
Improve re_atomic handling

### DIFF
--- a/modules/aufile/aufile_play.c
+++ b/modules/aufile/aufile_play.c
@@ -31,9 +31,9 @@ static void destructor(void *arg)
 {
 	struct auplay_st *st = arg;
 	/* Wait for termination of other thread */
-	if (st->run) {
+	if (re_atomic_rlx(&st->run)) {
 		debug("aufile: stopping playback thread\n");
-		st->run = false;
+		re_atomic_rlx_set(&st->run, false);
 		thrd_join(st->thread, NULL);
 	}
 
@@ -51,7 +51,7 @@ static int write_thread(void *arg)
 	uint32_t ptime = st->prm.ptime;
 
 	t = tmr_jiffies();
-	while (st->run) {
+	while (re_atomic_rlx(&st->run)) {
 		struct auframe af;
 
 		auframe_init(&af, st->prm.fmt, st->sampv, st->sampc,
@@ -73,7 +73,7 @@ static int write_thread(void *arg)
 		sys_msleep(dt);
 	}
 
-	st->run = false;
+	re_atomic_rlx_set(&st->run, false);
 
 	return 0;
 }
@@ -120,10 +120,10 @@ int aufile_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 	st->sampv = mem_alloc(st->num_bytes, NULL);
 
 	info("aufile: writing speaker audio to %s\n", file);
-	st->run = true;
+	re_atomic_rlx_set(&st->run, true);
 	err = thread_create_name(&st->thread, "aufile_play", write_thread, st);
 	if (err) {
-		st->run = false;
+		re_atomic_rlx_set(&st->run, false);
 		goto out;
 	}
 

--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -45,8 +45,8 @@ static void destructor(void *arg)
 {
 	struct ausrc_st *st = arg;
 
-	if (st->run) {
-		st->run = false;
+	if (re_atomic_rlx(&st->run)) {
+		re_atomic_rlx_set(&st->run, false);
 		thrd_join(st->thread, NULL);
 	}
 
@@ -71,7 +71,7 @@ static int src_thread(void *arg)
 	if (!sampv)
 		return ENOMEM;
 
-	while (st->run) {
+	while (re_atomic_rlx(&st->run)) {
 		struct auframe af;
 
 		sys_msleep(ms);
@@ -90,7 +90,7 @@ static int src_thread(void *arg)
 		ts += st->ptime;
 
 		if (aubuf_cur_size(st->aubuf) == 0)
-			st->run = false;
+			re_atomic_rlx_set(&st->run, false);
 	}
 
 	mem_deref(sampv);
@@ -105,7 +105,7 @@ static void timeout(void *arg)
 	tmr_start(&st->tmr, st->ptime ? st->ptime : 40, timeout, st);
 
 	/* check if audio buffer is empty */
-	if (!st->run) {
+	if (!re_atomic_rlx(&st->run)) {
 		tmr_cancel(&st->tmr);
 
 		info("aufile: end of file\n");
@@ -254,10 +254,10 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	tmr_start(&st->tmr, ptime, timeout, st);
 
-	st->run = true;
+	re_atomic_rlx_set(&st->run, true);
 	err = thread_create_name(&st->thread, "aufile_src", src_thread, st);
 	if (err) {
-		st->run = false;
+		re_atomic_rlx_set(&st->run, false);
 		goto out;
 	}
 


### PR DESCRIPTION
Since we can not rely on C11 `_Atomic` (`RE_ATOMIC`) keyword only (no C99 and MSVC support). We have to be explicit about atomic usage. This is also needed for C11 too, since _Atomic has implicit sequentially-consistent memory ordering by default. On weak memory ordering architectures like ARM these needs extra memory barriers and can lead to performance drops if relaxed ordering is enough.

We have to be careful about `re_atomic_weak` (relaxed memory) usage, but for `boolean run` this should be fine and is lock and data-race free. Also with explicit definitions its much fewer code than mutex locking.