### PR TITLE
call: do not stop streams on session progress

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2260,18 +2260,15 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 		break;
 	}
 
-	call_stream_stop(call);
-
-	if (media)
-		call_stream_start(call, false);
-
-	if (media)
-		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
-	else
-		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
-
-	if (media)
+	if (media) {
 		update_media(call);
+		call_stream_start(call, false);
+		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
+	}
+	else {
+		call_stream_stop(call);
+		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
+	}
 }
 
 


### PR DESCRIPTION
This should be the working replacement for PR https://github.com/baresip/baresip/pull/1922 which caused these issues (which are almost the same):
- https://github.com/baresip/baresip/issues/1957
- https://github.com/baresip/baresip/issues/1963

If a UAS sends multiple 183 Session Progress with unchanged SDP, then the streams where stopped and restarted always. This PR fixes this behavior.

The problem with the PR https://github.com/baresip/baresip/pull/1922 was that `call_stream_start()` was missing, or more concretely `stream_enable()` which is needed for processing the RX stream. E.g. for the "free-line signal", which is early-audio from callee (or UAS) to the caller.

@robert-scheck, @juha-h  : please could you test this version?