### PR TITLE
audio: revert some TX commits and fix TX poll mode

### DIFF
--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -244,9 +244,7 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	info("aufile: audio ptime=%u sampc=%zu\n", st->ptime, st->sampc);
 
 	/* 1 - inf seconds of audio */
-	err = aubuf_alloc(&st->aubuf,
-			  st->sampc * 2,
-			  0);
+	err = aubuf_alloc(&st->aubuf, 0, 0);
 	if (err)
 		goto out;
 

--- a/modules/multicast/source.c
+++ b/modules/multicast/source.c
@@ -295,11 +295,10 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 		unsigned i;
 
 		for (i = 0; i < 16; i++) {
-			poll_aubuf_tx(src);
-
 			if (aubuf_cur_size(src->aubuf) < src->psize)
 				break;
 
+			poll_aubuf_tx(src);
 		}
 	}
 }
@@ -335,7 +334,9 @@ static void *tx_thread(void *arg)
 		if (ts > now)
 			continue;
 
-		poll_aubuf_tx(src);
+		if (aubuf_cur_size(src->aubuf) >= src->psize)
+			poll_aubuf_tx(src);
+
 		ts += src->ptime;
 	}
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -686,10 +686,10 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 		return;
 
 	for (i=0; i<16; i++) {
-		poll_aubuf_tx(a);
-
 		if (aubuf_cur_size(tx->aubuf) < tx->psize)
 			break;
+
+		poll_aubuf_tx(a);
 	}
 
 	/* Exact timing: send Telephony-Events from here */


### PR DESCRIPTION
This https://github.com/baresip/rem/pull/74 is a replacement for the commits reverted here.
This PR fixes also the TX poll mode if e.g. pulse_async is used, which provides audio frames smaller than `ptime`.

- Revert "audio: always start reading in TX poll mode (#1980)"
- Revert "audio: always start reading in TX thread (#1979)"
- Revert "multicast: always start reading of TX aubuf (#1981)"

With https://github.com/baresip/rem/pull/74 also zero is allowed for the min size of aubuf. This disables the low latency control in aubuf which is needed for module aufile in order to read the whole WAV file into an aubuf before the reading is started.
- aufile: disable aubuf wish sz
