### PR TITLE
call: fix heap-buffer-overflow in prack_handler

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2020,6 +2020,9 @@ static void prack_handler(const struct sip_msg *msg, void *arg)
 {
 	struct call *call = arg;
 
+	if (!msg || !call)
+		return;
+
 	if (msg->req || (msg->scode >= 200 && msg->scode < 300))
 		call->early_confirmed = true;
 


### PR DESCRIPTION
We had some strange selftest CI errors sometimes, looks like these are related to this heap-buffer-overflow:

SUMMARY: AddressSanitizer: heap-buffer-overflow src/call.c:2024:25 in prack_handler

Found by:
`make CC=clang EXTRA_CFLAGS="-fsanitize=address" EXTRA_LFLAGS="-fsanitize=address"`

Related: https://github.com/baresip/baresip/pull/1973#issuecomment-1190151908

CC: @cspiel1 @maximilianfridrich 