### PR TITLE
event: fix wrong place of the err check

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -212,9 +212,10 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 		if (user_data) {
 			err |= odict_entry_add(od, "userdata", ODICT_STRING,
 				user_data);
-			if (err)
-				goto out;
 		}
+
+		if (err)
+			goto out;
 	}
 
 	if (str_isset(prm)) {


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/baresip/baresip/pull/1951