### PR TITLE
call: disable prack_handler temporarily

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2023,8 +2023,10 @@ static void prack_handler(const struct sip_msg *msg, void *arg)
 	if (!msg || !call)
 		return;
 
+#if 0 /* TODO: fix heap-buffer-overflow on hangup */
 	if (msg->req || (msg->scode >= 200 && msg->scode < 300))
 		call->early_confirmed = true;
+#endif
 
 	return;
 }


### PR DESCRIPTION
Since #1996 looks like a serious issue and prack_handler is broken (maybe selftest only), disabling it temporarily should be fine for now I think.