### PR TITLE
cmake: add EXTRA_MODULES option

### DIFF
--- a/cmake/modules.cmake
+++ b/cmake/modules.cmake
@@ -96,3 +96,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   list(APPEND MODULES avcapture)
   list(APPEND MODULES coreaudio)
 endif()
+
+if(DEFINED EXTRA_MODULES)
+  list(APPEND MODULES ${EXTRA_MODULES})
+endif()


### PR DESCRIPTION
With -DEXTRA_MODULES="mod1;mod2" additional modules can be added