### PR TITLE
avformat: check shared for both audio+video

### DIFF
--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -450,8 +450,9 @@ struct shared *avformat_shared_lookup(const char *dev)
 	for (le = sharedl.head; le; le = le->next) {
 
 		struct shared *sh = le->data;
+		bool have_av = sh->au.ctx != NULL && sh->vid.ctx != NULL;
 
-		if (0 == str_casecmp(sh->dev, dev))
+		if (have_av && 0 == str_casecmp(sh->dev, dev))
 			return sh;
 	}
 


### PR DESCRIPTION
avformat has a shared state between audio and video.

the shared state can be a multimedia file that has both audio and video stream.
in this case the state can be shared.

the state is not supposed to be shared across sessions