### PR TITLE
gzrtp: Call event hander when SAS needs to be verified

### DIFF
--- a/modules/gzrtp/gzrtp.cpp
+++ b/modules/gzrtp/gzrtp.cpp
@@ -75,9 +75,6 @@ static int session_alloc(struct menc_sess **sessp, struct sdp_session *sdp,
 {
 	struct menc_sess *st;
 	(void)offerer;
-	(void)eventh;
-	(void)errorh;
-	(void)arg;
 	int err = 0;
 
 	if (!sessp || !sdp)
@@ -91,10 +88,15 @@ static int session_alloc(struct menc_sess **sessp, struct sdp_session *sdp,
 	if (!st->session)
 		err = ENOMEM;
 
-	if (err)
+	if (err) {
 		mem_deref(st);
-	else
+	}
+	else {
+		st->session->eventh = eventh;
+		st->session->errorh = errorh;
+		st->session->arg = arg;
 		*sessp = st;
+	}
 
 	return err;
 }

--- a/modules/gzrtp/session.h
+++ b/modules/gzrtp/session.h
@@ -35,6 +35,10 @@ public:
 	static int cmd_unverify_sas(struct re_printf *pf, void *arg);
 	static int cmd_sas(bool verify, struct re_printf *pf, void *arg);
 
+	menc_event_h *eventh;
+	menc_error_h *errorh;
+	void *arg;
+
 private:
 	static std::vector<Session *> s_sessl;
 

--- a/modules/gzrtp/stream.cpp
+++ b/modules/gzrtp/stream.cpp
@@ -658,10 +658,11 @@ void Stream::srtpSecretsOn(std::string c, std::string s, bool verified)
 				if (re_snprintf(buf, sizeof(buf), "%s,%d",
 						c.c_str(),
 						m_session->id()))
-					(m_session->eventh)(MENC_EVENT_VERIFY_REQUEST,
-							    buf,
-							    NULL,
-							    m_session->arg);
+					(m_session->eventh)
+						(MENC_EVENT_VERIFY_REQUEST,
+						 buf,
+						 NULL,
+						 m_session->arg);
 				else
 					warning("zrtp: failed to print verify "
 						" arguments\n");

--- a/modules/gzrtp/stream.cpp
+++ b/modules/gzrtp/stream.cpp
@@ -639,6 +639,7 @@ void Stream::srtpSecretsOn(std::string c, std::string s, bool verified)
 {
 	m_sas = s;
 	m_ciphers = c;
+	char buf[128] = "";
 
 	if (s.empty()) {
 		info("zrtp: Stream <%s> is encrypted (%s)\n",
@@ -649,10 +650,23 @@ void Stream::srtpSecretsOn(std::string c, std::string s, bool verified)
 		     "SAS is [%s] (%s)\n",
 		     media_name(), c.c_str(), s.c_str(),
 		     (verified)? "verified" : "NOT VERIFIED");
-		if (!verified)
+		if (!verified) {
 			warning("zrtp: SAS is not verified, type "
 			        "'/zrtp_verify %d' to verify\n",
 			        m_session->id());
+			if (m_session->eventh) {
+				if (re_snprintf(buf, sizeof(buf), "%s,%d",
+						c.c_str(),
+						m_session->id()))
+					(m_session->eventh)(MENC_EVENT_VERIFY_REQUEST,
+							    buf,
+							    NULL,
+							    m_session->arg);
+				else
+					warning("zrtp: failed to print verify "
+						" arguments\n");
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
The event should be processed by menu module instead of warning log from gzrtp module