### PR TITLE
ctrl_tcp: change unsafe operations on an mbuf to the safe mbuf interface

### DIFF
--- a/modules/ctrl_tcp/tcp_netstring.c
+++ b/modules/ctrl_tcp/tcp_netstring.c
@@ -70,13 +70,22 @@ static bool netstring_send_handler(int *err, struct mbuf *mb, void *arg)
 	re_snprintf(num_str, sizeof(num_str), "%zu", mbuf_get_left(mb));
 	num_len = strlen(num_str);
 
-	mb->pos = NETSTRING_HEADER_SIZE - (num_len + 1);
-	mbuf_write_mem(mb, (uint8_t*) num_str, num_len);
-	mb->pos = NETSTRING_HEADER_SIZE - (num_len + 1);
-	mb->buf[mb->pos + num_len] = ':';
-	mb->buf[mb->end] = ',';
+	mbuf_set_pos(mb, NETSTRING_HEADER_SIZE - (num_len + 1));
+	*err = mbuf_write_mem(mb, (uint8_t*) num_str, num_len);
+	if (*err)
+		return true;
 
-	mb->end += 1;
+	mbuf_set_pos(mb, NETSTRING_HEADER_SIZE - (num_len + 1) + num_len);
+	*err = mbuf_write_u8(mb, ':');
+	if (*err)
+		return true;
+
+	mbuf_skip_to_end(mb);
+	*err = mbuf_write_u8(mb, ',');
+	if (*err)
+		return true;
+
+	mbuf_set_pos(mb, NETSTRING_HEADER_SIZE - (num_len + 1));
 
 	++netstring->n_tx;
 


### PR DESCRIPTION
It prevents a buffer overflow in case of a message which is exactly the size of the buffer. The end symbol would be out of bound.