### PR TITLE
Generate only one MENC_EVENT_PEER_VERIFIED event when all streams are verified

### DIFF
--- a/modules/gzrtp/session.cpp
+++ b/modules/gzrtp/session.cpp
@@ -132,6 +132,8 @@ bool Session::request_master(Stream *stream)
 
 void Session::on_secure(Stream *stream)
 {
+	char buf[128] = "";
+
 	++m_encrypted;
 
 	if (m_encrypted == m_streams.size() && m_master) {
@@ -140,6 +142,18 @@ void Session::on_secure(Stream *stream)
 		     m_master->get_ciphers(),
 		     m_master->get_sas(),
 		     (m_master->sas_verified())? "verified" : "NOT VERIFIED");
+		if (m_master->sas_verified() && m_master->session()->eventh) {
+			if (re_snprintf(buf, sizeof(buf), "%d",
+					m_master->session()->id()))
+				(m_master->session()->eventh)
+					(MENC_EVENT_PEER_VERIFIED,
+					 buf,
+					 NULL,
+					 m_master->session()->arg);
+			else
+				warning("zrtp: failed to print"
+					" verified argument\n");
+			}
 		return;
 	}
 

--- a/modules/gzrtp/stream.cpp
+++ b/modules/gzrtp/stream.cpp
@@ -668,20 +668,6 @@ void Stream::srtpSecretsOn(std::string c, std::string s, bool verified)
 						" arguments\n");
 			}
 		}
-		else {
-			if (m_session->eventh) {
-				if (re_snprintf(buf, sizeof(buf), "%d",
-						m_session->id()))
-					(m_session->eventh)
-						(MENC_EVENT_PEER_VERIFIED,
-						 buf,
-						 NULL,
-						 m_session->arg);
-				else
-					warning("zrtp: failed to print"
-						" verified argument\n");
-			}
-		}
 	}
 }
 

--- a/modules/gzrtp/stream.h
+++ b/modules/gzrtp/stream.h
@@ -78,6 +78,8 @@ public:
 	bool sas_verified();
 	void verify_sas(bool verify);
 
+	Session *session() { return m_session; }
+
 private:
 	static void zrtp_timer_cb(void *arg);
 	static bool udp_helper_send_cb(int *err, struct sa *src,


### PR DESCRIPTION
Before this every stream (audio, video) of a session generated its own event