### PR TITLE
config,net: add use_getaddrinfo/dns_getaddrinfo option

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -384,9 +384,10 @@ struct config_net {
 	struct {
 		char addr[64];
 		bool fallback;
-	} nsv[NET_MAX_NS];      /**< Configured DNS nameservers     */
-	size_t nsc;             /**< Number of DNS nameservers      */
-	bool use_linklocal;     /**< Use v4/v6 link-local addresses */
+	} nsv[NET_MAX_NS];      /**< Configured DNS nameservers         */
+	size_t nsc;             /**< Number of DNS nameservers          */
+	bool use_linklocal;     /**< Use v4/v6 link-local addresses     */
+	bool use_getaddrinfo;   /**< Use getaddrinfo for A/AAAA records */
 };
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -98,6 +98,7 @@ static struct config core_config = {
 		{ {"",0} },
 		0,
 		true,
+		false,
 	},
 };
 
@@ -452,6 +453,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_apply(conf, "dns_server", dns_server_handler, &cfg->net);
 	(void)conf_apply(conf, "dns_fallback",
 			   dns_fallback_handler, &cfg->net);
+	(void)conf_get_bool(conf, "dns_getaddrinfo",
+			    &cfg->net.use_getaddrinfo);
 	(void)conf_get_str(conf, "net_interface",
 			   cfg->net.ifname, sizeof(cfg->net.ifname));
 
@@ -782,6 +785,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"
 			  "#dns_fallback\t\t8.8.8.8:53\n"
+			  "#dns_getaddrinfo\t\tno\n"
 			  "#net_interface\t\t%H\n"
 			  "\n"
 			  "# Play tones\n"

--- a/src/net.c
+++ b/src/net.c
@@ -413,6 +413,11 @@ int net_alloc(struct network **netp, const struct config_net *cfg)
 		goto out;
 	}
 
+	if (cfg->use_getaddrinfo)
+		dnsc_getaddrinfo(net->dnsc, true);
+	else
+		dnsc_getaddrinfo(net->dnsc, false);
+
 	net_if_apply(add_laddr_filter, net);
 	info("Local network addresses:\n");
 	if (!list_count(&net->laddrs))
@@ -584,8 +589,10 @@ int net_dns_debug(struct re_printf *pf, const struct network *net)
 	if (err)
 		nsn = 0;
 
-	err = re_hprintf(pf, " DNS Servers from %s: (%u)\n",
-			 from_sys ? "System" : "Config", nsn);
+	err = re_hprintf(pf, " DNS Servers from %s%s: (%u)\n",
+			 from_sys ? "System" : "Config",
+			 net->cfg.use_getaddrinfo ? "(+getaddrinfo)" : "",
+			 nsn);
 	for (i=0; i<nsn; i++)
 		err |= re_hprintf(pf, "   %u: %J\n", i, &nsv[i]);
 


### PR DESCRIPTION
`dns_getaddrinfo yes`  is useful for debugging (`/etc/hosts`).