### PR TITLE
Add both Threads and ZLIB to find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,8 @@ include(GNUInstallDirs)
 include(CheckIncludeFile)
 find_package(RE REQUIRED)
 find_package(REM REQUIRED)
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
 
 ##############################################################################
 #
@@ -183,7 +185,7 @@ endif()
 # Main target library
 #
 
-set(LINKLIBS ${REM_LIBRARIES} ${RE_LIBRARIES} Threads::Threads -lz -lm)
+set(LINKLIBS ${REM_LIBRARIES} ${RE_LIBRARIES} Threads::Threads ZLIB::ZLIB -lm)
 if(USE_OPENSSL)
   list(APPEND LINKLIBS OpenSSL::SSL OpenSSL::Crypto)
 endif()


### PR DESCRIPTION
This fixes Threads package links on my system (cross-compiler arm-linux-musleabi):

```
CMake Error at CMakeLists.txt:196 (target_link_libraries):
  Target "baresip" links to:

    Threads::Threads

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

Because currently it uses `Threads::Threads` in `target_link_libraries` but it never found in `find_package`.
The same idea is for ZLIB, because it seems that clear to use the same way