### PR TITLE
refer out of dialog

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -38,6 +38,8 @@
 #    ;stunpass=STUN/TURN/ICE-password
 #    ;stunserver=stun:[user:pass]@host[:port]  # see RFC 3986: Use of the format "user:password" in the userinfo field is deprecated.
 #    ;tcpsrcport=6060
+#    ;uas_user=username
+#    ;uas_pass=password
 #    ;video_codecs=h264,h263,...
 #
 # Examples:

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -138,7 +138,10 @@ enum sipansbeep account_sipansbeep(const struct account *acc);
 void account_set_sipansbeep(struct account *acc, enum sipansbeep beep);
 void account_set_autelev_pt(struct account *acc, uint32_t pt);
 uint32_t account_autelev_pt(struct account *acc);
-
+bool account_uasmethod_deny(const struct account *acc, const struct pl *met);
+bool account_uasmethod_allow(const struct account *acc, const struct pl *met);
+const char* account_uas_user(const struct account *acc);
+const char* account_uas_pass(const struct account *acc);
 
 /*
  * Call

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -790,6 +790,7 @@ enum ua_event {
 	UA_EVENT_AUDIO_ERROR,
 	UA_EVENT_CALL_LOCAL_SDP,      /**< param: offer or answer */
 	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
+	UA_EVENT_REFER,
 	UA_EVENT_MODULE,
 	UA_EVENT_CUSTOM,
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -827,7 +827,7 @@ int  ua_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_options_send(struct ua *ua, const char *uri,
 		     options_resp_h *resph, void *arg);
-int  ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
+int  ua_refer_send(struct ua *ua, const char *uri, const char *referto,
 		    refer_resp_h *resph, void *arg);
 int  ua_debug(struct re_printf *pf, const struct ua *ua);
 int  ua_state_json_api(struct odict *od, const struct ua *ua);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -809,6 +809,7 @@ enum answer_method {
 typedef void (ua_event_h)(struct ua *ua, enum ua_event ev,
 			  struct call *call, const char *prm, void *arg);
 typedef void (options_resp_h)(int err, const struct sip_msg *msg, void *arg);
+typedef void (refer_resp_h)(int err, const struct sip_msg *msg, void *arg);
 
 typedef void (ua_exit_h)(void *arg);
 
@@ -826,6 +827,8 @@ int  ua_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_options_send(struct ua *ua, const char *uri,
 		     options_resp_h *resph, void *arg);
+int  ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
+		    refer_resp_h *resph, void *arg);
 int  ua_debug(struct re_printf *pf, const struct ua *ua);
 int  ua_state_json_api(struct odict *od, const struct ua *ua);
 int  ua_print_calls(struct re_printf *pf, const struct ua *ua);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -519,6 +519,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 	bool incall;
 	enum sdp_dir ardir, vrdir;
 	uint32_t count;
+	struct pl val;
 	int err;
 	(void)arg;
 
@@ -711,6 +712,19 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		menu_stop_play();
 		call_hold(call, false);
 		menu_selcall(call);
+		break;
+
+	case UA_EVENT_REFER:
+		val = pl_null;
+		if (!strncmp(prm, "sip:", 4))
+			pl_set_str(&val, "invite");
+
+		(void)menu_param_decode(prm, "method", &val);
+		if (!pl_strcmp(&val, "invite")) {
+			info("menu: incoming REFER to %s\n", prm);
+			ua_connect(ua, NULL, NULL, prm, VIDMODE_ON);
+		}
+
 		break;
 
 	case UA_EVENT_REGISTER_OK:

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -926,6 +926,20 @@ static void options_resp_handler(int err, const struct sip_msg *msg, void *arg)
 }
 
 
+static void refer_resp_handler(int err, const struct sip_msg *msg, void *arg)
+{
+	(void)arg;
+
+	if (err) {
+		warning("REFER reply error (%m)\n", err);
+		return;
+	}
+
+	info("%r: REFER reply %u %r\n", &msg->to.auri,
+	     msg->scode, &msg->reason);
+}
+
+
 static int options_command(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
@@ -973,6 +987,58 @@ out:
 	mem_deref(uri);
 	if (err) {
 		(void)re_hprintf(pf, "could not send options: %m\n", err);
+	}
+
+	return err;
+}
+
+
+static int cmd_refer(struct re_printf *pf, void *arg)
+{
+	const struct cmd_arg *carg = arg;
+	struct pl word[2] = {PL_INIT, PL_INIT};
+	struct ua *ua = menu_ua_carg(pf, carg, &word[0], &word[1]);
+	char *uri = NULL;
+	struct mbuf *uribuf = NULL;
+	int err = 0;
+
+	err = pl_strdup(&uri, &word[0]);
+	if (err)
+		goto out;
+
+	if (!ua)
+		ua = uag_find_requri(uri);
+
+	if (!ua) {
+		(void)re_hprintf(pf, "could not find UA for %s\n", uri);
+		err = EINVAL;
+		goto out;
+	}
+
+	uribuf = mbuf_alloc(64);
+	if (!uribuf)
+		return ENOMEM;
+
+	err = account_uri_complete(ua_account(ua), uribuf, uri);
+	if (err) {
+		(void)re_hprintf(pf, "invalid URI\n");
+		return EINVAL;
+	}
+
+	mem_deref(uri);
+
+	uribuf->pos = 0;
+	err = mbuf_strdup(uribuf, &uri, uribuf->end);
+	if (err)
+		goto out;
+
+	err = ua_refer_send(ua, uri, &word[1], refer_resp_handler, NULL);
+
+out:
+	mem_deref(uribuf);
+	mem_deref(uri);
+	if (err) {
+		(void)re_hprintf(pf, "could not send REFER (%m)\n", err);
 	}
 
 	return err;
@@ -1426,6 +1492,7 @@ static const struct cmd cmdv[] = {
 {"help",      'h',        0, "Help menu",               print_commands       },
 {"listcalls", 'l',        0, "List active calls",       cmd_print_calls      },
 {"options",   'o',  CMD_PRM, "Options",                 options_command      },
+{"refer",     'R',  CMD_PRM, "Send REFER outside dialog", cmd_refer          },
 {"reginfo",   'r',        0, "Registration info",       ua_print_reg_status  },
 {"setadelay", 0,    CMD_PRM, "Set answer delay for outgoing call",
                                                         cmd_set_adelay       },

--- a/src/account.c
+++ b/src/account.c
@@ -42,6 +42,8 @@ static void destructor(void *arg)
 	mem_deref(acc->auplay_dev);
 	mem_deref(acc->cert);
 	mem_deref(acc->extra);
+	mem_deref(acc->uas_user);
+	mem_deref(acc->uas_pass);
 }
 
 
@@ -420,6 +422,25 @@ static int video_codecs_decode(struct account *acc, const struct pl *prm)
 }
 
 
+static void uasauth_decode(struct account *acc, const struct pl *prm)
+{
+	struct pl val;
+
+	if (!acc || !prm)
+		return;
+
+	if (msg_param_decode(prm, "uas_user", &val))
+		return;
+
+	(void)pl_strdup(&acc->uas_user, &val);
+
+	if (msg_param_decode(prm, "uas_pass", &val))
+		return;
+
+	(void)pl_strdup(&acc->uas_pass, &val);
+}
+
+
 static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 {
 	struct pl auth_user, tmp;
@@ -553,7 +574,8 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	       rel100_decode(acc, &acc->laddr.params);
 	       answermode_decode(acc, &acc->laddr.params);
 	       autoanswer_decode(acc, &acc->laddr.params);
-	       dtmfmode_decode(acc,&acc->laddr.params);
+	       dtmfmode_decode(acc, &acc->laddr.params);
+	       uasauth_decode(acc, &acc->laddr.params);
 	err |= audio_codecs_decode(acc, &acc->laddr.params);
 	err |= video_codecs_decode(acc, &acc->laddr.params);
 	err |= media_decode(acc, &acc->laddr.params);
@@ -1924,4 +1946,22 @@ int account_json_api(struct odict *od, struct odict *odcfg,
 
 	mem_deref(obn);
 	return err;
+}
+
+
+const char* account_uas_user(const struct account *acc)
+{
+	if (!acc)
+		return NULL;
+
+	return acc->uas_user;
+}
+
+
+const char* account_uas_pass(const struct account *acc)
+{
+	if (!acc)
+		return NULL;
+
+	return acc->uas_pass;
 }

--- a/src/core.h
+++ b/src/core.h
@@ -336,6 +336,7 @@ int ua_print_require(struct re_printf *pf, const struct ua *ua);
 struct call *ua_find_call_onhold(const struct ua *ua);
 struct call *ua_find_active_call(struct ua *ua);
 void ua_handle_options(struct ua *ua, const struct sip_msg *msg);
+bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg);
 void sipsess_conn_handler(const struct sip_msg *msg, void *arg);
 bool ua_catchall(struct ua *ua);
 bool ua_reghasladdr(const struct ua *ua, const struct sa *laddr);

--- a/src/core.h
+++ b/src/core.h
@@ -33,6 +33,13 @@ struct stream_param;
  * Account
  */
 
+struct uasauth {
+	struct le he;
+
+	char *met;
+	bool deny;
+};
+
 
 struct account {
 	char *buf;                   /**< Buffer for the SIP address         */
@@ -81,6 +88,8 @@ struct account {
 	char *auplay_dev;
 	uint32_t autelev_pt;         /**< Payload type for telephone-events  */
 	char *extra;                 /**< Extra parameters                   */
+	char *uas_user;              /**< UAS authentication username        */
+	char *uas_pass;              /**< UAS authentication password        */
 };
 
 

--- a/src/event.c
+++ b/src/event.c
@@ -433,6 +433,7 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_AUDIO_ERROR:          return "AUDIO_ERROR";
 	case UA_EVENT_CALL_LOCAL_SDP:       return "CALL_LOCAL_SDP";
 	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
+	case UA_EVENT_REFER:                return "REFER";
 	case UA_EVENT_MODULE:               return "MODULE";
 	case UA_EVENT_CUSTOM:               return "CUSTOM";
 	default: return "?";

--- a/src/ua.c
+++ b/src/ua.c
@@ -960,6 +960,8 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 	if (err)
 		warning("ua: reply to REFER failed (%m)\n", err);
 
+	debug("ua: REFER to %r\n", &hdr->val);
+	ua_event(ua, UA_EVENT_REFER, NULL, "%r", &hdr->val);
 	return err;
 }
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1359,7 +1359,7 @@ int ua_options_send(struct ua *ua, const char *uri,
  *
  * @return 0 if success, otherwise errorcode
  */
-int ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
+int ua_refer_send(struct ua *ua, const char *uri, const char *referto,
 		    refer_resp_h *resph, void *arg)
 {
 	int err = 0;
@@ -1370,7 +1370,7 @@ int ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
 	err = sip_req_send(ua, "REFER", uri, resph, arg,
 			   "Contact: <%s>\r\n"
 			   "%H"
-			   "Refer-To: %r\r\n"
+			   "Refer-To: %s\r\n"
 			   "Refer-Sub: false\r\n"
 			   "Content-Length: 0\r\n"
 			   "\r\n",

--- a/src/ua.c
+++ b/src/ua.c
@@ -1056,6 +1056,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 	if (err)
 		goto out;
 
+	add_extension(ua, "norefersub");
 	list_append(uag_list(), &ua->le, ua);
 	ua_event(ua, UA_EVENT_CREATE, NULL, aor);
 
@@ -1367,10 +1368,14 @@ int ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
 		return EINVAL;
 
 	err = sip_req_send(ua, "REFER", uri, resph, arg,
+			   "Contact: <%s>\r\n"
+			   "%H"
 			   "Refer-To: %r\r\n"
 			   "Refer-Sub: false\r\n"
 			   "Content-Length: 0\r\n"
 			   "\r\n",
+			   account_aor(ua_account(ua)),
+			   ua_print_supported, ua,
 			   referto);
 	if (err) {
 		warning("ua: send options: (%m)\n", err);

--- a/src/ua.c
+++ b/src/ua.c
@@ -950,8 +950,8 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 		pl_bool(&sub, &hdr->val);
 
 	if (sub) {
-		warning("ua: out of dialog REFER with subscription not "
-			"supported\n");
+		debug("ua: out of dialog REFER with subscription not "
+			"supported by %s\n", __func__);
 		return false;
 	}
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -954,6 +954,7 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 			  msg, true, 202, "Accepted",
 			  "%H"
 			  "%s"
+			  "Refer-Sub: false\r\n"
 			  "Content-Length: 0\r\n"
 			  "\r\n",
 			  sip_contact_print, &contact);

--- a/src/ua.c
+++ b/src/ua.c
@@ -1408,7 +1408,7 @@ int ua_options_send(struct ua *ua, const char *uri,
  * @return 0 if success, otherwise errorcode
  */
 int ua_refer_send(struct ua *ua, const char *uri, const char *referto,
-		    refer_resp_h *resph, void *arg)
+		  refer_resp_h *resph, void *arg)
 {
 	int err = 0;
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -937,7 +937,7 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 	struct sip_uas_auth auth;
 	struct account *acc = ua_account(ua);
 	struct uri *uri = account_luri(acc);
-	bool sub = false;
+	bool sub = true;
 	int err;
 
 	debug("ua: incoming REFER message from %r (%J)\n",

--- a/src/ua.c
+++ b/src/ua.c
@@ -933,8 +933,10 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 {
 	struct sip_contact contact;
 	const struct sip_hdr *hdr;
+	char realm[32];
 	struct sip_uas_auth auth;
 	struct account *acc = ua_account(ua);
+	struct uri *uri = account_luri(acc);
 	bool sub = false;
 	int err;
 
@@ -962,7 +964,8 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 		return true;
 	}
 
-	auth.realm = acc->dispname;
+	re_snprintf(realm, sizeof(realm), "%r@%r", &uri->user, &uri->host);
+	auth.realm = realm;
 	err = sip_uas_auth_check(&auth, msg, uas_authorization, ua);
 	switch (err) {
 	case 0:

--- a/src/ua.c
+++ b/src/ua.c
@@ -1348,6 +1348,39 @@ int ua_options_send(struct ua *ua, const char *uri,
 
 
 /**
+ * Send SIP REFER message to a peer
+ *
+ * @param ua       User-Agent object
+ * @param uri      Peer SIP Address
+ * @param referto  Refer-To value
+ * @param resph    Response handler
+ * @param arg      Handler argument
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int ua_refer_send(struct ua *ua, const char *uri, const struct pl *referto,
+		    refer_resp_h *resph, void *arg)
+{
+	int err = 0;
+
+	if (!ua || !str_isset(uri))
+		return EINVAL;
+
+	err = sip_req_send(ua, "REFER", uri, resph, arg,
+			   "Refer-To: %r\r\n"
+			   "Refer-Sub: false\r\n"
+			   "Content-Length: 0\r\n"
+			   "\r\n",
+			   referto);
+	if (err) {
+		warning("ua: send options: (%m)\n", err);
+	}
+
+	return err;
+}
+
+
+/**
  * Get presence status of a User-Agent
  *
  * @param ua User-Agent object

--- a/src/uag.c
+++ b/src/uag.c
@@ -189,18 +189,21 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 
 	(void)arg;
 
-	if (pl_strcmp(&msg->met, "OPTIONS"))
-		return false;
-
 	ua = uag_find_msg(msg);
 	if (!ua) {
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
 		return true;
 	}
 
-	ua_handle_options(ua, msg);
+	if (!pl_strcmp(&msg->met, "OPTIONS")) {
+		ua_handle_options(ua, msg);
+		return true;
+	}
 
-	return true;
+	if (!pl_strcmp(&msg->met, "REFER"))
+		return ua_handle_refer(ua, msg);
+
+	return false;
 }
 
 

--- a/test/main.c
+++ b/test/main.c
@@ -59,6 +59,7 @@ static const struct test tests[] = {
 	TEST(test_stunuri),
 	TEST(test_ua_alloc),
 	TEST(test_ua_options),
+	TEST(test_ua_refer),
 	TEST(test_ua_register),
 	TEST(test_ua_register_auth),
 	TEST(test_ua_register_auth_dns),

--- a/test/test.h
+++ b/test/test.h
@@ -237,6 +237,7 @@ int test_play(void);
 int test_stunuri(void);
 int test_ua_alloc(void);
 int test_ua_options(void);
+int test_ua_refer(void);
 int test_ua_register(void);
 int test_ua_register_auth(void);
 int test_ua_register_auth_dns(void);


### PR DESCRIPTION
- ua: add ua_handle_refer
- ua: add UA_EVENT_REFER
- ua: add Refer-Sub to REFER response
- ua,menu: add API function and command for sending out-of-dialog REFER
- ua: add mandatory headers to REFER
- ua,menu: do URI complete for refer-to URI
- account: add UAS authentication
- ua: add authorization check for incoming out-of-dialog REFER
- ua: user@host for digest realm
- ua: handle REFER set Refer-Sub defaul to true
- ua: SIP request handler should not print warning and return false
- test: add test for out-of-dialog REFER
