### PR TITLE
Update media fixes

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -373,8 +373,7 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 		return EINVAL;
 
 	err  = call_set_media_estdir(call, adir, vdir);
-	if (call_state(call) == CALL_STATE_ESTABLISHED)
-		err |= call_set_media_direction(call, adir, vdir);
+	err |= call_set_media_direction(call, adir, vdir);
 
 	return err;
 }

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -667,7 +667,6 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 		if (!str_cmp(prm, "answer") &&
 				call_state(call) == CALL_STATE_ESTABLISHED)
 			menu_selcall(call);
-		video_update(call_video(call), call_peeruri(call));
 		break;
 
 	case UA_EVENT_CALL_TRANSFER:

--- a/src/call.c
+++ b/src/call.c
@@ -369,13 +369,13 @@ static int update_media(struct call *call)
 	if (call->acc->mnat && call->acc->mnat->updateh && call->mnats)
 		err = call->acc->mnat->updateh(call->mnats);
 
-	if (stream_is_ready(audio_strm(call->audio))) {
+	if (stream_is_ready(audio_strm(call->audio)))
 		err |= update_audio(call);
-	}
 
-	if (stream_is_ready(video_strm(call->video))) {
+	if (stream_is_ready(video_strm(call->video)))
 		err |= video_update(call->video, call->peer_uri);
-	}
+	else
+		video_stop(call->video);
 
 	return err;
 }

--- a/src/call.c
+++ b/src/call.c
@@ -2293,7 +2293,6 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	}
 
 	if (media) {
-		update_media(call);
 		call_stream_start(call, false);
 		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
 	}


### PR DESCRIPTION
Fix for https://github.com/baresip/baresip/issues/2074.
Relates to: https://github.com/baresip/re/pull/515

- call: do not call update_media in progress handler
- call: in update_media() always update video/audio

Tested:
- Test early media cases: switch on/off of video/audio during 1xx

TODO:
- Clarify if @alfredh webrtc use case still work: See commit fb99976031e63bb1a53d9213dd6b185cf43639a0

Edit:
--> Done: the commit  fb99976031e63bb1a53d9213dd6b185cf43639a0 still is present. Only extended by a stop video.
