### PR TITLE
uag: out-of-dialog REFER handler checks to.tag

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -204,7 +204,7 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 		return true;
 	}
 
-	if (!pl_strcmp(&msg->met, "REFER"))
+	if (!pl_strcmp(&msg->met, "REFER") && !pl_isset(&msg->to.tag))
 		return ua_handle_refer(ua, msg);
 
 	return false;


### PR DESCRIPTION
The REFER handler of uag has to check if the to.tag is unset. This means that
the SIP request is outside of a dialog. Otherwise false should be returned and
the processing is passed to the SIP session request handler in re listen.c
which handles call transfers.
