### PR TITLE
account: set 100rel default to no

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -7,7 +7,7 @@
 #    ;transport={udp,tcp,tls}
 #
 #  addr-params:
-#    ;100rel={yes,no,required}
+#    ;100rel={yes,no,required}  # default: no
 #    ;answermode={manual,early,auto,early-audio,early-video}
 #    ;answerdelay=0
 #    ;audio_codecs=opus/48000/2,pcma,...

--- a/src/account.c
+++ b/src/account.c
@@ -240,7 +240,7 @@ static void rel100_decode(struct account *prm, const struct pl *pl)
 {
 	struct pl rmode;
 
-	prm->rel100_mode = REL100_ENABLED;
+	prm->rel100_mode = REL100_DISABLED;
 
 	if (0 == msg_param_decode(pl, "100rel", &rmode)) {
 


### PR DESCRIPTION
100rel will not be put to the Supported header. And if the peer has 100rel in the Required header, baresip answers with a SIP 420 Bad Extension.

Will also update the Wiki.