### PR TITLE
call, event, audio: send DTMF via hidden call

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1316,6 +1316,7 @@ int  audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		       int pt_rx, const char *params);
 const struct aucodec *audio_codec(const struct audio *au, bool tx);
 struct config_audio *audio_config(struct audio *au);
+bool audio_txtelev_empty(const struct audio *au);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -245,6 +245,8 @@ void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
 const char   *call_user_data(const struct call *call);
 int call_set_user_data(struct call *call, const char *user_data);
+void call_set_evstop(struct call *call, bool stop);
+bool call_is_evstop(struct call *call);
 
 /*
  * Custom headers

--- a/src/audio.c
+++ b/src/audio.c
@@ -595,9 +595,13 @@ static void check_telev(struct audio *a, struct autx *tx)
 
 bool audio_txtelev_empty(const struct audio *au)
 {
-	const struct autx *tx = &au->tx;
+	const struct autx *tx;
 	bool empty;
 
+	if (!au)
+		return true;
+
+	tx = &au->tx;
 	mtx_lock(tx->mtx);
 	empty = telev_is_empty(au->telev);
 	mtx_unlock(tx->mtx);

--- a/src/audio.c
+++ b/src/audio.c
@@ -593,6 +593,18 @@ static void check_telev(struct audio *a, struct autx *tx)
 }
 
 
+bool audio_txtelev_empty(const struct audio *au)
+{
+	const struct autx *tx = &au->tx;
+	bool empty;
+
+	mtx_lock(tx->mtx);
+	empty = telev_is_empty(au->telev);
+	mtx_unlock(tx->mtx);
+	return empty;
+}
+
+
 /*
  * Write samples to Audio Player. This version of the write handler is used
  * for the configuration jitter_buffer_type JBUF_FIXED.

--- a/src/call.c
+++ b/src/call.c
@@ -81,6 +81,7 @@ struct call {
 	bool use_video;
 	bool use_rtp;
 	char *user_data;           /**< User data related to the call       */
+	bool evstop;               /**< UA events stopped flag              */
 };
 
 
@@ -3081,4 +3082,22 @@ int call_set_user_data(struct call *call, const char *user_data)
 		return err;
 
 	return 0;
+}
+
+
+void call_set_evstop(struct call *call, bool stop)
+{
+	if (!call)
+		return;
+
+	call->evstop = stop;
+}
+
+
+bool call_is_evstop(struct call *call)
+{
+	if (!call)
+		return false;
+
+	return call->evstop;
 }

--- a/src/event.c
+++ b/src/event.c
@@ -337,6 +337,11 @@ void ua_event(struct ua *ua, enum ua_event ev, struct call *call,
 		struct ua_eh *eh = le->data;
 		le = le->next;
 
+		if (call_is_evstop(call)) {
+			call_set_evstop(call, false);
+			break;
+		}
+
 		eh->h(ua, ev, call, buf, eh->arg);
 	}
 }


### PR DESCRIPTION
UA event handlers are processed in configuration order from h_1 to h_n. Any UA
event handler h_x  may set the calls event stop flag true. Following UA event
handlers are not processed. The next UA event is processed again by the UA
event handlers h_1 to h_x and not by h_{x+1} to h_n.

- call, event: add a UA event stop processing flag
- audio: add audio_txtelev_empty()

Note: If the flag is not set explicitely to `true` by the application, nothing will change for applications that rely on UA events.

Note2: A well known more clean solution would be to add a `return bool` to the UA event handler. But this would mean a break in the API and a lot of changes in different modules.

refers to:
- https://github.com/baresip/re/pull/537
- https://github.com/baresip/baresip-apps/pull/19