### PR TITLE
URI completion

### DIFF
--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -784,7 +784,7 @@ int gtk_mod_connect(struct gtk_mod *mod, const char *uri)
 
 	err = account_uri_complete(ua_account(mod->ua_cur), uribuf, uri);
 	if (err)
-		return EINVAL;
+		goto out;
 
 	uribuf->pos = 0;
 	err = mbuf_strdup(uribuf, &uri_copy, uribuf->end);
@@ -817,7 +817,7 @@ int gtk_mod_connect_attended(struct gtk_mod *mod, const char *uri,
 
 	err = account_uri_complete(ua_account(mod->ua_cur), uribuf, uri);
 	if (err)
-		return EINVAL;
+		goto out;
 
 	uribuf->pos = 0;
 	err = mbuf_strdup(uribuf, &uri_copy, uribuf->end);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -970,7 +970,7 @@ static int options_command(struct re_printf *pf, void *arg)
 	if (err) {
 		(void)re_hprintf(pf, "options_command failed to "
 				 "complete uri\n");
-		return EINVAL;
+		goto out;
 	}
 
 	mem_deref(uri);
@@ -1033,7 +1033,7 @@ static int cmd_refer(struct re_printf *pf, void *arg)
 	err = account_uri_complete(ua_account(ua), uribuf, uri);
 	if (err) {
 		(void)re_hprintf(pf, "invalid URI\n");
-		return EINVAL;
+		goto out;
 	}
 
 	mem_deref(uri);
@@ -1047,7 +1047,7 @@ static int cmd_refer(struct re_printf *pf, void *arg)
 	err = account_uri_complete(ua_account(ua), uribuf, touri);
 	if (err) {
 		(void)re_hprintf(pf, "invalid URI\n");
-		return EINVAL;
+		goto out;
 	}
 
 	mem_deref(touri);

--- a/src/account.c
+++ b/src/account.c
@@ -1774,6 +1774,8 @@ int account_uri_complete(const struct account *acc, struct mbuf *buf,
 
 	if (0 != re_regex(uri, len, "[^@]+@[^]+", NULL, NULL) &&
 		1 != uri_is_ip) {
+		if (acc->regint == 0)
+			return err;
 #if HAVE_INET6
 		if (AF_INET6 == acc->luri.af)
 			err |= mbuf_printf(buf, "@[%r]",

--- a/test/account.c
+++ b/test/account.c
@@ -130,6 +130,9 @@ int test_account_uri_complete(void)
 	err = account_alloc(&acc, "\"A\" <sip:A@proxy.com>");
 	TEST_ERR(err);
 
+	err = account_set_regint(acc, 3600);
+	TEST_ERR(err);
+
 	mb = mbuf_alloc(256);
 	ASSERT_TRUE(mb != NULL);
 

--- a/test/ua.c
+++ b/test/ua.c
@@ -209,6 +209,13 @@ int test_ua_alloc(void)
 	/* verify URI complete function */
 	err = account_uri_complete(ua_account(ua), mb, "bob");
 	ASSERT_EQ(0, err);
+	TEST_STRCMP("sip:bob", 7, mb->buf, mb->end);
+
+	mbuf_reset(mb);
+	err = account_set_regint(ua_account(ua), 3600);
+	ASSERT_EQ(0, err);
+	err = account_uri_complete(ua_account(ua), mb, "bob");
+	ASSERT_EQ(0, err);
 	TEST_STRCMP("sip:bob@test.invalid", 20, mb->buf, mb->end);
 
 	mem_deref(ua);


### PR DESCRIPTION
When providing `account_uri_complete` with an incomplete dialstring and an account, it would always append the local URI of the account to the dialstring - regardless of the account config. However, when using a local account (with `regint=0`), this could cause BareSIP to try calling itself.

Now, an incomplete URI is only completed for accounts with `regint != 0`, otherwise `account_uri_complete` returns -1 because the string would not be a valid SIP URI.

Further, a few potential memory leaks were fixed in modules using this function.