### PR TITLE
ua,reg,serreg: fix serial registration mode

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -839,6 +839,7 @@ int  ua_update_account(struct ua *ua);
 int  ua_register(struct ua *ua);
 int  ua_fallback(struct ua *ua);
 void ua_unregister(struct ua *ua);
+void ua_stop_register(struct ua *ua);
 bool ua_isregistered(const struct ua *ua);
 bool ua_regfailed(const struct ua *ua);
 unsigned ua_destroy(struct ua *ua);

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -129,7 +129,7 @@ static int register_curprio(void)
 
 		if (prio != sreg.prio) {
 			if (!fbregint)
-				ua_unregister(ua);
+				ua_stop_register(ua);
 
 			continue;
 		}

--- a/src/core.h
+++ b/src/core.h
@@ -185,6 +185,7 @@ int  reg_add(struct list *lst, struct ua *ua, int regid);
 int  reg_register(struct reg *reg, const char *reg_uri,
 		    const char *params, uint32_t regint, const char *outbound);
 void reg_unregister(struct reg *reg);
+void reg_stop(struct reg *reg);
 bool reg_isok(const struct reg *reg);
 bool reg_failed(const struct reg *reg);
 int  reg_debug(struct re_printf *pf, const struct reg *reg);

--- a/src/reg.c
+++ b/src/reg.c
@@ -253,6 +253,16 @@ void reg_unregister(struct reg *reg)
 }
 
 
+void reg_stop(struct reg *reg)
+{
+	if (!reg)
+		return;
+
+	reg->sipreg = mem_deref(reg->sipreg);
+	reg->scode = 0;
+}
+
+
 bool reg_isok(const struct reg *reg)
 {
 	if (!reg || !reg->sipreg)

--- a/src/ua.c
+++ b/src/ua.c
@@ -268,6 +268,29 @@ int ua_fallback(struct ua *ua)
 
 
 /**
+ * Stop all register clients of a User-Agent
+ *
+ * @param ua User-Agent
+ */
+void ua_stop_register(struct ua *ua)
+{
+	struct le *le;
+
+	if (!ua)
+		return;
+
+	if (!list_isempty(&ua->regl))
+		ua_event(ua, UA_EVENT_UNREGISTERING, NULL, NULL);
+
+	for (le = ua->regl.head; le; le = le->next) {
+		struct reg *reg = le->data;
+
+		reg_stop(reg);
+	}
+}
+
+
+/**
  * Unregister all Register clients of a User-Agent
  *
  * @param ua User-Agent


### PR DESCRIPTION
The commit a2ab6ab27052f7b4cf06b0bb7b7338768fd691ef changed the behavior of
the serial mode. This adds a function `ua_stop_register()` that has the
previous behavior.
