### PR TITLE
cmake: add APP_MODULES and APP_MODULES_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ endforeach()
 foreach(mod IN LISTS APP_MODULES)
   add_subdirectory(
     ${APP_MODULES_DIR}/${mod}
-    ${CMAKE_CURRENT_BINARY_DIR}/app/${mod}
+    ${CMAKE_CURRENT_BINARY_DIR}/app_modules/${mod}
   )
   set_target_properties(${mod} PROPERTIES PREFIX "")
   list(APPEND MODULES ${mod})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,15 @@ foreach(mod IN LISTS MODULES)
   set_target_properties(${mod} PROPERTIES PREFIX "")
 endforeach()
 
+foreach(mod IN LISTS APP_MODULES)
+  add_subdirectory(
+    ${APP_MODULES_DIR}/${mod}
+    ${CMAKE_CURRENT_BINARY_DIR}/app/${mod}
+  )
+  set_target_properties(${mod} PROPERTIES PREFIX "")
+  list(APPEND MODULES ${mod})
+endforeach()
+
 if(STATIC)
   foreach(mod IN LISTS MODULES)
     set(MOD_EXPORTS
@@ -186,9 +195,11 @@ endif()
 #
 
 set(LINKLIBS ${REM_LIBRARIES} ${RE_LIBRARIES} Threads::Threads)
+
 if(ZLIB_FOUND)
   list(APPEND LINKLIBS ZLIB::ZLIB)
 endif()
+
 if(USE_OPENSSL)
   list(APPEND LINKLIBS OpenSSL::SSL OpenSSL::Crypto)
 endif()


### PR DESCRIPTION
Make it possible to define custom app modules:

`cmake -B build -DAPP_MODULES_DIR=../baresip-apps/modules -DAPP_MODULES="auloop;vidloop"`

Works also with static builds:

`cmake -B build -DSTATIC=ON -DAPP_MODULES_DIR=../baresip-apps/modules -DAPP_MODULES="auloop;vidloop"`