### PR TITLE
ua: do not duplicate request URI parameters

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -1163,6 +1163,43 @@ int ua_update_account(struct ua *ua)
 
 
 /**
+ * Appends params to mbuf if params do not already exist in mbuf.
+ *
+ * @param mb mbuf to append to
+ * @param params params in the form ;uri-param1;uri-param2
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+static int append_params(struct mbuf *mb, struct pl *params)
+{
+	char param[512];
+	char *str = NULL;
+	char *pstr;
+	char *token;
+	int err;
+
+	if (!mb || !params)
+		return EINVAL;
+
+	err = pl_strdup(&str, params);
+	if (err || !str)
+		return err ? err : ENOMEM;
+
+	pstr = str;
+	while((token = strtok(pstr, ";"))) {
+		re_snprintf(param, sizeof(param), ";%s", token);
+		if (re_regex((const char *)mb->buf, mb->end, param))
+			mbuf_write_str(mb, param);
+
+		pstr = NULL;
+	}
+
+	mem_deref(str);
+	return 0;
+}
+
+
+/**
  * Connect an outgoing call to a given SIP uri with audio and video direction
  *
  * @param ua        User-Agent
@@ -1203,7 +1240,7 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 		goto out;
 
 	/* Append any optional URI parameters */
-	err |= mbuf_write_pl(dialbuf, &ua->acc->luri.params);
+	err |= append_params(dialbuf, &ua->acc->luri.params);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
If `ua_connect` or `ua_connect_dir` are called and the request URI contains URI parameters, it could occur that some parameters are duplicated if the account luri contains the exact same parameter.

Now, only non-duplicate URI parameters are appended to the request URI in `ua_connect_dir`.