### PR TITLE
call: allocate streams after peer_uri was set

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1003,9 +1003,6 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 		call->xcall = xcall;
 	}
 
-	if (call->af != AF_UNSPEC)
-		call_streams_alloc(call, got_offer);
-
 	if (cfg->avt.rtp_timeout) {
 		call_enable_rtp_timeout(call, cfg->avt.rtp_timeout*1000);
 	}
@@ -2146,6 +2143,10 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 		if (err)
 			return err;
 	}
+
+	err = call_streams_alloc(call, got_offer);
+	if (err)
+		return err;
 
 	if (got_offer) {
 

--- a/src/call.c
+++ b/src/call.c
@@ -783,7 +783,7 @@ static void call_decode_sip_autoanswer(struct call *call,
 }
 
 
-static int call_streams_alloc(struct call *call, bool got_offer)
+int call_streams_alloc(struct call *call, bool got_offer)
 {
 	struct account *acc = call->acc;
 	struct stream_param strm_prm;

--- a/src/core.h
+++ b/src/core.h
@@ -138,6 +138,7 @@ int  call_af(const struct call *call);
 void call_set_xrtpstat(struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
 const struct sa *call_laddr(const struct call *call);
+int call_streams_alloc(struct call *call, bool got_offer);
 
 /*
 * Custom headers

--- a/src/core.h
+++ b/src/core.h
@@ -138,7 +138,7 @@ int  call_af(const struct call *call);
 void call_set_xrtpstat(struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
 const struct sa *call_laddr(const struct call *call);
-int call_streams_alloc(struct call *call, bool got_offer);
+int call_streams_alloc(struct call *call);
 
 /*
 * Custom headers

--- a/src/ua.c
+++ b/src/ua.c
@@ -884,7 +884,6 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 	struct mbuf *desc = NULL;
 	const struct sip_hdr *hdr;
 	bool accept_sdp = true;
-	bool got_offer;
 	int err;
 
 	debug("ua: incoming OPTIONS message from %r (%J)\n",
@@ -907,8 +906,7 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 			return;
 		}
 
-		got_offer = (mbuf_get_left(msg->mb) > 0);
-		err = call_streams_alloc(call, got_offer);
+		err = call_streams_alloc(call);
 		if (err)
 			return;
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -884,6 +884,7 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 	struct mbuf *desc = NULL;
 	const struct sip_hdr *hdr;
 	bool accept_sdp = true;
+	bool got_offer;
 	int err;
 
 	debug("ua: incoming OPTIONS message from %r (%J)\n",
@@ -905,6 +906,11 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 					 500, "Call Error");
 			return;
 		}
+
+		got_offer = (mbuf_get_left(msg->mb) > 0);
+		err = call_streams_alloc(call, got_offer);
+		if (err)
+			return;
 
 		err = call_sdp_get(call, &desc, true);
 		if (err)


### PR DESCRIPTION
Related to: https://github.com/baresip/baresip/pull/2140

What changes:
- incoming calls: allocate the streams in `call_accept()`
- outgoing calls: allocate them in `sipsess_desc_handler()`, when the SDP offer is generated. Nothing changes for non-IP address calls.

What relates to https://github.com/baresip/baresip/pull/2140:
For now the peer_uri should be available when the streams are allocated. In a
next PR it could be passed to the streams.

Maybe in another PR the streams could be allocated after the SDP negotiation.
Currently this is not possible due to the "common audio or video codecs" check
which depends on the audio/video streams.
