### PR TITLE
sndfile Module - Add Custom snd_name in ~/.baresip/config

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1368,6 +1368,7 @@ struct stream_param {
 	bool use_rtp;       /**< Enable or disable RTP */
 	int af;             /**< Wanted address family */
 	const char *cname;  /**< Canonical name        */
+	const char *duri;
 };
 
 typedef void (stream_mnatconn_h)(struct stream *strm, void *arg);

--- a/src/call.c
+++ b/src/call.c
@@ -795,6 +795,7 @@ int call_streams_alloc(struct call *call)
 	strm_prm.use_rtp = call->use_rtp;
 	strm_prm.af      = call->af;
 	strm_prm.cname   = call->local_uri;
+	strm_prm.duri   = call->peer_uri;
 
 	/* Audio stream */
 	err = audio_alloc(&call->audio, &call->streaml, &strm_prm,

--- a/src/config.c
+++ b/src/config.c
@@ -1177,6 +1177,7 @@ int config_write_template(const char *file, const struct config *cfg)
 
 	(void)re_fprintf(f,
 			 "\n# sndfile\n"
+			 "#snd_name\t\tcuri, duri, OR both"
 			 "#snd_path\t\t/tmp\n");
 
 	(void)re_fprintf(f,

--- a/src/stream.c
+++ b/src/stream.c
@@ -50,36 +50,37 @@ struct receiver {
 /** Defines a generic media stream */
 struct stream {
 #ifndef RELEASE
-	uint32_t magic;          /**< Magic number for debugging            */
+	uint32_t magic;          /**< Magic number for debugging           */
 #endif
-	struct le le;            /**< Linked list element                   */
-	struct config_avt cfg;   /**< Stream configuration                  */
-	struct sdp_media *sdp;   /**< SDP Media line                        */
-	enum sdp_dir ldir;       /**< SDP direction of the stream           */
-	struct rtp_sock *rtp;    /**< RTP Socket                            */
-	struct rtcp_stats rtcp_stats;/**< RTCP statistics                   */
-	const struct mnat *mnat; /**< Media NAT traversal module            */
-	struct mnat_media *mns;  /**< Media NAT traversal state             */
-	const struct menc *menc; /**< Media encryption module               */
-	struct menc_sess *mencs; /**< Media encryption session state        */
-	struct menc_media *mes;  /**< Media Encryption media state          */
-	enum media_type type;    /**< Media type, e.g. audio/video          */
-	char *cname;             /**< RTCP Canonical end-point identifier   */
-	char *mid;               /**< Media stream identification           */
-	bool rtcp_mux;           /**< RTP/RTCP multiplex supported by peer  */
-	bool terminated;         /**< Stream is terminated flag             */
-	bool hold;               /**< Stream is on-hold (local)             */
-	bool mnat_connected;     /**< Media NAT is connected                */
-	bool menc_secure;        /**< Media stream is secure                */
-	stream_pt_h *pth;        /**< Stream payload type handler           */
-	stream_rtp_h *rtph;      /**< Stream RTP handler                    */
-	stream_rtcp_h *rtcph;    /**< Stream RTCP handler                   */
-	void *arg;               /**< Handler argument                      */
-	stream_mnatconn_h *mnatconnh;/**< Medianat connected handler        */
-	stream_rtpestab_h *rtpestabh;/**< RTP established handler           */
-	stream_rtcp_h *sessrtcph;    /**< Stream RTCP handler               */
-	stream_error_h *errorh;  /**< Stream error handler                  */
-	void *sess_arg;          /**< Session handlers argument             */
+	struct le le;            /**< Linked list element                  */
+	struct config_avt cfg;   /**< Stream configuration                 */
+	struct sdp_media *sdp;   /**< SDP Media line                       */
+	enum sdp_dir ldir;       /**< SDP direction of the stream          */
+	struct rtp_sock *rtp;    /**< RTP Socket                           */
+	struct rtcp_stats rtcp_stats;/**< RTCP statistics                  */
+	const struct mnat *mnat; /**< Media NAT traversal module           */
+	struct mnat_media *mns;  /**< Media NAT traversal state            */
+	const struct menc *menc; /**< Media encryption module              */
+	struct menc_sess *mencs; /**< Media encryption session state       */
+	struct menc_media *mes;  /**< Media Encryption media state         */
+	enum media_type type;    /**< Media type, e.g. audio/video         */
+	char *cname;             /**< RTCP Canonical incoming end-point    */
+	char *duri;              /**< RTCP Canonical outgoing end-point    */
+	char *mid;               /**< Media stream identification          */
+	bool rtcp_mux;           /**< RTP/RTCP multiplex supported by peer */
+	bool terminated;         /**< Stream is terminated flag            */
+	bool hold;               /**< Stream is on-hold (local)            */
+	bool mnat_connected;     /**< Media NAT is connected               */
+	bool menc_secure;        /**< Media stream is secure               */
+	stream_pt_h *pth;        /**< Stream payload type handler          */
+	stream_rtp_h *rtph;      /**< Stream RTP handler                   */
+	stream_rtcp_h *rtcph;    /**< Stream RTCP handler                  */
+	void *arg;               /**< Handler argument                     */
+	stream_mnatconn_h *mnatconnh;/**< Medianat connected handler       */
+	stream_rtpestab_h *rtpestabh;/**< RTP established handler          */
+	stream_rtcp_h *sessrtcph;    /**< Stream RTCP handler              */
+	stream_error_h *errorh;  /**< Stream error handler                 */
+	void *sess_arg;          /**< Session handlers argument            */
 
 	struct bundle *bundle;
 	uint8_t extmap_counter;
@@ -145,6 +146,7 @@ static void stream_destructor(void *arg)
 	mem_deref(s->bundle);  /* NOTE: deref before rtp */
 	mem_deref(s->rtp);
 	mem_deref(s->cname);
+	mem_deref(s->duri);
 	mem_deref(s->mid);
 }
 
@@ -709,6 +711,10 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	}
 
 	err = str_dup(&s->cname, prm->cname);
+	if (err)
+		goto out;
+
+	err = str_dup(&s->duri, prm->duri);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
`snd_name` in ~/.baresip/config can be:
* `curi` (local_uri)
* `duri` (peer_uri)
* or `both` 

This is mostly working w/ the exception of one issue:

```
baresip $ make
  CC [M]  build-x86_64/modules/sndfile/sndfile.o
modules/sndfile/sndfile.c: In function ‘openfile’:
modules/sndfile/sndfile.c:98:36: error: invalid use of undefined type ‘struct stream’
   98 |                 snd_name_opt = strm->cname;
      |                                    ^~
modules/sndfile/sndfile.c:101:36: error: invalid use of undefined type ‘struct stream’
  101 |                 snd_name_opt = strm->duri;
      |                                    ^~
modules/sndfile/sndfile.c:106:39: error: invalid use of undefined type ‘struct stream’
  106 |                                   strm->cname,
      |                                       ^~
modules/sndfile/sndfile.c:107:39: error: invalid use of undefined type ‘struct stream’
  107 |                                   strm->duri);
      |                                       ^~
make: *** [mk/mod.mk:49: build-x86_64/modules/sndfile/sndfile.o] Error 1
```

`modules/sndfile/sndfile.c` includes `baresip.h` which references `struct stream`
I'm also passing the `*strm` pointer as `struct stream` to the `openfile` function and instantiating the `*strm` pointer via:
```
struct stream *strm = audio_strm(au);
```
in both the `encode_update` and `decode_update` functions before `(void)au` is called.
what am I missing?