### PR TITLE
sndfile Module - filename includes strm->cname (i.e. call->local_uri)…

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1368,6 +1368,7 @@ struct stream_param {
 	bool use_rtp;       /**< Enable or disable RTP */
 	int af;             /**< Wanted address family */
 	const char *cname;  /**< Canonical name        */
+	const char *peer;   /**< Peer uri/name or identifier  */
 };
 
 typedef void (stream_mnatconn_h)(struct stream *strm, void *arg);
@@ -1405,6 +1406,8 @@ void stream_set_session_handlers(struct stream *strm,
 struct stream *stream_lookup_mid(const struct list *streaml,
 				 const char *mid, size_t len);
 const char *stream_name(const struct stream *strm);
+const char *stream_cname(const struct stream *strm);
+const char *stream_peer(const struct stream *strm);
 int  stream_bundle_init(struct stream *strm, bool offerer);
 int  stream_debug(struct re_printf *pf, const struct stream *s);
 void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms);

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -32,7 +32,7 @@ struct sndfile_dec {
 	SNDFILE *dec;
 };
 
-static char file_path[256] = ".";
+static char file_path[512] = ".";
 
 
 static int timestamp_print(struct re_printf *pf, const struct tm *tm)
@@ -79,18 +79,24 @@ static int get_format(enum aufmt fmt)
 }
 
 
-static SNDFILE *openfile(const struct aufilt_prm *prm, bool enc)
+static SNDFILE *openfile(const struct aufilt_prm *prm,
+			 const struct stream *strm,
+			 bool enc)
 {
-	char filename[128];
+	char filename[256];
 	SF_INFO sfinfo;
 	time_t tnow = time(0);
 	struct tm *tm = localtime(&tnow);
 	SNDFILE *sf;
 	int format;
 
+	const char *cname = stream_cname(strm);
+	const char *peer = stream_peer(strm);
+
 	(void)re_snprintf(filename, sizeof(filename),
-			  "%s/dump-%H-%s.wav",
-				file_path,
+			  "%s/dump-%s=>%s%H-%s.wav",
+			  file_path,
+			  cname, peer,
 			  timestamp_print, tm, enc ? "enc" : "dec");
 
 	format = get_format(prm->fmt);
@@ -123,6 +129,7 @@ static int encode_update(struct aufilt_enc_st **stp, void **ctx,
 			 const struct audio *au)
 {
 	struct sndfile_enc *st;
+	const struct stream *strm = audio_strm(au);
 	int err = 0;
 	(void)ctx;
 	(void)af;
@@ -135,7 +142,7 @@ static int encode_update(struct aufilt_enc_st **stp, void **ctx,
 	if (!st)
 		return EINVAL;
 
-	st->enc = openfile(prm, true);
+	st->enc = openfile(prm, strm, true);
 	if (!st->enc)
 		err = ENOMEM;
 
@@ -153,6 +160,7 @@ static int decode_update(struct aufilt_dec_st **stp, void **ctx,
 			 const struct audio *au)
 {
 	struct sndfile_dec *st;
+	const struct stream *strm = audio_strm(au);
 	int err = 0;
 	(void)ctx;
 	(void)af;
@@ -165,7 +173,7 @@ static int decode_update(struct aufilt_dec_st **stp, void **ctx,
 	if (!st)
 		return EINVAL;
 
-	st->dec = openfile(prm, false);
+	st->dec = openfile(prm, strm, false);
 	if (!st->dec)
 		err = ENOMEM;
 

--- a/modules/sndfile/sndfile.c
+++ b/modules/sndfile/sndfile.c
@@ -94,7 +94,7 @@ static SNDFILE *openfile(const struct aufilt_prm *prm,
 	const char *peer = stream_peer(strm);
 
 	(void)re_snprintf(filename, sizeof(filename),
-			  "%s/dump-%s=>%s%H-%s.wav",
+			  "%s/dump-%s=>%s-%H-%s.wav",
 			  file_path,
 			  cname, peer,
 			  timestamp_print, tm, enc ? "enc" : "dec");

--- a/src/call.c
+++ b/src/call.c
@@ -795,6 +795,7 @@ int call_streams_alloc(struct call *call)
 	strm_prm.use_rtp = call->use_rtp;
 	strm_prm.af      = call->af;
 	strm_prm.cname   = call->local_uri;
+	strm_prm.peer    = call->peer_uri;
 
 	/* Audio stream */
 	err = audio_alloc(&call->audio, &call->streaml, &strm_prm,

--- a/src/stream.c
+++ b/src/stream.c
@@ -64,7 +64,8 @@ struct stream {
 	struct menc_sess *mencs; /**< Media encryption session state        */
 	struct menc_media *mes;  /**< Media Encryption media state          */
 	enum media_type type;    /**< Media type, e.g. audio/video          */
-	char *cname;             /**< RTCP Canonical end-point identifier   */
+	char *cname;             /**< RTCP Canonical incoming end-point     */
+	char *peer;              /**< RTCP Canonical outgoing end-point     */
 	char *mid;               /**< Media stream identification           */
 	bool rtcp_mux;           /**< RTP/RTCP multiplex supported by peer  */
 	bool terminated;         /**< Stream is terminated flag             */
@@ -145,6 +146,7 @@ static void stream_destructor(void *arg)
 	mem_deref(s->bundle);  /* NOTE: deref before rtp */
 	mem_deref(s->rtp);
 	mem_deref(s->cname);
+	mem_deref(s->peer);
 	mem_deref(s->mid);
 }
 
@@ -709,6 +711,10 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	}
 
 	err = str_dup(&s->cname, prm->cname);
+	if (err)
+		goto out;
+
+	err = str_dup(&s->peer, prm->peer);
 	if (err)
 		goto out;
 
@@ -1515,6 +1521,38 @@ const char *stream_name(const struct stream *strm)
 		return NULL;
 
 	return media_name(strm->type);
+}
+
+
+/**
+ * Get the value of the stream->cname (i.e. call->local_uri)
+ *
+ * @param strm Stream object
+ *
+ * @return Name of stream type
+ */
+const char *stream_cname(const struct stream *strm)
+{
+	if (!strm)
+		return NULL;
+
+	return strm->cname;
+}
+
+
+/**
+ * Get the value of the stream->peer (i.e. call->peer_uri)
+ *
+ * @param strm Stream object
+ *
+ * @return Name of stream type
+ */
+const char *stream_peer(const struct stream *strm)
+{
+	if (!strm)
+		return NULL;
+
+	return strm->peer;
 }
 
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -64,8 +64,8 @@ struct stream {
 	struct menc_sess *mencs; /**< Media encryption session state        */
 	struct menc_media *mes;  /**< Media Encryption media state          */
 	enum media_type type;    /**< Media type, e.g. audio/video          */
-	char *cname;             /**< RTCP Canonical incoming end-point     */
-	char *peer;              /**< RTCP Canonical outgoing end-point     */
+	char *cname;             /**< RTCP Canonical end-point identifier   */
+	char *peer;              /**< RTCP Canonical end-point identifier   */
 	char *mid;               /**< Media stream identification           */
 	bool rtcp_mux;           /**< RTP/RTCP multiplex supported by peer  */
 	bool terminated;         /**< Stream is terminated flag             */
@@ -714,9 +714,11 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = str_dup(&s->peer, prm->peer);
-	if (err)
-		goto out;
+	if (prm->peer) {
+		err = str_dup(&s->peer, prm->peer);
+		if (err)
+			goto out;
+	}
 
 	/* Jitter buffer */
 	if (prm->use_rtp && cfg->jbtype != JBUF_OFF && cfg->jbuf_del.max) {
@@ -1525,11 +1527,11 @@ const char *stream_name(const struct stream *strm)
 
 
 /**
- * Get the value of the stream->cname (i.e. call->local_uri)
+ * Get the value of the RTCP Canonical end-point identifier
  *
  * @param strm Stream object
  *
- * @return Name of stream type
+ * @return Canonical end-point identifier
  */
 const char *stream_cname(const struct stream *strm)
 {
@@ -1541,11 +1543,11 @@ const char *stream_cname(const struct stream *strm)
 
 
 /**
- * Get the value of the stream->peer (i.e. call->peer_uri)
+ * Get the value of the RTCP Canonical end-point identifier
  *
  * @param strm Stream object
  *
- * @return Name of stream type
+ * @return Canonical end-point identifier
  */
 const char *stream_peer(const struct stream *strm)
 {


### PR DESCRIPTION
… && strm->peer values (i.e. call->peer_uri) to derive source and destination of recorded call