### PR TITLE
cmake: synchronize behaviour of -DSHARE_PATH="…" with GNU Makefiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,11 @@ include_directories(
 
 link_directories(/usr/local/lib)
 
-add_definitions(
-  -DSHARE_PATH="${SHARE_PATH}"
-)
+if(SHARE_PATH)
+  add_definitions(-DSHARE_PATH="${SHARE_PATH}")
+else()
+  add_definitions(-DSHARE_PATH="${CMAKE_INSTALL_FULL_DATADIR}/baresip")
+endif()
 
 if(DEFAULT_CAFILE)
   add_definitions(-DDEFAULT_CAFILE="${DEFAULT_CAFILE}")


### PR DESCRIPTION
The current implementation leads with `cmake` to `-DSHARE_PATH=\"\"` which leads to an empty string after `audio_path` in a freshly generated `.baresip/config` - which is wrong. According to the GNU Makefiles, it should be by default something like `/usr/share/baresip` (if not overriden).

Patch behaviour (backwards compliant) is to
- use override via `SHARE_PATH`, otherwise
- use distribution default via `SHARE_INSTALL_PREFIX`, otherwise
- use defaults from `cmake --install` during sound files installation