### PR TITLE
baresip.h: bump BARESIP_VERSION

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -13,7 +13,7 @@ extern "C" {
 
 
 /** Defines the Baresip version string */
-#define BARESIP_VERSION "2.7.0"
+#define BARESIP_VERSION "2.8.0"
 
 
 #ifndef NET_MAX_NS


### PR DESCRIPTION
@sreimers I think that this should be done in the release steps. In the list it is in the "After Release" steps.

Should we merge it and set the tag with force to HEAD?