### PR TITLE
release v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to baresip will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.1] - 2022-10-01
+
+* baresip.h: bump BARESIP\_VERSION by @cspiel1 in https://github.com/baresip/baresip/pull/2196
+
 ## [2.8.0] - 2022-10-01
 
 * opensles cmake by @juha-h in https://github.com/baresip/baresip/pull/2108

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(baresip VERSION 2.8.0)
+project(baresip VERSION 2.8.1)
 
 set(PROJECT_SOVERSION 1) # bump if ABI breaks
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 #
 
 PROJECT	  := baresip
-VERSION   := 2.8.0
+VERSION   := 2.8.1
 DESCR     := "Baresip is a modular SIP User-Agent with audio and video support"
 
 # Verbose and silent build modes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+baresip (2.8.1) unstable; urgency=medium
+
+  * version 2.8.1
+
+ -- Christian Spielberger <c.spielberger@commend.com>  Sat, 1 Oct 2022 12:00:00 +0200
+
 baresip (2.8.0) unstable; urgency=medium
 
   * version 2.8.0

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -13,7 +13,7 @@ extern "C" {
 
 
 /** Defines the Baresip version string */
-#define BARESIP_VERSION "2.8.0"
+#define BARESIP_VERSION "2.8.1"
 
 
 #ifndef NET_MAX_NS


### PR DESCRIPTION
### Create/Prepare PRs for new Release (re/rem/baresip)
- [x] Update `CHANGELOG.md`
  - Click `Draft a new release` on Release page
  - Fill a new release tag version and title (like v2.4.0)
  - Press `Auto-generate Release notes` 
  - **Save as draft** (don't publish yet)
  - Copy release notes to `CHANGELOG.md`
- [x] Update `debian/changelog`
- [x] Check version numbers
  - `CMakefile`
  - `Makefile`
  - `include/baresip.h` (baresip only)
- [x] Check ABI compatibility (only `re` and `rem` for now)
  - `CMakefile` (Bump PROJECT_SOVERSION)
  - `Makefile` (Bump ABI_MAJOR)
- [ ] <s>Comment out PRE Release identifier `-dev`</s>
  - <s>`CMakefile` </s>
  - <s>`Makefile` </s>
- [ ] All tests green? [re/rem/retest/baresip]

### Release
- [ ] Merge PRs in this order
  - libre
  - librem
  - retest (needs only a version tag - no PR)
  - baresip
- [ ] Publish draft Releases (follow the same order)
  - Maybe `Auto-generate Release notes` is needed to update (delete last notes first)

### After Release
- [ ] Merge main branches to stable
  - re - https://github.com/baresip/re/compare/stable...main?expand=1
  - rem - https://github.com/baresip/rem/compare/stable...main?expand=1
  - retest - https://github.com/baresip/retest/compare/stable...main?expand=1
  - baresip - https://github.com/baresip/baresip/compare/stable...main?expand=1
- [ ] Bump main branch versions with PRE Release identifier `-dev`
  - `CMakefile`
  - `Makefile`
  - `include/baresip.h` (baresip only)