### PR TITLE
Avoid 'designated initializers are a C++20 extension' warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ else()
     -Wstrict-prototypes
     -Wuninitialized
     -Wvla
+    -Wno-c++20-designator
   )
 endif()
 


### PR DESCRIPTION
Avoid  warnings like
```
In file included from /usr/src/libbaresip-android/rem/include/rem_audio.h:11:
/usr/src/libbaresip-android/rem/include/rem_aubuf.h:31:3: warning: designated initializers are a C++20 extension [-Wc++20-designator]
                .fmt = AUFMT_RAW,
                ^
```
produced by `/opt/Android/ndk/25.1.8937393/toolchains/llvm/prebuilt/linux-x86_64/bin/clang`.