### PR TITLE
Avoid gzrtp module `'memcpy' will always overflow` warnings

### DIFF
--- a/modules/gzrtp/CMakeLists.txt
+++ b/modules/gzrtp/CMakeLists.txt
@@ -18,4 +18,5 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     -Wno-aggregate-return
     -Wno-pedantic
     -Wno-missing-field-initializers
+    -Wno-fortify-source
 )


### PR DESCRIPTION
Avoid these kind of warnings when compiling gzrtp module:
```
In file included from /usr/src/libbaresip-android/ZRTPCPP/zrtp/libzrtpcpp/ZRtp.h/usr/src/libbaresip-android/ZRTPCPP/zrtp/libzrtpcpp/ZrtpPacketCommit.h::30137:
:42:/usr/src/libbaresip-android/ZRTPCPP/zrtp/libzrtpcpp/ZrtpPacketCommit.h :137:42: warning: 'memcpy' will always overflow; destination buffer has size 0, but size argument is 8 [-Wfortify-source]warning: 
'memcpy' will always overflow; destination buffer has size 0, but size argument is 8 [-Wfortify-source]
    void setHMACMulti(uint8_t* hash)   { memcpy(commitHeader->hmac-4*ZRTP_WORD_SIZE, hash, sizeof(commitHeader->hmac)); };
    void setHMACMulti(uint8_t* hash)   { memcpy(commitHeader->hmac-4*ZRTP_WORD_SIZE, hash, sizeof(commitHeader->hmac)); };                                         ^

                                         ^
```
According to upstream, the code works despite of the warnings.