### PR TITLE
call, menu: support display name for outgoing calls

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -726,7 +726,7 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 
 	case UA_EVENT_REFER:
 		val = pl_null;
-		if (!strncmp(prm, "sip:", 4))
+		if (!re_regex(prm, strlen(prm), "sip:"))
 			pl_set_str(&val, "invite");
 
 		(void)menu_param_decode(prm, "method", &val);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -606,9 +606,9 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			"Audio & video must not be"
 			" inactive at the same time\n";
 
-	/* with display name */
+	/* full form with display name */
 	err = re_regex(carg->prm, str_len(carg->prm),
-		"[^ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]*"
+		"[~ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]*"
 		"audio=[^ \t\r\n]*[ \t\r\n]*video=[^ \t\r\n]*",
 		&dname, NULL, &pluri, NULL, &argdir[0], NULL, &argdir[1]);
 	if (err) {
@@ -618,9 +618,17 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			       &pluri, &argdir[0], &argdir[1]);
 	}
 
-	if (err)
+	/* short form with display name */
+	struct pl db = PL_INIT;
+	if (err) {
 		err = re_regex(carg->prm, str_len(carg->prm),
-			"[^ ]* [^ ]*",&pluri, &argdir[0]);
+			       "[~ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]+"
+			       "[^ \t\r\n]*",
+			       &dname, NULL, &pluri, &db, &argdir[0]);
+	} else {
+		err = re_regex(carg->prm, str_len(carg->prm),
+			       "[^ ]* [^ ]*",&pluri, &argdir[0]);
+	}
 
 	if (err || !re_regex(argdir[0].p, argdir[0].l, "=")) {
 		(void)re_hprintf(pf, "%s", usage);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -590,6 +590,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 	struct menu *menu = menu_get();
 	enum sdp_dir adir, vdir;
 	struct pl argdir[2] = {PL_INIT, PL_INIT};
+	struct pl dname = PL_INIT;
 	struct pl pluri;
 	struct call *call;
 	char *uri = NULL;
@@ -605,9 +606,18 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			"Audio & video must not be"
 			" inactive at the same time\n";
 
+	/* with display name */
 	err = re_regex(carg->prm, str_len(carg->prm),
-		"[^ ]* audio=[^ ]* video=[^ ]*",
-		&pluri, &argdir[0], &argdir[1]);
+		"[^ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]*"
+		"audio=[^ \t\r\n]*[ \t\r\n]*video=[^ \t\r\n]*",
+		&dname, NULL, &pluri, NULL, &argdir[0], NULL, &argdir[1]);
+	if (err) {
+		dname = pl_null;
+		err = re_regex(carg->prm, str_len(carg->prm),
+			       "[~ ]+ audio=[^ ]* video=[^ ]*",
+			       &pluri, &argdir[0], &argdir[1]);
+	}
+
 	if (err)
 		err = re_regex(carg->prm, str_len(carg->prm),
 			"[^ ]* [^ ]*",&pluri, &argdir[0]);
@@ -647,6 +657,11 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 		goto out;
 	}
 
+	if (pl_isset(&dname)) {
+		mbuf_write_pl(uribuf, &dname);
+		mbuf_write_str(uribuf, " <");
+	}
+
 	err = account_uri_complete(ua_account(ua), uribuf, uri);
 	if (err) {
 		(void)re_hprintf(pf, "ua_connect failed to complete uri\n");
@@ -654,6 +669,9 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 	}
 
 	mem_deref(uri);
+
+	if (pl_isset(&dname))
+		mbuf_write_u8(uribuf, '>');
 
 	uribuf->pos = 0;
 	err = mbuf_strdup(uribuf, &uri, uribuf->end);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -614,19 +614,19 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 	if (err) {
 		dname = pl_null;
 		err = re_regex(carg->prm, str_len(carg->prm),
-			       "[~ ]+ audio=[^ ]* video=[^ ]*",
+			       "[^ ]+ audio=[^ ]* video=[^ ]*",
 			       &pluri, &argdir[0], &argdir[1]);
 	}
 
 	/* short form with display name */
-	struct pl db = PL_INIT;
 	if (err) {
 		err = re_regex(carg->prm, str_len(carg->prm),
 			       "[~ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]+"
 			       "[^ \t\r\n]*",
-			       &dname, NULL, &pluri, &db, &argdir[0]);
+			       &dname, NULL, &pluri, NULL, &argdir[0]);
 	}
-	else {
+
+	if (err) {
 		err = re_regex(carg->prm, str_len(carg->prm),
 			       "[^ ]* [^ ]*",&pluri, &argdir[0]);
 	}

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -625,7 +625,8 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 			       "[~ \t\r\n<]*[ \t\r\n]*<[^>]+>[ \t\r\n]+"
 			       "[^ \t\r\n]*",
 			       &dname, NULL, &pluri, &db, &argdir[0]);
-	} else {
+	}
+	else {
 		err = re_regex(carg->prm, str_len(carg->prm),
 			       "[^ ]* [^ ]*",&pluri, &argdir[0]);
 	}

--- a/src/call.c
+++ b/src/call.c
@@ -1119,6 +1119,9 @@ int call_connect(struct call *call, const struct pl *paddr)
 			err = pl_strdup(&call->peer_uri, &addr.auri);
 		}
 
+		if (pl_isset(&addr.dname))
+			pl_strdup(&call->peer_name, &addr.dname);
+
 		uri_header_get(&addr.uri.headers, &rname, &rval);
 		if (pl_isset(&rval))
 			err = re_sdprintf(&call->replaces, "%r",&rval);


### PR DESCRIPTION
This enables parsing the display name out of the dial URI and report it via
UA events to the application.
