### PR TITLE
cmake: link CMAKE_CURRENT_BINARY_DIR modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,11 +315,12 @@ add_subdirectory(test)
 
 if(NOT STATIC AND UNIX)
   foreach(mod IN LISTS MODULES)
+    set(mod_lib ${mod}${CMAKE_SHARED_LIBRARY_SUFFIX})
     add_custom_command(
       TARGET baresip_exe POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E create_symlink
-        ${CMAKE_BINARY_DIR}/modules/${mod}/${mod}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        ${CMAKE_BINARY_DIR}/${mod}${CMAKE_SHARED_LIBRARY_SUFFIX}
+        ${CMAKE_CURRENT_BINARY_DIR}/modules/${mod}/${mod_lib}
+        ${CMAKE_CURRENT_BINARY_DIR}/${mod}${CMAKE_SHARED_LIBRARY_SUFFIX}
     )
   endforeach()
 endif()


### PR DESCRIPTION
Fixes subdirectory symlinks.