### PR TITLE
call: hangup call on transp reset if necessary

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2554,11 +2554,6 @@ int call_reset_transp(struct call *call, const struct sa *laddr)
 	if (!call)
 		return EINVAL;
 
-	if (!call_target_refresh_allowed(call)) {
-		call_hangup(call, 0, "Transport of User Agent changed");
-		return 0;
-	}
-
 	sdp_session_set_laddr(call->sdp, laddr);
 
 	return call_modify(call);

--- a/src/call.c
+++ b/src/call.c
@@ -2554,6 +2554,11 @@ int call_reset_transp(struct call *call, const struct sa *laddr)
 	if (!call)
 		return EINVAL;
 
+	if (!call_target_refresh_allowed(call)) {
+		call_hangup(call, 0, "Transport of User Agent changed");
+		return 0;
+	}
+
 	sdp_session_set_laddr(call->sdp, laddr);
 
 	return call_modify(call);

--- a/src/uag.c
+++ b/src/uag.c
@@ -731,8 +731,17 @@ int uag_reset_transp(bool reg, bool reinvite)
 			if (net_dst_source_addr_get(raddr, &laddr))
 				continue;
 
-			if (sa_isset(&laddr, SA_ADDR))
+			if (sa_isset(&laddr, SA_ADDR)) {
+				if (!call_target_refresh_allowed(call)) {
+					call_hangup(call, 0, "Transport of "
+						    "User Agent changed");
+					ua_event(ua, UA_EVENT_CALL_CLOSED,
+						 call, "Transport of "
+						 "User Agent changed");
+					continue;
+				}
 				err = call_reset_transp(call, &laddr);
+			}
 		}
 	}
 


### PR DESCRIPTION
If the transport is reset (e.g. an IP address change) and a call is in the early media state, session modifications might not be possible. In this case, the peer will never receive our transport update (e.g our new IP) and we will no longer be able to communicate with the peer. In such cases - when target refreshes are not possible - hangup the call.