### PR TITLE
Avoid snapshot compiler warnings

### DIFF
--- a/modules/selfview/CMakeLists.txt
+++ b/modules/selfview/CMakeLists.txt
@@ -7,4 +7,3 @@ if(STATIC)
 else()
     add_library(${PROJECT_NAME} MODULE ${SRCS})
 endif()
-

--- a/modules/snapshot/CMakeLists.txt
+++ b/modules/snapshot/CMakeLists.txt
@@ -8,5 +8,9 @@ else()
     add_library(${PROJECT_NAME} MODULE ${SRCS})
 endif()
 
+target_compile_options(${PROJECT_NAME} PRIVATE
+    -Wno-clobbered
+)
+
 target_include_directories(${PROJECT_NAME} PRIVATE ${PNG_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PNG_LIBRARIES})

--- a/modules/snapshot/CMakeLists.txt
+++ b/modules/snapshot/CMakeLists.txt
@@ -8,9 +8,11 @@ else()
     add_library(${PROJECT_NAME} MODULE ${SRCS})
 endif()
 
-target_compile_options(${PROJECT_NAME} PRIVATE
-    -Wno-clobbered
-)
+if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+    target_compile_options(${PROJECT_NAME} PRIVATE
+        -Wno-clobbered
+    )
+endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${PNG_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PNG_LIBRARIES})


### PR DESCRIPTION
Avoid these kind of snapshot compiler warnings during cmake build on Debian 11:
```
/usr/src/orig/baresip/modules/snapshot/png_vf.c: In function ‘png_save_vidframe’:
/usr/src/orig/baresip/modules/snapshot/png_vf.c:23:13: warning: variable ‘png_row_pointers’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
   23 |  png_byte **png_row_pointers = NULL;
      |             ^~~~~~~~~~~~~~~~
/usr/src/orig/baresip/modules/snapshot/png_vf.c:29:8: warning: variable ‘fp’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
   29 |  FILE *fp = NULL;
      |        ^~
/usr/src/orig/baresip/modules/snapshot/png_vf.c:35:6: warning: variable ‘err’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
   35 |  int err = 0;
      |      ^~~
/usr/src/orig/baresip/modules/snapshot/png_vf.c:21:46: warning: argument ‘vf’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
   21 | int png_save_vidframe(const struct vidframe *vf, const char *path)
      |                       ~~~~~~~~~~~~~~~~~~~~~~~^~
```