### PR TITLE
menu fix display name

### DIFF
--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -627,6 +627,7 @@ static int cmd_dialdir(struct re_printf *pf, void *arg)
 	}
 
 	if (err) {
+		dname = pl_null;
 		err = re_regex(carg->prm, str_len(carg->prm),
 			       "[^ ]* [^ ]*",&pluri, &argdir[0]);
 	}


### PR DESCRIPTION
- ua: use mbuf functions for ua_connect_dir
- menu: fix display name for command dialdir
