### PR TITLE
config: fix template for avcodec_xxx

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1163,10 +1163,10 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#avcodec_h264dec\th264\n"
 			"#avcodec_h265enc\tlibx265\n"
 			"#avcodec_h265dec\thevc\n"
-			"#avcodec_hwaccel\t%s\n",
-			default_avcodec_hwaccel(),
-			"#avcodec_profile_level_id 42002a\n",
-			"#avcodec_keyint\t\t10\n"
+			"#avcodec_hwaccel\t%s\n"
+			"#avcodec_profile_level_id 42002a\n"
+			"#avcodec_keyint\t\t10\n",
+			default_avcodec_hwaccel()
 			);
 
 	(void)re_fprintf(f,


### PR DESCRIPTION
Fixes a bug in config template generation. The added string must be part of the first string.

After fix:

```
# avcodec
#avcodec_h264enc        libx264
#avcodec_h264dec        h264
#avcodec_h265enc        libx265
#avcodec_h265dec        hevc
#avcodec_hwaccel        vaapi
#avcodec_profile_level_id 42002a
#avcodec_keyint         10
```
