### PR TITLE
cmake: use CMAKE_SHARED_MODULE_SUFFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ add_subdirectory(test)
 
 if(NOT STATIC AND UNIX)
   foreach(mod IN LISTS MODULES)
-    set(mod_lib ${mod}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(mod_lib ${mod}${CMAKE_SHARED_MODULE_SUFFIX})
     add_custom_command(
       TARGET baresip_exe POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E create_symlink
@@ -327,7 +327,7 @@ if(NOT STATIC AND UNIX)
     )
   endforeach()
   foreach(mod IN LISTS APP_MODULES)
-    set(mod_lib ${mod}${CMAKE_SHARED_LIBRARY_SUFFIX})
+    set(mod_lib ${mod}${CMAKE_SHARED_MODULE_SUFFIX})
     add_custom_command(
       TARGET baresip_exe POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E create_symlink


### PR DESCRIPTION
Fixes #2289 