### PR TITLE
ua: use sdp connection data instead origin

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -622,7 +622,7 @@ static int sdp_connection(struct mbuf *mb, int *af, struct sa *sa)
 
 	*af = AF_UNSPEC;
 	err = re_regex((char *)mbuf_buf(mb), mbuf_get_left(mb),
-		       "IN IP[46]+ [^ \r\n]+", &pl1, &pl2);
+		       "c=IN IP[46]1 [^ \r\n]+", &pl1, &pl2);
 	if (err)
 		return EINVAL;
 
@@ -817,7 +817,7 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 
 	sa_init(&dst, AF_UNSPEC);
 	if (msg && !sdp_connection(msg->mb, &af, &dst)) {
-		info("ua: using origin address %j of SDP offer\n", &dst);
+		info("ua: using connection-address %j of SDP offer\n", &dst);
 		sa_cpy(&ua->dst, &dst);
 	}
 	else if (sa_isset(&ua->dst, SA_ADDR)) {

--- a/src/ua.c
+++ b/src/ua.c
@@ -643,12 +643,13 @@ static int sdp_connection(struct mbuf *mb, int *af, struct sa *sa)
 				"m=video [0-9]+ ", &pl1);
 
 	if (err)
-		return EINVAL;
+		goto out;
 
 	err = sa_set_str(sa, addr, pl_u32(&pl1));
 	if (sa_af(sa) == AF_INET6 && sa_is_linklocal(sa))
 		err |= net_set_dst_scopeid(net, sa);
 
+out:
 	mem_deref(addr);
 	return err;
 }


### PR DESCRIPTION
WebRTC based clients use always `IP4 127.0.0.1` or `IP4 0.0.0.0` as origin `<addrtype> <unicast-address>` for privacy reasons.

https://www.rfc-editor.org/rfc/rfc4566.html#section-5.2

```
 For privacy reasons, it is sometimes desirable to obfuscate the
   username and IP address of the session originator.  If this is a
   concern, an arbitrary <username> and private <unicast-address> MAY be
   chosen to populate the "o=" field, provided that these are selected
   in a manner that does not affect the global uniqueness of the field.
```