### PR TITLE
avformat: fix hwaccel vaapi

### DIFF
--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -163,8 +163,6 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 		if (!frame2)
 			goto out;
 
-		/* Many hw decoders are happy about YUV420P */
-		frame2->format = AV_PIX_FMT_YUV420P;
 		ret = av_hwframe_transfer_data(frame2, frame, 0);
 		if (ret < 0) {
 			av_frame_free(&frame2);


### PR DESCRIPTION
When using VP8 decoder with VAAPI hwaccel, the function call hwtransfer_data crashes. The pixel format should be set by this function. In this case the pixel format is NV12.

```
error: XDG_RUNTIME_DIR not set in the environment.
error: can't connect to X server!
libva info: VA-API version 1.10.0
libva info: Trying to open /usr/lib/x86_64-linux-gnu/dri/iHD_drv_video.so
libva info: Found init function __vaDriverInit_1_10
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.10 (libva 2.10.0)
vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 21.1.1 ()
vainfo: Supported profile and entrypoints
      VAProfileMPEG2Simple            :	VAEntrypointVLD
      VAProfileMPEG2Main              :	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointVLD
      VAProfileH264Main               :	VAEntrypointEncSliceLP
      VAProfileH264High               :	VAEntrypointVLD
      VAProfileH264High               :	VAEntrypointEncSliceLP
      VAProfileJPEGBaseline           :	VAEntrypointVLD
      VAProfileJPEGBaseline           :	VAEntrypointEncPicture
      VAProfileH264ConstrainedBaseline:	VAEntrypointVLD
      VAProfileH264ConstrainedBaseline:	VAEntrypointEncSliceLP
      VAProfileVP8Version0_3          :	VAEntrypointVLD
      VAProfileHEVCMain               :	VAEntrypointVLD
      VAProfileHEVCMain10             :	VAEntrypointVLD
      VAProfileVP9Profile0            :	VAEntrypointVLD
      VAProfileVP9Profile2            :	VAEntrypointVLD
```
