### PR TITLE
webrtc: fix browser offer handling

### DIFF
--- a/webrtc/src/demo.h
+++ b/webrtc/src/demo.h
@@ -17,9 +17,10 @@ struct session {
 	char id[4];
 };
 
-int session_new(struct list *sessl, struct session **sessp,
-		const struct rtc_configuration *pc_config,
-		const struct mnat *mnat, const struct menc *menc);
+int session_new(struct list *sessl, struct session **sessp);
+int session_start(struct session *sess,
+		  const struct rtc_configuration *pc_config,
+		  const struct mnat *mnat, const struct menc *menc);
 struct session *session_lookup(const struct list *sessl,
 			       const struct http_msg *msg);
 int  session_handle_ice_candidate(struct session *sess,

--- a/webrtc/www/js/main.js
+++ b/webrtc/www/js/main.js
@@ -290,7 +290,7 @@ function send_put_sdp(descr)
 
 	xhr.onreadystatechange = function() {
 		if (this.readyState === XMLHttpRequest.DONE &&
-		    this.status === 200) {
+		    (this.status === 200 || this.status === 201)) {
 
 			console.log("post sdp: (%d %s)", this.status, this.statusText);
 


### PR DESCRIPTION
Tested with:
- Firefox 106.0.5 (64-bit)
- Chromium 107.0.5304.110

```diff
diff --git a/webrtc/src/demo.c b/webrtc/src/demo.c
index 7f48f909..1cd96261 100644
--- a/webrtc/src/demo.c
+++ b/webrtc/src/demo.c
@@ -27,7 +27,7 @@ static struct demo {
 
 
 static struct rtc_configuration pc_config = {
-       .offerer = true
+       .offerer = false
 };
 
diff --git a/webrtc/www/js/main.js b/webrtc/www/js/main.js
index c1f42b6f..b98abb91 100644
--- a/webrtc/www/js/main.js
+++ b/webrtc/www/js/main.js
@@ -19,7 +19,7 @@ disconnectButton.disabled = true;
 let pc;           /* PeerConnection */
 let localStream;  /* MediaStream */
 let session_id;   /* String (Opaque, generated by Server) */
-let b_offerer = false;  /* false: Send Offer, true: Send Answer */
+let b_offerer = true;  /* false: Send Offer, true: Send Answer */
```

