### PR TITLE
TLS server support SNI based certificate selection

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -1066,6 +1066,7 @@ static const char *autoans_header_name(enum answer_method met)
 int ua_alloc(struct ua **uap, const char *aor)
 {
 	struct ua *ua;
+	struct uri *luri;
 	char *buf = NULL;
 	int err;
 
@@ -1126,6 +1127,15 @@ int ua_alloc(struct ua **uap, const char *aor)
 			return err;
 		}
 
+		luri = account_luri(ua->acc);
+		err = tls_add_certf(uag_tls(), ua->acc->cert,
+				    luri ? &luri->host : NULL);
+		if (err) {
+			warning("uag: SIP/TLS add server "
+				"certificate %s failed: %m\n",
+				ua->acc->cert, err);
+			return err;
+		}
 	}
 
 	err = create_register_clients(ua);

--- a/src/uag.c
+++ b/src/uag.c
@@ -273,18 +273,29 @@ static bool uri_host_local(const struct uri *uri)
 
 
 #ifdef USE_TLS
-static int add_transp_clientcert(void)
+static int add_account_certs(void)
 {
 	struct le *le;
 	int err = 0;
 
 	for (le = list_head(&uag.ual); le; le = le->next) {
 		struct account *acc = ua_account(le->data);
+		struct uri *luri;
 		if (acc->cert) {
 			err = sip_transp_add_ccert(uag.sip,
 					&acc->laddr.uri, acc->cert);
 			if (err) {
 				warning("uag: SIP/TLS add client "
+					"certificate %s failed: %m\n",
+					acc->cert, err);
+				return err;
+			}
+
+			luri = account_luri(acc);
+			err = tls_add_certf(uag.tls, acc->cert,
+					    luri ? &luri->host : NULL);
+			if (err) {
+				warning("uag: SIP/TLS add server "
 					"certificate %s failed: %m\n",
 					acc->cert, err);
 				return err;
@@ -392,7 +403,7 @@ static int uag_transp_add(const struct sa *laddr)
 			return err;
 		}
 
-		err = add_transp_clientcert();
+		err = add_account_certs();
 		if (err)
 			return err;
 	}


### PR DESCRIPTION
For incoming SIP requests a certificate is selected by SNI in the TLS client hello.

Multiple certificates can be configured by means of the account parameter `;cert=`.

relates to: https://github.com/baresip/re/pull/596