### PR TITLE
Add OPTIONS handling for webrtc demo

### DIFF
--- a/webrtc/src/demo.c
+++ b/webrtc/src/demo.c
@@ -248,6 +248,13 @@ static void http_req_handler(struct http_conn *conn,
 			return;
 		}
 	}
+    else if (0 == pl_strcasecmp(&msg->met, "OPTIONS")) {
+        http_reply(conn, 204, "OK",
+                   "Content-Length: 0\r\n"
+                   "Access-Control-Allow-Origin: *\r\n"
+                   "Access-Control-Allow-Headers: *\r\n"
+                   "\r\n");
+    }
 	else {
 		warning("demo: not found: %r %r\n", &msg->met, &msg->path);
 		http_ereply(conn, 404, "Not Found");

--- a/webrtc/src/demo.c
+++ b/webrtc/src/demo.c
@@ -248,13 +248,13 @@ static void http_req_handler(struct http_conn *conn,
 			return;
 		}
 	}
-    else if (0 == pl_strcasecmp(&msg->met, "OPTIONS")) {
-        http_reply(conn, 204, "OK",
-                   "Content-Length: 0\r\n"
-                   "Access-Control-Allow-Origin: *\r\n"
-                   "Access-Control-Allow-Headers: *\r\n"
-                   "\r\n");
-    }
+	else if (0 == pl_strcasecmp(&msg->met, "OPTIONS")) {
+		http_reply(conn, 204, "OK",
+				   "Content-Length: 0\r\n"
+				   "Access-Control-Allow-Origin: *\r\n"
+				   "Access-Control-Allow-Headers: *\r\n"
+				   "\r\n");
+	}
 	else {
 		warning("demo: not found: %r %r\n", &msg->met, &msg->path);
 		http_ereply(conn, 404, "Not Found");


### PR DESCRIPTION
The WebRTC demo currently does not handle OPTIONS http requests. This works fine as long as you only use the demo's given frontend on port 9000.

To see how well Flutter WebRTC works with our backend using BareSIP, I made a Flutter program that connects to the BareSIP WebRTC demo backend.

Since this is CORS, and some browsers send "preflight requests", an OPTIONS request before each of certain types of requests. I had to add this commit to enable PUT/PATCH requests.

Network traffic in firefox looks like this when communicating with the demo:
![grafik](https://user-images.githubusercontent.com/12276205/202449055-e087548f-409b-4654-a62b-146907dd4ecb.png)

Tested on Firefox
Works on Chrome (Doesn't seem to do preflight requests)

This PR fixes that.
