### PR TITLE
mk: remove rtpext.c from srcs.mk

### DIFF
--- a/src/srcs.mk
+++ b/src/srcs.mk
@@ -34,7 +34,6 @@ SRCS	+= net.c
 SRCS	+= peerconn.c
 SRCS	+= play.c
 SRCS	+= reg.c
-SRCS	+= rtpext.c
 SRCS	+= rtpstat.c
 SRCS	+= sdp.c
 SRCS	+= sipreq.c


### PR DESCRIPTION
Fixes old Makefile build