### PR TITLE
uag,call: do not override status code and reason

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1204,10 +1204,12 @@ void call_hangup(struct call *call, uint16_t scode, const char *reason)
 			sipsess_abort(call->sess);
 		}
 		else {
-			if (scode < 400) {
+			if (!scode)
 				scode = 486;
+
+			if (!str_isset(reason))
 				reason = "Rejected";
-			}
+
 			info("call: rejecting incoming call from %s (%u %s)\n",
 			     call->peer_uri, scode, reason);
 			(void)sipsess_reject(call->sess, scode, reason, NULL);

--- a/src/uag.c
+++ b/src/uag.c
@@ -733,7 +733,7 @@ int uag_reset_transp(bool reg, bool reinvite)
 
 			if (sa_isset(&laddr, SA_ADDR)) {
 				if (!call_target_refresh_allowed(call)) {
-					call_hangup(call, 0, "Transport of "
+					call_hangup(call, 500, "Transport of "
 						    "User Agent changed");
 					ua_event(ua, UA_EVENT_CALL_CLOSED,
 						 call, "Transport of "


### PR DESCRIPTION
Helps when someone wants to analyse unexpected call termination by the peer.