### PR TITLE
mediatrack: add audio and video getters

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1641,6 +1641,8 @@ int  mediatrack_start_audio(struct media_track *media,
 			    struct list *ausrcl, struct list *aufiltl);
 int  mediatrack_start_video(struct media_track *media);
 struct stream *media_get_stream(const struct media_track *media);
+struct audio *media_get_audio(const struct media_track *media);
+struct video *media_get_video(const struct media_track *media);
 enum media_kind mediatrack_kind(const struct media_track *media);
 const char *media_kind_name(enum media_kind kind);
 

--- a/src/mediatrack.c
+++ b/src/mediatrack.c
@@ -169,7 +169,7 @@ struct stream *media_get_stream(const struct media_track *media)
 
 struct audio *media_get_audio(const struct media_track *media)
 {
-	if (!media || media->kind == MEDIA_KIND_VIDEO)
+	if (!media || media->kind != MEDIA_KIND_AUDIO)
 		return NULL;
 
 	return media->u.au;
@@ -178,7 +178,7 @@ struct audio *media_get_audio(const struct media_track *media)
 
 struct video *media_get_video(const struct media_track *media)
 {
-	if (!media || media->kind == MEDIA_KIND_AUDIO)
+	if (!media || media->kind != MEDIA_KIND_VIDEO)
 		return NULL;
 
 	return media->u.vid;

--- a/src/mediatrack.c
+++ b/src/mediatrack.c
@@ -167,6 +167,24 @@ struct stream *media_get_stream(const struct media_track *media)
 }
 
 
+struct audio *media_get_audio(const struct media_track *media)
+{
+	if (!media || media->kind == MEDIA_KIND_VIDEO)
+		return NULL;
+
+	return media->u.au;
+}
+
+
+struct video *media_get_video(const struct media_track *media)
+{
+	if (!media || media->kind == MEDIA_KIND_AUDIO)
+		return NULL;
+
+	return media->u.vid;
+}
+
+
 const char *media_kind_name(enum media_kind kind)
 {
 	switch (kind) {


### PR DESCRIPTION
This is useful for `audio_set_devicename` etc.