### PR TITLE
rtp/rtcp: add additional Receiver Reports

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1412,6 +1412,7 @@ void stream_set_secure(struct stream *strm, bool secure);
 bool stream_is_secure(const struct stream *strm);
 int  stream_start_mediaenc(struct stream *strm);
 int  stream_start_rtcp(const struct stream *strm);
+void stream_rtcp_enable_rr(const struct stream *strm, bool enable);
 int  stream_enable(struct stream *strm, bool enable);
 int stream_open_natpinhole(struct stream *strm);
 void stream_mnat_attr(struct stream *strm, const char *name,

--- a/src/peerconn.c
+++ b/src/peerconn.c
@@ -182,6 +182,7 @@ static void menc_event_handler(enum menc_event event,
 		media->dtls_ok = true;
 
 		stream_set_secure(strm, true);
+		stream_rtcp_enable_rr(strm, true);
 		stream_start_rtcp(strm);
 
 		if (pc->estabh)

--- a/src/stream.c
+++ b/src/stream.c
@@ -1497,7 +1497,7 @@ int stream_start_rtcp(const struct stream *strm)
  * Enable/Disable additional RTCP Receiver Reports
  *
  * @param strm   Stream object
- * @param enable @param enable True for enable and false for disable
+ * @param enable True for enable and false for disable
  */
 void stream_rtcp_enable_rr(const struct stream *strm, bool enable)
 {

--- a/src/stream.c
+++ b/src/stream.c
@@ -1494,6 +1494,21 @@ int stream_start_rtcp(const struct stream *strm)
 
 
 /**
+ * Enable/Disable additional RTCP Receiver Reports
+ *
+ * @param strm   Stream object
+ * @param enable @param enable True for enable and false for disable
+ */
+void stream_rtcp_enable_rr(const struct stream *strm, bool enable)
+{
+	if (!strm)
+		return;
+
+	rtcp_enable_rr(strm->rtp, enable);
+}
+
+
+/**
  * Enable stream
  *
  * @param strm   Stream object


### PR DESCRIPTION
Looks like webrtc needs seperate receiver reports (chrome libwebrtc warning):

```
[1216/160509.964737:WARNING:rtcp_receiver.cc(355)] OnPeriodicRttUpdate: Timeout: No RTCP RR received.
[1216/160510.964757:WARNING:rtcp_receiver.cc(357)] OnPeriodicRttUpdate: Timeout: No increase in RTCP RR extended highest sequence number.
```