### PR TITLE
aubuf: add AUBUF_FILE mode

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -449,7 +449,7 @@ static int play_file_ausrc(struct play **playp,
 	if (err)
 		goto out;
 
-	aubuf_set_mode(play->aubuf, AUBUF_FILE);
+	aubuf_set_live(play->aubuf, false);
 	play->ausrc = ausrc;
 	err = start_ausrc(play);
 	if (err)


### PR DESCRIPTION
A new aubuf mode AUBUF_FILE reduces the complexity of the code for the repeated
playback. In `aubuf_write_handler()` the frames have to be taken from `aubuf`
without any exception, otherwise this leads to cracks in the playback.

based on: https://github.com/baresip/rem/pull/117 
