### PR TITLE
play: flush aubuf before restart

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -374,6 +374,8 @@ static void ausrc_error_handler(int err, const char *str, void *arg)
 		mtx_lock(&play->lock);
 		play->ausrc_st = mem_deref(play->ausrc_st);
 		mtx_unlock(&play->lock);
+
+		aubuf_flush(play->aubuf);
 	}
 }
 


### PR DESCRIPTION
Fixes an audio drop-out caused by faulty timestamps on first restart. When the
timestamps are reset to zero, then the aubuf has to be flushed.
