### PR TITLE
avcodec: constrain bitrate

### DIFF
--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -164,7 +164,10 @@ static int open_encoder(struct videnc_state *st,
 
 	av_opt_set_defaults(st->ctx);
 
-	st->ctx->bit_rate  = prm->bitrate;
+	st->ctx->bit_rate	= prm->bitrate;
+	st->ctx->rc_max_rate	= prm->bitrate;
+	st->ctx->rc_buffer_size = prm->bitrate / 2;
+
 	st->ctx->width     = size->w;
 	st->ctx->height    = size->h;
 


### PR DESCRIPTION
With `rc_buffer_size` and `rc_max_rate` the encoder can better calculate a constant average bitrate and this avoids large bitrate spikes.

See: https://trac.ffmpeg.org/wiki/Limiting%20the%20output%20bitrate