### PR TITLE
menu: debounce tone playback with a timer

### DIFF
--- a/modules/menu/CMakeLists.txt
+++ b/modules/menu/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(menu)
 
-set(SRCS menu.c static_menu.c dynamic_menu.c)
+set(SRCS menu.c static_menu.c dynamic_menu.c tone.c)
 
 if(STATIC)
     add_library(${PROJECT_NAME} OBJECT ${SRCS})

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -381,20 +381,10 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 
 static int stop_ringing(struct re_printf *pf, void *arg)
 {
-	struct menu *menu;
-	struct play *p;
-
 	(void)pf;
 	(void)arg;
 
-	menu = menu_get();
-	p = menu->play;
-	menu->play = NULL;
-
-	if (p) {
-		mem_deref(p);
-	}
-
+	menu_stop_play();
 	return 0;
 }
 

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -14,7 +14,6 @@ enum statmode {
 
 struct menu{
 	struct tmr tmr_stat;          /**< Call status timer              */
-	struct play *play;            /**< Current audio player state     */
 	struct mbuf *dialbuf;         /**< Buffer for dialled number      */
 	struct call *xfer_call;       /**< Attended transfer call         */
 	struct call *xfer_targ;       /**< Transfer target call           */
@@ -64,3 +63,6 @@ int  menu_param_decode(const char *prm, const char *name, struct pl *val);
 struct call *menu_find_call(call_match_h *matchh, const struct call *exclude);
 struct call *menu_find_call_state(enum call_state st);
 enum sdp_dir decode_sdp_enum(const struct pl *pl);
+
+/* Tone */
+void menu_stop_play(void);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -39,14 +39,13 @@ static int about_box(struct re_printf *pf, void *unused)
 
 static int answer_call(struct ua *ua, struct call *call)
 {
-	struct menu *menu = menu_get();
 	int err;
 
 	if (!call)
 		return EINVAL;
 
 	/* Stop any ongoing ring-tones */
-	menu->play = mem_deref(menu->play);
+	menu_stop_play();
 
 	err  = uag_hold_others(call);
 	err |= ua_answer(ua, call, VIDMODE_ON);

--- a/modules/menu/tone.c
+++ b/modules/menu/tone.c
@@ -1,0 +1,76 @@
+/**
+ * @file tone.c  Signal tones
+ *
+ * Copyright (C) 2022 Commend.com - c.spielberger@commend.com
+ */
+#include <string.h>
+#include <re.h>
+#include <baresip.h>
+#include "tone.h"
+
+enum {
+	DEBOUNCE_DELAY =   20,
+};
+
+struct {
+	struct play *play;            /**< Current audio player state     */
+	int repeat;
+	char *filename;
+	enum Device device;
+	struct tmr tmr_play;
+} tone;
+
+
+void tone_init(void)
+{
+	memset(&tone, 0, sizeof(tone));
+}
+
+
+static void do_play(void *arg)
+{
+	enum Device device = tone.device;
+	struct config *cfg = conf_config();
+	struct player *player = baresip_player();
+	const char *play_mod = cfg->audio.alert_mod;
+	const char *play_dev = cfg->audio.alert_dev;
+	(void) arg;
+
+	if (device == DEVICE_PLAYER) {
+		play_mod = cfg->audio.play_mod;
+		play_dev = cfg->audio.play_dev;
+	}
+
+	play_file(&tone.play, player, tone.filename, tone.repeat,
+		  play_mod, play_dev);
+
+	tone.filename = mem_deref(tone.filename);
+}
+
+
+void tone_stop(void)
+{
+	tmr_cancel(&tone.tmr_play);
+
+	tone.filename = mem_deref(tone.filename);
+	tone.play = mem_deref(tone.play);
+}
+
+
+void tone_play(const struct pl *pl, int repeat, enum Device device)
+{
+	if (!pl_isset(pl))
+		return;
+
+	pl_strdup(&tone.filename, pl);
+	tone.repeat = repeat;
+	tone.device = device;
+
+	tmr_start(&tone.tmr_play, DEBOUNCE_DELAY, do_play, NULL);
+}
+
+
+void tone_set_finish_handler(play_finish_h *fh, void *arg)
+{
+	play_set_finish_handler(tone.play, fh, arg);
+}

--- a/modules/menu/tone.h
+++ b/modules/menu/tone.h
@@ -1,0 +1,15 @@
+/**
+ * @file tone.h module menu internal API for playing tones
+ *
+ * Copyright (c) 2022 Commend.com - c.spielberger@commend.com
+ */
+
+enum Device {
+	DEVICE_ALERT,
+	DEVICE_PLAYER
+};
+
+void tone_init(void);
+void tone_stop(void);
+void tone_play(const struct pl *pl, int repeat, enum Device device);
+void tone_set_finish_handler(play_finish_h *fh, void *arg);


### PR DESCRIPTION
There are different situations where the ring-/ringback tone is started and
after a few millisecond stopped again. Fast start-stop sequences of the
playback should be avoided. These are such situations:
- First 180 Ringing, then 183 Session progress.
- Callee has automatic call answer configured.

Separates also tones.c from menu.c.
