### PR TITLE
call,menu: send UPDATE only if allowed (RFC-3311)

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -408,11 +408,6 @@ static int set_video_dir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	if (!call_target_refresh_allowed(call)) {
-		(void)re_hprintf(pf, "video update not allowed currently");
-		return EINVAL;
-	}
-
 	if (0 == str_cmp(carg->prm, sdp_dir_name(SDP_INACTIVE))) {
 		err = call_set_video_dir(call, SDP_INACTIVE);
 	}

--- a/src/call.c
+++ b/src/call.c
@@ -1151,7 +1151,7 @@ int call_connect(struct call *call, const struct pl *paddr)
 
 
 /**
- * Update the current call by sending Re-INVITE or UPDATE
+ * Update the current call media and send Re-INVITE or UPDATE if allowed
  *
  * @param call Call object
  *

--- a/src/call.c
+++ b/src/call.c
@@ -1168,7 +1168,7 @@ int call_modify(struct call *call)
 	debug("call: modify\n");
 
 	err = call_sdp_get(call, &desc, true);
-	if (!err) {
+	if (!err && call_target_refresh_allowed(call)) {
 		err = sipsess_modify(call->sess, desc);
 		if (err)
 			goto out;


### PR DESCRIPTION
The check if UPDATE is allowed is missing.

On the other side, a local change of the early media processing is always allowed.
