### PR TITLE
RTP Resend

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -294,6 +294,8 @@ void stream_update_encoder(struct stream *s, int pt_enc);
 int  stream_pt_enc(const struct stream *strm);
 int  stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 		 struct mbuf *mb);
+int  stream_resend(struct stream *s, uint16_t seq, bool ext, bool marker,
+		  int pt, uint32_t ts, struct mbuf *mb);
 
 /* Receive */
 void stream_flush(struct stream *s);

--- a/src/stream.c
+++ b/src/stream.c
@@ -917,6 +917,27 @@ int stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 }
 
 
+/**
+ * Write stream data to the network
+ *
+ * @param s		Stream object
+ * @param seq		Sequence
+ * @param ext		Extension bit
+ * @param marker	Marker bit
+ * @param pt		Payload type
+ * @param ts		Timestamp
+ * @param mb		Payload buffer
+ *
+ * @return int	0 if success, errorcode otherwise
+ */
+int stream_resend(struct stream *s, uint16_t seq, bool ext, bool marker,
+		  int pt, uint32_t ts, struct mbuf *mb)
+{
+	return rtp_resend(s->rtp, seq, &s->tx.raddr_rtp, ext, marker, pt, ts,
+			  mb);
+}
+
+
 static void disable_mnat(struct stream *s)
 {
 	info("stream: disable MNAT (%s)\n", media_name(s->type));


### PR DESCRIPTION
Instead of requesting a new picture we should answer a Generic NACK with resending the rtp packet if available.

Tested with Chrome/Firefox (needs #2380) 108 and Safari iOS (1-2% packet loss simulation).

Depends on https://github.com/baresip/re/pull/626
