### PR TITLE
video: add rtcp-fb Generic NACK

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1024,6 +1024,9 @@ int video_alloc(struct video **vp, struct list *streaml,
 
 	/* RFC 4585 */
 	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
+				   "rtcp-fb", "* nack");
+
+	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), false,
 				   "rtcp-fb", "* nack pli");
 
 	/* RFC 4796 */


### PR DESCRIPTION
Firefox needs for activating `Generic NACK` a extra rtcp-fb line (which looks RFC conform).