### PR TITLE
call: set media dir also for MNAT case

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1141,10 +1141,16 @@ int call_connect(struct call *call, const struct pl *paddr)
 
 	/* If we are using asyncronous medianat like STUN/TURN, then
 	 * wait until completed before sending the INVITE */
-	if (!call->acc->mnat)
+	if (!call->acc->mnat) {
 		err = send_invite(call);
-	else
+	}
+	else {
 		err = call_streams_alloc(call);
+		if (err)
+			return err;
+
+		call_set_mdir(call, call->estadir, call->estvdir);
+	}
 
 	return err;
 }


### PR DESCRIPTION
If STUN/TURN/ICE was configured the media direction for the INVITE was not set
that was given by `ua_connect_dir()`. This lead to a fallback to send-receive
for audio and video.

Note: If `ua_connect()` is used, nothing changes. Then the media direction is send-receive, the default.