### PR TITLE
PRACK refactoring

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -208,7 +208,7 @@ int  call_send_digit(struct call *call, char key);
 bool call_has_audio(const struct call *call);
 bool call_has_video(const struct call *call);
 bool call_early_video_available(const struct call *call);
-bool call_target_refresh_allowed(const struct call *call);
+bool call_refresh_allowed(const struct call *call);
 int  call_transfer(struct call *call, const char *uri);
 int  call_replace_transfer(struct call *target_call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -408,7 +408,7 @@ static int set_video_dir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	if (!call_target_refresh_allowed(call)) {
+	if (!call_refresh_allowed(call)) {
 		(void)re_hprintf(pf, "video update not allowed currently");
 		return EINVAL;
 	}

--- a/src/call.c
+++ b/src/call.c
@@ -59,7 +59,6 @@ struct call {
 	bool answered;            /**< True if call has been answered       */
 	bool got_offer;           /**< Got SDP Offer from Peer              */
 	bool on_hold;             /**< True if call is on hold (local)      */
-	bool early_confirmed;     /**< Early media confirmed by PRACK       */
 	struct mnat_sess *mnats;  /**< Media NAT session                    */
 	bool mnat_wait;           /**< Waiting for MNAT to establish        */
 	struct menc_sess *mencs;  /**< Media encryption session state       */
@@ -1358,6 +1357,12 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 		return EINVAL;
 	}
 
+	if (sipsess_awaiting_prack(call->sess)) {
+		info("call: answer: can not answer because we are awaiting a "
+		     "PRACK to a 1xx response with SDP\n");
+		return EAGAIN;
+	}
+
 	if (vmode == VIDMODE_OFF)
 		call->video = mem_deref(call->video);
 
@@ -1492,15 +1497,9 @@ int call_sdp_get(const struct call *call, struct mbuf **descp, bool offer)
  *
  * @return True if a target refresh is currently allowed, otherwise false
  */
-bool call_target_refresh_allowed(const struct call *call)
+bool call_refresh_allowed(const struct call *call)
 {
-	if (!call)
-		return false;
-
-	return call_state(call) == CALL_STATE_ESTABLISHED ||
-		    (call->early_confirmed &&
-			(call_state(call) == CALL_STATE_EARLY ||
-			 call_state(call) == CALL_STATE_INCOMING));
+	return call ? sipsess_refresh_allowed(call->sess) : false;
 }
 
 
@@ -2083,9 +2082,6 @@ static void prack_handler(const struct sip_msg *msg, void *arg)
 
 	if (!msg || !call)
 		return;
-
-	if (msg->req || (msg->scode >= 200 && msg->scode < 300))
-		call->early_confirmed = true;
 
 	return;
 }

--- a/src/uag.c
+++ b/src/uag.c
@@ -751,7 +751,7 @@ int uag_reset_transp(bool reg, bool reinvite)
 				continue;
 
 			if (sa_isset(&laddr, SA_ADDR)) {
-				if (!call_target_refresh_allowed(call)) {
+				if (!call_refresh_allowed(call)) {
 					call_hangup(call, 500, "Transport of "
 						    "User Agent changed");
 					ua_event(ua, UA_EVENT_CALL_CLOSED,


### PR DESCRIPTION
- Do not allow answer if awaiting PRACK to a 1xx response with SDP.
- Refactor call_refresh_allowed to use new re function `sipsess_refresh_allowed`.

Related re PR:
- https://github.com/baresip/re/pull/630