### PR TITLE
menu: ringback/early audio handling for parallel calls

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -203,6 +203,7 @@ int  call_progress(struct call *call);
 void call_hangup(struct call *call, uint16_t scode, const char *reason);
 int  call_modify(struct call *call);
 int  call_hold(struct call *call, bool hold);
+void call_set_audio_ldir(struct call *call, enum sdp_dir dir);
 int  call_set_video_dir(struct call *call, enum sdp_dir dir);
 int  call_send_digit(struct call *call, char key);
 bool call_has_audio(const struct call *call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -336,9 +336,9 @@ static void play_ringback(const struct call *call)
 
 static void check_ringback(struct call *call)
 {
-	enum sdp_dir ardir = sdp_media_rdir(stream_sdpmedia(
-					    audio_strm(call_audio(call))));
-	bool ring = !(ardir & SDP_RECVONLY);
+	enum sdp_dir adir = sdp_media_dir(stream_sdpmedia(
+					  audio_strm(call_audio(call))));
+	bool ring = !(adir & SDP_RECVONLY);
 
 	if (ring && !menu.ringback &&
 	    !menu_find_call(active_call_test, NULL)) {

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -140,9 +140,8 @@ static void turnoff_earlyaudio(struct call* call, void *arg)
 	ardir = sdp_media_rdir(stream_sdpmedia(audio_strm(call_audio(call))));
 	if (ardir & SDP_RECVONLY) {
 		call_set_audio_ldir(call, ardir & SDP_SENDONLY);
-		/* TODO: 100rel used and allowed */
-/*                if (call_refresh_allowed(call))*/
-/*                        call_modify(call);*/
+		if (call_refresh_allowed(call))
+			call_modify(call);
 	}
 }
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -23,7 +23,7 @@ static struct menu menu;
 
 enum {
 	MIN_RINGTIME = 1000,
-	TONE_DELAY   =   20,
+	TONE_DELAY   =   20,         /* Delay for starting tone in [ms]      */
 };
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -206,6 +206,7 @@ static void menu_stop_play(void)
 {
 	menu.play = mem_deref(menu.play);
 	menu.ringback = false;
+	tmr_cancel(&menu.tmr_play);
 }
 
 
@@ -336,11 +337,10 @@ static void play_ringback(const struct call *call)
 
 static void check_ringback(struct call *call)
 {
-	bool ring;
-	enum sdp_dir ardir;
+	enum sdp_dir ardir = sdp_media_rdir(stream_sdpmedia(
+					    audio_strm(call_audio(call))));
+	bool ring = !(ardir & SDP_RECVONLY);
 
-	ardir = sdp_media_rdir(stream_sdpmedia(audio_strm(call_audio(call))));
-	ring = (ardir & SDP_RECVONLY) ? false : true;
 	if (ring && !menu.ringback &&
 	    !menu_find_call(active_call_test, NULL)) {
 		play_ringback(call);

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -32,6 +32,7 @@ struct menu{
 	int32_t adelay;               /**< Outgoing auto answer delay     */
 	char *ansval;                 /**< Call-Info/Alert-Info value     */
 	struct odict *ovaufile;       /**< Override aufile dictionary     */
+	struct tmr tmr_play;          /**< Tones play timer               */
 };
 
 /*Get menu object*/

--- a/src/call.c
+++ b/src/call.c
@@ -2333,12 +2333,14 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	}
 
 	if (media) {
+		mem_ref(call);
 		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
 		call_stream_start(call, false);
+		mem_deref(call);
 	}
 	else {
-		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
 		call_stream_stop(call);
+		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
 	}
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -1464,6 +1464,21 @@ int call_hold(struct call *call, bool hold)
 
 
 /**
+ * Sets the audio local direction of the given call
+ *
+ * @param call  Call object
+ * @param dir   SDP media direction
+ */
+void call_set_audio_ldir(struct call *call, enum sdp_dir dir)
+{
+	if (!call)
+		return;
+
+	stream_set_ldir(audio_strm(call_audio(call)), dir);
+}
+
+
+/**
  * Sets the video direction of the given call
  *
  * @param call  Call object
@@ -2318,12 +2333,12 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	}
 
 	if (media) {
-		call_stream_start(call, false);
 		call_event_handler(call, CALL_EVENT_PROGRESS, call->peer_uri);
+		call_stream_start(call, false);
 	}
 	else {
-		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_RINGING, call->peer_uri);
+		call_stream_stop(call);
 	}
 }
 


### PR DESCRIPTION
This PR introduces a logic for handling ringback tones and early media for multiple outgoing calls (parallel call feature).

- call,menu: no early audio if multiple outgoing calls
- menu: delayed play for ringback and ring tone

Follow up PR:
- These changes: https://github.com/baresip/baresip/pull/2368 . Check if SIP UPDATE is allowed directly in `call_modify()` and return err if not allowed.