### PR TITLE
cmake: increase minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # Versioning
 #
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 project(baresip VERSION 2.10.0)
 


### PR DESCRIPTION
There is a fix in cmake v3.13 for sub-folders. With v3.12.5 there are still
warnings like this for each module:

```
CMake Error at CMakeLists.txt:363 (install):
  install TARGETS given target "account" which does not exist in this
  directory.
```
