### PR TITLE
pulse: replace obsolete string pulse_async (makes baresip PipeWire compatible)

### DIFF
--- a/modules/pulse/pastream.c
+++ b/modules/pulse/pastream.c
@@ -93,7 +93,7 @@ static void stream_latency_update_cb(pa_stream *s, void *arg)
 
 	pa_err = pa_stream_get_latency(s, &usec, &neg);
 	if (!pa_err)
-		debug("pulse_async: stream %s latency update "
+		debug("pulse: stream %s latency update "
 				"usec=%lu, neg=%d\n", st->sname, usec, neg);
 }
 
@@ -104,7 +104,7 @@ static void stream_underflow_cb(pa_stream *s, void *arg)
 	(void)s;
 
 	if (!st->shutdown)
-		warning("pulse_async: stream %s underrun\n",  st->sname);
+		warning("pulse: stream %s underrun\n",  st->sname);
 }
 
 
@@ -113,7 +113,7 @@ static void stream_overflow_cb(pa_stream *s, void *arg)
 	struct pastream_st *st = arg;
 	(void)s;
 
-	warning("pulse_async: stream %s overrun\n", st->sname);
+	warning("pulse: stream %s overrun\n", st->sname);
 }
 
 
@@ -185,14 +185,14 @@ int pastream_start(struct pastream_st* st, void *arg)
 				PA_STREAM_AUTO_TIMING_UPDATE);
 	}
 	else {
-		warning("pulse_async: stream %s unsupported stream "
+		warning("pulse: stream %s unsupported stream "
 			"direction %d\n",
 			st->sname, (int)st->direction);
 	}
 
 out:
 	if (st && pa_err) {
-		warning("pulse_async: stream %s stream error %d\n", st->sname,
+		warning("pulse: stream %s stream error %d\n", st->sname,
 			pa_err);
 		err = EINVAL;
 	}

--- a/modules/pulse/player.c
+++ b/modules/pulse/player.c
@@ -36,7 +36,7 @@ static void auplay_destructor(void *arg)
 }
 
 
-int pulse_async_player_alloc(struct auplay_st **stp, const struct auplay *ap,
+int pulse_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	struct auplay_prm *prm, const char *dev, auplay_write_h *wh, void *arg)
 {
 	struct auplay_st *st;
@@ -45,7 +45,7 @@ int pulse_async_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (!stp || !ap || !prm || !wh)
 		return EINVAL;
 
-	info ("pulse_async: opening player (%u Hz, %d channels, device %s, "
+	info ("pulse: opening player (%u Hz, %d channels, device %s, "
 		"ptime %u)\n", prm->srate, prm->ch, dev, prm->ptime);
 
 	st = mem_zalloc(sizeof(*st), auplay_destructor);
@@ -69,13 +69,13 @@ int pulse_async_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 
 	err = pastream_start(st->b, st);
 	if (err) {
-		warning("pulse_async: could not connect playback stream %s "
+		warning("pulse: could not connect playback stream %s "
 			"(%m)\n", st->b->sname, err);
 		err = ENODEV;
 		goto out;
 	}
 
-	info ("pulse_async: playback stream %s started\n", st->b->sname);
+	info ("pulse: playback stream %s started\n", st->b->sname);
 
   out:
 	if (err)
@@ -99,7 +99,7 @@ static void dev_list_cb(pa_context *context, const pa_sink_info *l, int eol,
 
 	err = mediadev_add(dev_list, l->name);
 	if (err)
-		warning("pulse_async: playback device %s could not be added\n",
+		warning("pulse: playback device %s could not be added\n",
 			l->name);
 }
 
@@ -110,13 +110,13 @@ static pa_operation *get_dev_info(pa_context *context, struct list *dev_list)
 }
 
 
-int pulse_async_player_init(struct auplay *ap)
+int pulse_player_init(struct auplay *ap)
 {
 	if (!ap)
 		return EINVAL;
 
 	list_init(&ap->dev_list);
-	return pulse_async_set_available_devices(&ap->dev_list, get_dev_info);
+	return pulse_set_available_devices(&ap->dev_list, get_dev_info);
 }
 
 
@@ -141,7 +141,7 @@ void stream_write_cb(pa_stream *s, size_t len, void *arg)
 
 	pa_err = pa_stream_begin_write(s, &sampv, &sz);
 	if (pa_err || !sampv) {
-		warning("pulse_async: pa_stream_begin_write error (%s)\n",
+		warning("pulse: pa_stream_begin_write error (%s)\n",
 			pa_strerror(pa_err));
 		goto out;
 	}
@@ -153,7 +153,7 @@ void stream_write_cb(pa_stream *s, size_t len, void *arg)
 
 	pa_err= pa_stream_write(s, sampv, sz, NULL, 0LL, PA_SEEK_RELATIVE);
 	if (pa_err < 0) {
-		warning("pulse_async: pa_stream_write error (%s)\n",
+		warning("pulse: pa_stream_write error (%s)\n",
 			pa_strerror(pa_err));
 	}
 

--- a/modules/pulse/pulse.c
+++ b/modules/pulse/pulse.c
@@ -16,7 +16,7 @@
 
 
 /**
- * @defgroup pulse_async pulse_async
+ * @defgroup pulse pulse
  *
  * Audio driver module for Pulseaudio
  *
@@ -62,7 +62,7 @@ static void reconnth(void *arg)
 	if (pa.retry < 10)
 		tmr_start(&pa.rc, RECONN_DELAY, reconnth, NULL);
 	else
-		warning ("pulse_async: could not connect to pulseaudio\n");
+		warning ("pulse: could not connect to pulseaudio\n");
 }
 
 
@@ -98,8 +98,8 @@ static void context_state_cb(pa_context *context, void *arg)
 
 		case PA_CONTEXT_READY:
 			pa_threaded_mainloop_signal(c->mainloop, 0);
-			pulse_async_player_init(auplay);
-			pulse_async_recorder_init(ausrc);
+			pulse_player_init(auplay);
+			pulse_recorder_init(ausrc);
 			break;
 
 		case PA_CONTEXT_TERMINATED:
@@ -178,7 +178,7 @@ static int paconn_start(struct paconn_st **ppaconn)
 
 	pa_context_set_state_callback(c->context, context_state_cb, c);
 	if (pa_context_connect(c->context, NULL, 0, NULL) < 0) {
-		warning ("pulse_async: could not connect to context (%s)\n",
+		warning ("pulse: could not connect to context (%s)\n",
 			pa_strerror(pa_context_errno(c->context)));
 		err = EINVAL;
 		goto out;
@@ -189,7 +189,7 @@ static int paconn_start(struct paconn_st **ppaconn)
 		err = EINVAL;
 
 	pa_threaded_mainloop_unlock(c->mainloop);
-	info ("pulse_async: initialized (%m)\n", err);
+	info ("pulse: initialized (%m)\n", err);
 
   out:
 	if (err)
@@ -243,7 +243,7 @@ static void dev_info_notify_cb(pa_operation *op, void *arg)
 }
 
 
-int pulse_async_set_available_devices(struct list *dev_list,
+int pulse_set_available_devices(struct list *dev_list,
 	pa_operation *(get_dev_info_cb)(pa_context *, struct list*))
 {
 	pa_operation *op = NULL;
@@ -270,9 +270,9 @@ static int module_init(void)
 		return err;
 
 	err  = auplay_register(&auplay, baresip_auplayl(),
-			       "pulse_async", pulse_async_player_alloc);
+			       "pulse", pulse_player_alloc);
 	err |= ausrc_register(&ausrc, baresip_ausrcl(),
-			      "pulse_async", pulse_async_recorder_alloc);
+			      "pulse", pulse_recorder_alloc);
 
 	return err;
 }

--- a/modules/pulse/pulse.h
+++ b/modules/pulse/pulse.h
@@ -35,16 +35,16 @@ struct pastream_st {
 
 
 /*player.c*/
-int pulse_async_player_init(struct auplay *ap);
-int pulse_async_player_alloc(struct auplay_st **stp, const struct auplay *ap,
+int pulse_player_init(struct auplay *ap);
+int pulse_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	struct auplay_prm *prm, const char *device,
 	auplay_write_h *wh, void *arg);
 void stream_write_cb(pa_stream *s, size_t len, void *arg);
 
 
 /*recorder.c*/
-int pulse_async_recorder_init(struct ausrc *as);
-int pulse_async_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
+int pulse_recorder_init(struct ausrc *as);
+int pulse_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	struct ausrc_prm *prm, const char *dev, ausrc_read_h *rh,
 	ausrc_error_h *errh, void *arg);
 void stream_read_cb(pa_stream *s, size_t len, void *arg);
@@ -52,7 +52,7 @@ void stream_read_cb(pa_stream *s, size_t len, void *arg);
 
 /*pulse.c*/
 struct paconn_st *paconn_get(void);
-int pulse_async_set_available_devices(struct list *dev_list,
+int pulse_set_available_devices(struct list *dev_list,
 	pa_operation *(get_dev_info_cb)(pa_context *, struct list*));
 
 

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -42,7 +42,7 @@ static void ausrc_destructor(void *arg)
 }
 
 
-int pulse_async_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
+int pulse_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	struct ausrc_prm *prm, const char *dev, ausrc_read_h *rh,
 	ausrc_error_h *errh, void *arg)
 {
@@ -52,7 +52,7 @@ int pulse_async_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (!stp || !as || !prm || !rh)
 		return EINVAL;
 
-	info ("pulse_async: opening recorder(%u Hz, %d channels,"
+	info ("pulse: opening recorder(%u Hz, %d channels,"
 	      "device '%s')\n", prm->srate, prm->ch, dev);
 
 	st = mem_zalloc(sizeof(*st), ausrc_destructor);
@@ -84,13 +84,13 @@ int pulse_async_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 
 	err = pastream_start(st->b, st);
 	if (err) {
-		warning("pulse_async: could not connect record stream %s "
+		warning("pulse: could not connect record stream %s "
 			"(%m)\n", st->b->sname, err);
 		err = ENODEV;
 		goto out;
 	}
 
-	info ("pulse_async: record stream %s started\n", st->b->sname);
+	info ("pulse: record stream %s started\n", st->b->sname);
 
   out:
 	if (err)
@@ -117,7 +117,7 @@ static void dev_list_cb(pa_context *context, const pa_source_info *l, int eol,
 
 	err = mediadev_add(dev_list, l->name);
 	if (err)
-		warning("pulse_async: record device %s could not be added\n",
+		warning("pulse: record device %s could not be added\n",
 			l->name);
 }
 
@@ -128,13 +128,13 @@ static pa_operation *get_dev_info(pa_context *context, struct list *dev_list)
 }
 
 
-int pulse_async_recorder_init(struct ausrc *as)
+int pulse_recorder_init(struct ausrc *as)
 {
 	if (!as)
 		return EINVAL;
 
 	list_init(&as->dev_list);
-	return pulse_async_set_available_devices(&as->dev_list, get_dev_info);
+	return pulse_set_available_devices(&as->dev_list, get_dev_info);
 }
 
 
@@ -165,7 +165,7 @@ void stream_read_cb(pa_stream *s, size_t len, void *arg)
 	while (pa_stream_readable_size(s) > 0) {
 		pa_err = pa_stream_peek(s, &pabuf, &rlen);
 		if (pa_err < 0) {
-			warning ("pulse_async: %s pa_stream_peek error (%s)\n",
+			warning ("pulse: %s pa_stream_peek error (%s)\n",
 				st->b->sname, pa_strerror(pa_err));
 			goto out;
 		}


### PR DESCRIPTION
Yesterday I replaced pulseaudio daemon with WirePlumber / Pipewire on my dev host. The plan was too use pipewire-pulse.service which makes pipewire compatible to pulseaudio clients like baresip with module pulse.

With command `/play ring.wav` didn't hear anything. Also no error messages.

The reason for this seems to be this faulty registration with the obsolete key `pulse_async`.

```c
        err  = auplay_register(&auplay, baresip_auplayl(),
                              "pulse_async", pulse_async_player_alloc);
        err |= ausrc_register(&ausrc, baresip_ausrcl(),
                             "pulse_async", pulse_async_recorder_alloc);
```

Replacing `pulse_async` by `pulse` solves the problem.