### PR TITLE
cmake/pulse: Remove pulse-simple library lookup

### DIFF
--- a/cmake/FindPULSE.cmake
+++ b/cmake/FindPULSE.cmake
@@ -25,25 +25,13 @@ find_library(PULSE_LIBRARY
     PATHS /usr/local/lib /usr/lib
 )
 
-find_library(PULSE_SIMPLE_LIBRARY
-    NAME pulse-simple
-    HINTS
-        "${PULSE_LIBRARY_DIRS}"
-        "${PULSE_HINTS}/lib"
-    PATHS /usr/local/lib /usr/lib
-)
-
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PULSE DEFAULT_MSG PULSE_LIBRARY
     PULSE_INCLUDE_DIR)
 
 if(PULSE_FOUND)
     set( PULSE_INCLUDE_DIRS ${PULSE_INCLUDE_DIR} )
-    if(DEFINED PULSE_SIMPLE_LIBRARY)
-      set( PULSE_LIBRARIES ${PULSE_LIBRARY} ${PULSE_SIMPLE_LIBRARY} )
-    else()
-      set( PULSE_LIBRARIES ${PULSE_LIBRARY} )
-    endif()
+    set( PULSE_LIBRARIES ${PULSE_LIBRARY} )
 else()
     set( PULSE_INCLUDE_DIRS )
     set( PULSE_LIBRARIES )


### PR DESCRIPTION
The PulseAudio driver using the simple API has already been removed via commit 1aac3e3589977d5785a7ecd74bcad0d99e907c99, commit 5fb1e54e9d11082eba76d3b86d399e1539a0cc8c and commit d0a47f07214c61102c04c5de0d2b88a94b25b89c.