### PR TITLE
make rtcp interval configureable

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -279,6 +279,7 @@ int  stream_alloc(struct stream **sp, struct list *streaml,
 		  void *arg);
 void stream_hold(struct stream *s, bool hold);
 void stream_set_ldir(struct stream *s, enum sdp_dir dir);
+void stream_set_rtcp_interval(struct stream *s, uint32_t n);
 void stream_set_srate(struct stream *s, uint32_t srate_tx, uint32_t srate_rx);
 bool stream_is_ready(const struct stream *strm);
 int  stream_print(struct re_printf *pf, const struct stream *s);

--- a/src/mediatrack.c
+++ b/src/mediatrack.c
@@ -131,6 +131,8 @@ int mediatrack_start_video(struct media_track *media)
 		info("mediatrack: video stream is disabled..\n");
 	}
 
+	stream_set_rtcp_interval(video_strm(vid), 1000);
+
 	return 0;
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -1147,6 +1147,15 @@ enum sdp_dir stream_ldir(const struct stream *s)
 }
 
 
+void stream_set_rtcp_interval(struct stream *s, uint32_t n)
+{
+	if (!s)
+		return;
+
+	rtcp_set_interval(s->rtp, n);
+}
+
+
 void stream_set_srate(struct stream *s, uint32_t srate_tx, uint32_t srate_rx)
 {
 	if (!s)


### PR DESCRIPTION
WebRTC uses 5 seconds for audio and 1 second interval for video rtcp

ref:
https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/modules/rtp_rtcp/source/rtcp_sender.cc#362