### PR TITLE
magic: use C99 __func__ macro

### DIFF
--- a/src/magic.h
+++ b/src/magic.h
@@ -18,7 +18,7 @@
 #define MAGIC_CHECK(s) \
 	if (MAGIC != s->magic) {					\
 		warning("%s: wrong magic struct=%p (magic=0x%08x)\n",	\
-			__REFUNC__, s, s->magic);			\
+			__func__, s, s->magic);			\
 		BREAKPOINT;						\
 	}
 #else


### PR DESCRIPTION
Since we support C99 and later we can use the macro `__func__` directly.
