### PR TITLE
gtk: return NULL on mtx_init() != thrd_success

### DIFF
--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -395,11 +395,10 @@ struct call_window *call_window_new(struct call *call, struct gtk_mod *mod,
 	GtkWidget *button_box, *vbox, *hbox;
 	GtkWidget *duration;
 	int err = 0;
+
 	err = mtx_init(&last_data_mut, mtx_plain) != thrd_success;
-	if (err) {
-		err = ENOMEM;
-		goto out;
-	}
+	if (err)
+		return NULL;
 
 	win = mem_zalloc(sizeof(*win), call_window_destructor);
 	if (!win)


### PR DESCRIPTION
Get rid of the following clang compiler warnings:

```
modules/gtk/call_window.c:399:6: error: variable 'win' is used uninitialized whenever 'if' condition is true [-Werror,-Wsometimes-uninitialized]
        if (err) {
            ^~~
modules/gtk/call_window.c:553:9: note: uninitialized use occurs here
        return win;
               ^~~
modules/gtk/call_window.c:399:2: note: remove the 'if' if its condition is always false
        if (err) {
        ^~~~~~~~~~
modules/gtk/call_window.c:393:25: note: initialize the variable 'win' to silence this warning
        struct call_window *win;
                               ^
                                = NULL
```

Can not return `ENOMEM`, because of return type `struct call_window *`.