### PR TITLE
ci: add libgtk-3-dev to build GTK+ 3 module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
                             libfdk-aac-dev \
                             libglib2.0-dev \
                             libgstreamer1.0-dev \
+                            libgtk-3-dev \
                             libjack-jackd2-dev \
                             libmosquitto-dev \
                             libmpg123-dev \


### PR DESCRIPTION
I would like to see the gtk module built as part of the CI (also to fix possible issues earlier than currently).