### PR TITLE
audio: payload type handler thread safe

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -783,7 +783,7 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 						  telev_work_destructor);
 		w->a  = a;
 		w->mb = mbuf_dup(mb);
-		re_thread_async(NULL, async_telev_event, w);
+		re_thread_async_main(NULL, async_telev_event, w);
 		return ENODATA;
 	}
 


### PR DESCRIPTION
Looking into the `stream_pt_handler()`:
- Changing the decoder should be done in the main thread
- Manipulation of `audio->telev` and calling the `audio->eventh()` should be done in the main thread.

This PR handles the second point.

