### PR TITLE
ci: install pkg-config on mac-os

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,8 @@ jobs:
                         mpg123 \
                         spandsp \
                         sdl2 \
-                        glib-utils
+                        glib-utils \
+                        pkg-config
 
     - uses: sreimers/pr-dependency-action@v0.5
       with:


### PR DESCRIPTION
The following build failed on macos-11:
https://github.com/baresip/baresip/actions/runs/4195739157/jobs/7288101408
Arised with:
https://github.com/baresip/baresip/pull/2454#issuecomment-1434166069