### PR TITLE
Client cert renegotiation in http

### DIFF
--- a/modules/dtls_srtp/dtls_srtp.c
+++ b/modules/dtls_srtp/dtls_srtp.c
@@ -531,7 +531,7 @@ static int module_init(void)
 		return err;
 	}
 
-	tls_set_verify_client(tls);
+	tls_set_verify_client_trust_all(tls);
 
 	err = tls_set_srtp(tls, srtp_profiles);
 	if (err) {


### PR DESCRIPTION
tls_set_verify_client has same functionality like tls_set_verify_client_trust_all. The old name was misleading for tls usages other than dtls and will be removed.