### PR TITLE
Dshow fixes

### DIFF
--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -151,8 +151,10 @@ public:
 		struct vidframe vidframe;
 		uint64_t timestamp = (uint64_t)(sample_time * VIDEO_TIMEBASE);
 		if (buf_len != buf_len_RGB32 * 4) {
-			warning("dshow: BufferCB got %uB, required %uB (%ux%u)\n",
-				buf_len, buf_len_RGB32 * 4, src->size.w, src->size.h);
+			warning("dshow: BufferCB got %uB, "
+				"required %uB (%ux%u)\n",
+				buf_len, buf_len_RGB32 * 4,
+				src->size.w, src->size.h);
 			return S_OK;
 		}
 

--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -150,7 +150,10 @@ public:
 		uint32_t *buf_RGB32;
 		struct vidframe vidframe;
 		uint64_t timestamp = (uint64_t)(sample_time * VIDEO_TIMEBASE);
-		(void)buf_len;
+		if (buf_len != buf_len_RGB32 * 4) {
+			warning("dshow: BufferCB got %uB, required %uB (%ux%u)\n", buf_len, buf_len_RGB32 * 4, src->size.w, src->size.h);
+			return S_OK;
+		}
 
 		vidframe_init_buf(&vidframe, VID_FMT_RGB32, &src->size, buf);
 

--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -367,8 +367,10 @@ static int config_pin(struct vidsrc_st *st, IPin *pin)
 	h = st->size.h;
 	w = st->size.w;
 	while ((hr = media_enum->Next(1, &mt, NULL)) == S_OK) {
-		if (mt->formattype != FORMAT_VideoInfo)
+		if (mt->formattype != FORMAT_VideoInfo) {
+			mt = free_mt(mt);
 			continue;
+		}
 
 		vih = (VIDEOINFOHEADER *) mt->pbFormat;
 		rw = vih->bmiHeader.biWidth;

--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -345,7 +345,7 @@ static AM_MEDIA_TYPE *free_mt(AM_MEDIA_TYPE *mt)
 
 static int config_pin(struct vidsrc_st *st, IPin *pin)
 {
-	AM_MEDIA_TYPE *mt;
+	AM_MEDIA_TYPE *mt = NULL;
 	AM_MEDIA_TYPE *best_mt = NULL;
 	IEnumMediaTypes *media_enum = NULL;
 	IAMStreamConfig *stream_conf = NULL;
@@ -389,6 +389,7 @@ static int config_pin(struct vidsrc_st *st, IPin *pin)
 				best_match = diff;
 				free_mt(best_mt);
 				best_mt = mt;
+				mt = NULL;				
 			}
 		}
 	}

--- a/modules/dshow/dshow.cpp
+++ b/modules/dshow/dshow.cpp
@@ -151,7 +151,8 @@ public:
 		struct vidframe vidframe;
 		uint64_t timestamp = (uint64_t)(sample_time * VIDEO_TIMEBASE);
 		if (buf_len != buf_len_RGB32 * 4) {
-			warning("dshow: BufferCB got %uB, required %uB (%ux%u)\n", buf_len, buf_len_RGB32 * 4, src->size.w, src->size.h);
+			warning("dshow: BufferCB got %uB, required %uB (%ux%u)\n",
+				buf_len, buf_len_RGB32 * 4, src->size.w, src->size.h);
 			return S_OK;
 		}
 
@@ -394,7 +395,7 @@ static int config_pin(struct vidsrc_st *st, IPin *pin)
 				best_match = diff;
 				free_mt(best_mt);
 				best_mt = mt;
-				mt = NULL;				
+				mt = NULL;
 			}
 		}
 	}


### PR DESCRIPTION
1. Memory that is already freed is referenced if camera has no resolution equal to requested but best match is the last media offered by the device. Spotted when trying to use 640x480 resolution with OBS-Camera - unlike physical cameras I own this one list resolutions from highest to lowest and the last one, 640x360 is the best match.
2. If during format enumeration device would return something other than FORMAT_VideoInfo (but I'm not sure if/when it can actually happen) then media type memory is leaked.
3. This I believe is actually OBS-Camera issue, but checking buffer buffer size in BufferCB might prevent crash. I'm not sure if I've used the latest version of OBS / virtual camera, but it was reporting back incorrect video size (not the one set by the user) but then returning frames with the size specified by the user. In my test stream was set to 640x360 (SetFormat inside config_pin function) but camera returned back (GetFormat) information about 1920x1080 resolution. Actual frames in callback had 640x360 resolution resulting in buffer overrun / crash.