### PR TITLE
video: add NULL pointer check for vidisp

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -812,7 +812,7 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	++vrx->stats.disp_frames;
 
-	if (vrx->vd && vrx->vd->disph)
+	if (vrx->vd && vrx->vd->disph && vrx->vidisp)
 		err = vrx->vd->disph(vrx->vidisp, v->peer, frame, timestamp);
 
 	frame_filt = mem_deref(frame_filt);


### PR DESCRIPTION
This fixes a baresip crash that occurs when there follows one more frame after a re-INVITE switches off video RX.