### PR TITLE
menu: limit early audio TX streams

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -33,6 +33,7 @@ sip_tos			160 # See TOS fields!
 call_local_timeout	120
 call_max_calls		4
 call_hold_other_calls	yes
+#call_max_earlyaudio	32		# 0 deactivates the limit
 
 # Audio
 #audio_path		/usr/local/share/baresip

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -33,7 +33,7 @@ sip_tos			160 # See TOS fields!
 call_local_timeout	120
 call_max_calls		4
 call_hold_other_calls	yes
-#call_max_earlyaudio	32		# 0 deactivates the limit
+#call_max_earlyaudio	32
 
 # Audio
 #audio_path		/usr/local/share/baresip

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -33,7 +33,6 @@ sip_tos			160 # See TOS fields!
 call_local_timeout	120
 call_max_calls		4
 call_hold_other_calls	yes
-#call_max_earlyaudio	32
 
 # Audio
 #audio_path		/usr/local/share/baresip
@@ -247,6 +246,7 @@ video_selfview		window # {window,pip}
 #busy_aufile		busy.wav
 #error_aufile		error.wav
 #sip_autoanswer_aufile	autoanswer.wav
+#menu_max_earlyaudio	32
 
 # GTK
 #gtk_clean_number	no

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -131,7 +131,7 @@ static void limit_earlyaudio(struct call* call, void *arg)
 	ndir  = ardir;
 	conf_get_u32(conf_cur(), "call_max_earlyaudio", &maxcnt);
 
-	if (maxcnt && menu.outcnt > maxcnt)
+	if (menu.outcnt > maxcnt)
 		ndir = SDP_INACTIVE;
 	else if (menu.outcnt > 1)
 		ndir &= SDP_SENDONLY;

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -129,7 +129,7 @@ static void limit_earlyaudio(struct call* call, void *arg)
 
 	ardir = sdp_media_rdir(stream_sdpmedia(audio_strm(call_audio(call))));
 	ndir  = ardir;
-	conf_get_u32(conf_cur(), "call_max_earlyaudio", &maxcnt);
+	conf_get_u32(conf_cur(), "menu_max_earlyaudio", &maxcnt);
 
 	if (menu.outcnt > maxcnt)
 		ndir = SDP_INACTIVE;

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -33,6 +33,7 @@ struct menu{
 	char *ansval;                 /**< Call-Info/Alert-Info value     */
 	struct odict *ovaufile;       /**< Override aufile dictionary     */
 	struct tmr tmr_play;          /**< Tones play timer               */
+	size_t outcnt;                /**< Outgoing call counter          */
 };
 
 /*Get menu object*/

--- a/src/config.c
+++ b/src/config.c
@@ -734,8 +734,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
 			  "call_hold_other_calls\tyes\n"
-			  "#call_max_earlyaudio\t32\t\t"
-			  "# 0 deactivates the limit\n"
+			  "#call_max_earlyaudio\t32\n"
 			  "\n"
 			  "# Audio\n"
 #if defined (SHARE_PATH)

--- a/src/config.c
+++ b/src/config.c
@@ -734,6 +734,8 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
 			  "call_hold_other_calls\tyes\n"
+			  "#call_max_earlyaudio\t32\t\t"
+			  "# 0 deactivates the limit\n"
 			  "\n"
 			  "# Audio\n"
 #if defined (SHARE_PATH)

--- a/src/config.c
+++ b/src/config.c
@@ -734,7 +734,6 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
 			  "call_hold_other_calls\tyes\n"
-			  "#call_max_earlyaudio\t32\n"
 			  "\n"
 			  "# Audio\n"
 #if defined (SHARE_PATH)
@@ -1168,6 +1167,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#busy_aufile\t\tbusy.wav\n"
 			"#error_aufile\t\terror.wav\n"
 			"#sip_autoanswer_aufile\tautoanswer.wav\n"
+			"#menu_max_earlyaudio\t32\n"
 			);
 
 	(void)re_fprintf(f,


### PR DESCRIPTION
Parallel call memory issue: #2502 - Part 2

- menu,config: limit the number of early audio streams
- menu: optimize count of outgoing calls
