### PR TITLE
cmake: avoid include of /usr/local/include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ add_definitions(${RE_DEFINITIONS})
 include_directories(
   include
   src
-  /usr/local/include
   ${RE_INCLUDE_DIRS}
   ${OPENSSL_INCLUDE_DIR}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,6 @@ include_directories(
   ${OPENSSL_INCLUDE_DIR}
 )
 
-link_directories(/usr/local/lib)
-
 if(MOD_PATH)
   add_definitions(-DMOD_PATH="${MOD_PATH}")
 elseif(CMAKE_INSTALL_FULL_LIBDIR)


### PR DESCRIPTION
Including /usr/... is unsafe for cross-compilation.

In yocto build fixes the warning:
```
cc1: warning: include location "/usr/local/include" is unsafe for cross-compilation [-Wpoison-system-directories]
```
