### PR TITLE
play: flush of the aubuf directly before the replay starts

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -85,6 +85,7 @@ static void tmr_polling(void *arg)
 
 	if (play->ausrc && play->trep && play->trep <= tmr_jiffies()) {
 		play->trep = 0;
+		aubuf_flush(play->aubuf);
 		start_ausrc(play);
 	}
 
@@ -360,8 +361,6 @@ static void ausrc_error_handler(int err, const char *str, void *arg)
 		mtx_lock(&play->lock);
 		play->ausrc_st = mem_deref(play->ausrc_st);
 		mtx_unlock(&play->lock);
-
-		aubuf_flush(play->aubuf);
 	}
 }
 


### PR DESCRIPTION
The ausrc may call the errh (for eof) before the auplay got the complete data.
This commit avoids that data is lost. The flush is still needed in order to
reset internal fields for computing the timestamps.
