### PR TITLE
ctrl_dbus,ice,png_vf: Fix format string usage

### DIFF
--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -166,7 +166,7 @@ static void send_event(void *data, void *arg)
 	struct modev *modev = data;
 	(void)arg;
 
-	module_event("ctrl_dbus", modev->event, NULL, NULL, modev->txt);
+	module_event("ctrl_dbus", modev->event, NULL, NULL, "%s", modev->txt);
 	mem_deref(modev);
 }
 

--- a/modules/ice/ice.c
+++ b/modules/ice/ice.c
@@ -541,9 +541,9 @@ static int session_alloc(struct mnat_sess **sessp,
 	sess->offerer = offerer;
 
 	err |= sdp_session_set_lattr(ss, true,
-				     ice_attr_ufrag, sess->lufrag);
+				     ice_attr_ufrag, "%s", sess->lufrag);
 	err |= sdp_session_set_lattr(ss, true,
-				     ice_attr_pwd, sess->lpwd);
+				     ice_attr_pwd, "%s", sess->lpwd);
 	if (err)
 		goto out;
 

--- a/modules/snapshot/png_vf.c
+++ b/modules/snapshot/png_vf.c
@@ -121,7 +121,7 @@ int png_save_vidframe(const struct vidframe *vf, const char *path)
 
 	info("png: wrote %s\n", path);
 
-	module_event("snapshot", "wrote", NULL, NULL, path);
+	module_event("snapshot", "wrote", NULL, NULL, "%s", path);
 
  out:
 	/* Finish writing. */


### PR DESCRIPTION
I scanned the whole code base of BareSIP and re for format string and variable argument list issues. Using LLVM, I found 84 functions that use a variable argument list and I did my best to go through all of their invocations manually for potential problems (I have not found a way to use LLVM for this yet).

I have fixed three obvious errors, but there are more potential problem (and va_lists could lead to uncaught errors quite easily). Here are a few that look wrong:

- `rtmp_amf_command` there are quite a few mismatches between the number (and type) of variable arguments and the value of `body_propc` provided.
- `rtmp_amf_command` in rtmp/stream.c there is a `body_propc` mismatch
- `rtmp_amf_request` in rtmp/conn.c there is a `body_propc` mismatch
- `rtcp_quick_send` multiple count mismatches in rtp/rtcp.c

These functions I have not been able to go through all of their invocations yet (there are simply too many):
- `re_regex`
- `odict_entry_add`
- `mbuf_printf`
- `re_snprintf`
- `debug`, `warning`, `info` functions in BareSIP