### PR TITLE
variadic function fixes

### DIFF
--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -166,7 +166,7 @@ static void send_event(void *data, void *arg)
 	struct modev *modev = data;
 	(void)arg;
 
-	module_event("ctrl_dbus", modev->event, NULL, NULL, modev->txt);
+	module_event("ctrl_dbus", modev->event, NULL, NULL, "%s", modev->txt);
 	mem_deref(modev);
 }
 

--- a/modules/ice/ice.c
+++ b/modules/ice/ice.c
@@ -541,9 +541,9 @@ static int session_alloc(struct mnat_sess **sessp,
 	sess->offerer = offerer;
 
 	err |= sdp_session_set_lattr(ss, true,
-				     ice_attr_ufrag, sess->lufrag);
+				     ice_attr_ufrag, "%s", sess->lufrag);
 	err |= sdp_session_set_lattr(ss, true,
-				     ice_attr_pwd, sess->lpwd);
+				     ice_attr_pwd, "%s", sess->lpwd);
 	if (err)
 		goto out;
 

--- a/modules/snapshot/png_vf.c
+++ b/modules/snapshot/png_vf.c
@@ -121,7 +121,7 @@ int png_save_vidframe(const struct vidframe *vf, const char *path)
 
 	info("png: wrote %s\n", path);
 
-	module_event("snapshot", "wrote", NULL, NULL, path);
+	module_event("snapshot", "wrote", NULL, NULL, "%s", path);
 
  out:
 	/* Finish writing. */

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -119,8 +119,8 @@ int sdp_decode_multipart(const struct pl *ctype_prm, struct mbuf *mb)
 		return err;
 
 	err = mbuf_strdup(mb, &buf, mbuf_get_left(mb));
-	if (err || !buf)
-		return err ? err : ENOMEM;
+	if (err)
+		return err;
 
 	/* find 1st boundary */
 	s = strstr(buf, bnd_str);
@@ -140,6 +140,5 @@ int sdp_decode_multipart(const struct pl *ctype_prm, struct mbuf *mb)
 	}
 
 	mem_deref(buf);
-
 	return 0;
 }

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2011 Alfred E. Heggestad
  */
 #include <stdlib.h>
+#include <string.h>
 #include <re.h>
 #include <baresip.h>
 #include "core.h"
@@ -98,8 +99,10 @@ static void decode_part(const struct pl *part, struct mbuf *mb)
  */
 int sdp_decode_multipart(const struct pl *ctype_prm, struct mbuf *mb)
 {
-	struct pl bnd, s, e, p;
-	char expr[64];
+	struct pl p, bnd;
+	char bnd_str[64];
+	char *s, *e;
+	char *buf = NULL;
 	int err;
 
 	if (!ctype_prm || !mb)
@@ -111,27 +114,32 @@ int sdp_decode_multipart(const struct pl *ctype_prm, struct mbuf *mb)
 	if (err)
 		return err;
 
-	if (re_snprintf(expr, sizeof(expr), "--%r[^]+", &bnd) < 0)
-		return ENOMEM;
-
-	/* find 1st boundary */
-	err = re_regex((char *)mbuf_buf(mb), mbuf_get_left(mb), expr, &s);
+	err = pl_strcpy(&bnd, bnd_str, sizeof(bnd_str));
 	if (err)
 		return err;
 
+	err = mbuf_strdup(mb, &buf, mbuf_get_left(mb));
+	if (err || !buf)
+		return err ? err : ENOMEM;
+
+	/* find 1st boundary */
+	s = strstr(buf, bnd_str);
+
 	/* iterate over each part */
-	while (s.l > 2) {
-		if (re_regex(s.p, s.l, expr, &e))
-			return 0;
+	while (s) {
+		e = strstr(s + bnd.l, bnd_str);
+		if (!e)
+			break;
 
-		p.p = s.p + 2;
-		p.l = e.p - p.p - bnd.l - 2;
+		p.p = s + bnd.l + 2;
+		p.l = e - p.p - 2;
 
-		/* valid part in "p" */
 		decode_part(&p, mb);
 
 		s = e;
 	}
+
+	mem_deref(buf);
 
 	return 0;
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -1215,8 +1215,8 @@ static int append_params(struct mbuf *mb, struct pl *params)
 		return err ? err : ENOMEM;
 
 	err = mbuf_strdup(mb, &buf, mbuf_get_left(mb));
-	if (err || !buf)
-		return err ? err : ENOMEM;
+	if (err)
+		return err;
 
 	pstr = str;
 	while((token = strtok(pstr, ";"))) {

--- a/src/ua.c
+++ b/src/ua.c
@@ -1202,6 +1202,7 @@ static int append_params(struct mbuf *mb, struct pl *params)
 {
 	char param[512];
 	char *str = NULL;
+	char *buf = NULL;
 	char *pstr;
 	char *token;
 	int err;
@@ -1213,16 +1214,21 @@ static int append_params(struct mbuf *mb, struct pl *params)
 	if (err || !str)
 		return err ? err : ENOMEM;
 
+	err = mbuf_strdup(mb, &buf, mbuf_get_left(mb));
+	if (err || !buf)
+		return err ? err : ENOMEM;
+
 	pstr = str;
 	while((token = strtok(pstr, ";"))) {
 		re_snprintf(param, sizeof(param), ";%s", token);
-		if (re_regex((const char *)mb->buf, mb->end, param))
+		if (strstr(buf, param) == NULL)
 			mbuf_write_str(mb, param);
 
 		pstr = NULL;
 	}
 
 	mem_deref(str);
+	mem_deref(buf);
 	return 0;
 }
 


### PR DESCRIPTION
Fixes a few occasions of calls to variadic functions that could fail in certain instances.

I used an LLVM pass to check all of baresip and re where the last non-variadic argument passed to a variadic function is not a constant. Such function calls are potentially dangerous, so I checked those function calls manually for potential bugs/vulnerabilities. I have checked the 52 warnings generated by this pass, most of which were not an issue. Still, this is a snapshot in time and such problems could be introduced with any new code change.