### PR TITLE
ua: unescape incoming Refer-To header

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -967,12 +967,15 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 {
 	struct sip_contact contact;
 	const struct sip_hdr *hdr;
+	char refer_to_uri[256];
 	char realm[32];
 	struct sip_uas_auth auth;
+	struct sip_addr addr;
 	struct account *acc = ua_account(ua);
 	struct uri *uri = account_luri(acc);
 	bool sub = true;
 	int err;
+	refer_to_uri[0] = '\0';
 
 	debug("ua: incoming REFER message from %r (%J)\n",
 	      &msg->from.auri, &msg->src);
@@ -995,6 +998,13 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 		warning("call: bad REFER request from %r\n", &msg->from.auri);
 		(void)sip_reply(uag_sip(), msg, 400,
 				"Missing Refer-To header");
+		return true;
+	}
+	err = sip_addr_decode(&addr, &hdr->val);
+	if (err) {
+		warning("call: bad REFER request from %r\n", &msg->from.auri);
+		(void)sip_reply(uag_sip(), msg, 400,
+				"Invalid URI in Refer-To Header");
 		return true;
 	}
 
@@ -1040,8 +1050,18 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 	break;
 	}
 
-	debug("ua: REFER to %r\n", &hdr->val);
-	ua_event(ua, UA_EVENT_REFER, NULL, "%r", &hdr->val);
+	if (pl_isset(&addr.dname)) {
+		re_snprintf(refer_to_uri, sizeof(refer_to_uri), "%s%r%s",
+			    addr.dname.p[0] == '"' ? "" : "\"",
+			    &addr.dname,
+			    addr.dname.p[0] == '"' ? "" : "\" ");
+	}
+	re_snprintf(refer_to_uri + strlen(refer_to_uri),
+		    sizeof(refer_to_uri) - strlen(refer_to_uri),
+		    "<%H>%r", uri_unescape_pl, &addr.auri, &addr.params);
+
+	debug("ua: REFER to %s\n", refer_to_uri);
+	ua_event(ua, UA_EVENT_REFER, NULL, "%s", refer_to_uri);
 
 out:
 


### PR DESCRIPTION
The SIP URI we receive in the Refer-To header is already escaped, so before triggering `UA_EVENT_REFER`, we unescape it. Otherwise, we would double-escape this URI erroneously when sending the INVITE request to this URI.