### PR TITLE
ci: add gcc-12 for Ubuntu 22.04 (ubuntu-latest)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,19 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [gcc, clang]
+        compiler: [gcc, clang, gcc-12]
         os: [ubuntu-20.04, ubuntu-22.04, macos-11, macos-12]
         exclude:
           - os: macos-11
             compiler: gcc
+          - os: macos-11
+            compiler: gcc-12
           - os: macos-12
             compiler: gcc
+          - os: macos-12
+            compiler: gcc-12
+          - os: ubuntu-20.04
+            compiler: gcc-12
     env:
       CC: ${{ matrix.compiler }}
       MACOSX_DEPLOYMENT_TARGET: "10.12"


### PR DESCRIPTION
Add latest available gcc compiler (currently gcc-12) to catch possibly new build failures early; clang aka clang-14 is already the newest in Ubuntu 22.04 (ubuntu-latest).