### PR TITLE
cmake/gtk3: make sure gtk3 libs are found

### DIFF
--- a/modules/gtk/CMakeLists.txt
+++ b/modules/gtk/CMakeLists.txt
@@ -9,6 +9,7 @@ else()
 endif()
 
 add_definitions(${GTK3_CFLAGS} ${GTK3_CFLAGS_OTHER})
+target_link_directories(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARY_DIRS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${GTK3_LIBRARIES})
 
 target_compile_options(${PROJECT_NAME} PRIVATE


### PR DESCRIPTION
On OpenBSD most third-party libs are in `/usr/local/lib`. 3.0.0 built fine but 3.1.0 fails to build because there's no `-L/usr/local/lib` in the gtk module linking line.

my guess is that it's a regression from #2506.. but doing this fixes the build for me. Strangely, other modules depending on other 3rd-party libs don't fail to link.....