### PR TITLE
release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to baresip will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.0 - 2023-05-31
+
+## What's Changed
+* ci: add coverage workflow by @maximilianfridrich in https://github.com/baresip/baresip/pull/2550
+* cmake: fix win32 dbghelp by @sreimers in https://github.com/baresip/baresip/pull/2552
+* cmake/gtk3: make sure gtk3 libs are found by @landryb in https://github.com/baresip/baresip/pull/2554
+* pipewire: add pipewire module by @cspiel1 in https://github.com/baresip/baresip/pull/2439
+* audio: count TX underruns correctly (#2535) by @cspiel1 in https://github.com/baresip/baresip/pull/2553
+* variadic function fixes by @maximilianfridrich in https://github.com/baresip/baresip/pull/2523
+* ua: unescape incoming Refer-To header by @maximilianfridrich in https://github.com/baresip/baresip/pull/2541
+* pipewire/cmake: declare include dirs as system by @sreimers in https://github.com/baresip/baresip/pull/2556
+* sndio: re-add sndio module for OpenBSD by @landryb in https://github.com/baresip/baresip/pull/2555
+* Client cert renegotiation in http by @fAuernigg in https://github.com/baresip/baresip/pull/2461
+* aufile: joind already terminated thread frees stack by @cspiel1 in https://github.com/baresip/baresip/pull/2557
+* ccheck: c11 err handling exclude mutex\_alloc by @sreimers in https://github.com/baresip/baresip/pull/2560
+* alsa: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2558
+* Add instruction to build the doxygen docs by @gibix in https://github.com/baresip/baresip/pull/2561
+* fakevideo: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2565
+* cmake/findOpus: fix Could NOT find OPUS (missing: OPUS\_INCLUDE\_DIR) by @jobo-zt in https://github.com/baresip/baresip/pull/2568
+* cmake/findsdl: fix Could NOT find SDL (missing: SDL\_INCLUDE\_DIR) by @jobo-zt in https://github.com/baresip/baresip/pull/2571
+* avformat, g722: add macro UNISTD switch support for Windows by @jobo-zt in https://github.com/baresip/baresip/pull/2574
+* v4l2: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2567
+* mc: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2566
+* avformat: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2564
+* ausine: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2563
+* aubridge: use atomic for run flag by @cspiel1 in https://github.com/baresip/baresip/pull/2562
+* config: add different options for audio and video jitter buffer by @sreimers in https://github.com/baresip/baresip/pull/2569
+* Revert "ua: unescape incoming Refer-To header (#2541)" by @maximilianfridrich in https://github.com/baresip/baresip/pull/2577
+* stream: log last RTP packet debug after 100ms by @sreimers in https://github.com/baresip/baresip/pull/2587
+* ci/sanitizers: exit on first undefined behavior by @sreimers in https://github.com/baresip/baresip/pull/2589
+
+## New Contributors
+* @landryb made their first contribution in https://github.com/baresip/baresip/pull/2554
+* @gibix made their first contribution in https://github.com/baresip/baresip/pull/2561
+* @jobo-zt made their first contribution in https://github.com/baresip/baresip/pull/2568
+
+**Full Changelog**: https://github.com/baresip/baresip/compare/v3.1.0...v3.2.0
+
 ## 3.1.0 - 2023-04-27
 
 ## What's Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010 - 2022 Alfred E. Heggestad
 # Copyright (C) 2022 Sebastian Reimers
+# Copyright (C) 2023 Christian Spielberger
 #
 
 ##############################################################################
@@ -12,9 +13,9 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(baresip VERSION 3.1.0)
+project(baresip VERSION 3.2.0)
 
-set(PROJECT_SOVERSION 6) # bump if ABI breaks
+set(PROJECT_SOVERSION 7) # bump if ABI breaks
 
 # Pre-release identifier, comment out on a release
 # Increment for breaking changes (dev2, dev3...)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+baresip (3.2.0) unstable; urgency=medium
+
+  * version 3.2.0
+
+ -- Christian Spielberger <c.spielberger@commend.com>  Wed, 31 May 2023 08:00:00 +0200
+
 baresip (3.1.0) unstable; urgency=medium
 
   * version 3.1.0

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -13,7 +13,7 @@ extern "C" {
 
 
 /** Defines the Baresip version string */
-#define BARESIP_VERSION "3.1.0"
+#define BARESIP_VERSION "3.2.0"
 
 
 #ifndef NET_MAX_NS

--- a/mk/Doxyfile
+++ b/mk/Doxyfile
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 PROJECT_NAME           = baresip
-PROJECT_NUMBER         = 3.1.0
+PROJECT_NUMBER         = 3.2.0
 OUTPUT_DIRECTORY       = ../baresip-dox
 CREATE_SUBDIRS         = NO
 OUTPUT_LANGUAGE        = English


### PR DESCRIPTION
ABI increased because of
```patch
@@ -382,8 +382,14 @@ struct config_avt {
        struct range rtp_ports; /**< RTP port range                 */
        struct range rtp_bw;    /**< RTP Bandwidth range [bit/s]    */
        bool rtcp_mux;          /**< RTP/RTCP multiplexing          */
-       enum jbuf_type jbtype;  /**< Jitter buffer type             */
-       struct range jbuf_del;  /**< Delay, number of frames        */
+       struct {
+               enum jbuf_type jbtype;  /**< Jitter buffer type     */
+               struct range jbuf_del;  /**< Delay, number of frames*/
+       } audio;
+       struct {
+               enum jbuf_type jbtype;  /**< Jitter buffer type     */
+               struct range jbuf_del;  /**< Delay, number of frames*/
+       } video;
```