### PR TITLE
Fix oneway video sdp on answering call

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -256,6 +256,7 @@ const char   *call_user_data(const struct call *call);
 int call_set_user_data(struct call *call, const char *user_data);
 void call_set_evstop(struct call *call, bool stop);
 bool call_is_evstop(struct call *call);
+bool call_sent_answer(const struct call *call);
 
 /*
  * Custom headers

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -158,7 +158,11 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 
-	(void)call_set_media_estdir(call, adir, vdir);
+	if (call_sent_answer(call))
+		(void)call_set_media_estdir(call, adir, vdir);
+	else
+		(void)call_set_media_direction(call, adir, vdir);
+
 	err = answer_call(ua, call);
 	if (err)
 		re_hprintf(pf, "could not answer call (%m)\n", err);


### PR DESCRIPTION
BareSIP currently showed the following erroneous behavior when acting as the callee:

- Incoming INVITE with video=recvonly
- We answer the call using `/acceptdir` with video=recvonly
- BareSIP sends 200 OK with video=sendonly (wrong! we don't want to send video)
- BareSIP receives ACK
- BareSIP send re-INVITE with video=recvonly (to which peer answers with video=inactive)

Now, this is fixed and the behavior is as follows:

- Incoming INVITE with video=recvonly
- We answer the call using `/acceptdir` with video=recvonly
- BareSIP sends 200 OK with video=inactive
- No re-INVITES