### PR TITLE
stream: increase udp socket buffer for video

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -571,7 +571,10 @@ static int stream_sock_alloc(struct stream *s, int af)
 
 	udp_rxsz_set(rtp_sock(s->rtp), RTP_RECV_SIZE);
 
-	udp_sockbuf_set(rtp_sock(s->rtp), 65536);
+	if (s->type == MEDIA_VIDEO)
+		udp_sockbuf_set(rtp_sock(s->rtp), 65536 * 8);
+	else
+		udp_sockbuf_set(rtp_sock(s->rtp), 65536);
 
 	return 0;
 }


### PR DESCRIPTION
With higher video codec bitrates, packets are lost because udp recv buffer is to small.