### PR TITLE
stream: faster video jitter buffer offloading

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -473,9 +473,11 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 
 		if (s->type == MEDIA_VIDEO) {
 			/* Read all ready frames */
-			for (int i = 0; i < 1000; i++) {
+			uint32_t n = jbuf_packets(s->rx.jbuf);
+			while (n > 0) {
 				if (stream_decode(s) != EAGAIN)
 					break;
+				--n;
 			}
 		}
 		else {

--- a/src/stream.c
+++ b/src/stream.c
@@ -474,10 +474,9 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 		if (s->type == MEDIA_VIDEO) {
 			/* Read all ready frames */
 			uint32_t n = jbuf_packets(s->rx.jbuf);
-			while (n > 0) {
+			while (n--) {
 				if (stream_decode(s) != EAGAIN)
 					break;
-				--n;
 			}
 		}
 		else {

--- a/src/stream.c
+++ b/src/stream.c
@@ -471,9 +471,14 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 			metric_inc_err(s->rx.metric);
 		}
 
-
-		if (stream_decode(s) == EAGAIN)
-			(void) stream_decode(s);
+		if (s->type == MEDIA_VIDEO) {
+			/* Read all ready frames */
+			while (stream_decode(s) == EAGAIN);
+		}
+		else {
+			if (stream_decode(s) == EAGAIN)
+				(void)stream_decode(s);
+		}
 	}
 	else {
 		(void)handle_rtp(s, hdr, mb, 0, false);

--- a/src/stream.c
+++ b/src/stream.c
@@ -473,7 +473,10 @@ static void rtp_handler(const struct sa *src, const struct rtp_header *hdr,
 
 		if (s->type == MEDIA_VIDEO) {
 			/* Read all ready frames */
-			while (stream_decode(s) == EAGAIN);
+			for (int i = 0; i < 1000; i++) {
+				if (stream_decode(s) != EAGAIN)
+					break;
+			}
 		}
 		else {
 			if (stream_decode(s) == EAGAIN)


### PR DESCRIPTION
With higher bitrates video decoding freezes sometimes since jitter buffer offloading is not fast enough.