### PR TITLE
video/decode: add timestamp

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1214,9 +1214,9 @@ typedef int (videnc_packetize_h)(struct videnc_state *ves,
 
 typedef int (viddec_update_h)(struct viddec_state **vdsp,
 			      const struct vidcodec *vc, const char *fmtp);
-typedef int (viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
-                              bool *intra, bool marker, uint16_t seq,
-                              struct mbuf *mb);
+typedef int(viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
+			     bool *intra, bool marker, uint16_t seq,
+			     uint64_t ts, struct mbuf *mb);
 
 struct vidcodec {
 	struct le le;

--- a/modules/av1/av1.h
+++ b/modules/av1/av1.h
@@ -18,5 +18,5 @@ int av1_encode_packetize(struct videnc_state *ves,
 /* Decode */
 int av1_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
 		      const char *fmtp);
-int av1_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
+int av1_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb);

--- a/modules/av1/decode.c
+++ b/modules/av1/decode.c
@@ -140,8 +140,8 @@ static int copy_obu(struct mbuf *mb_bs, const uint8_t *buf, size_t size)
 }
 
 
-int av1_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb)
+int av1_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb)
 {
 	aom_codec_frame_flags_t flags;
 	aom_codec_iter_t iter = NULL;
@@ -150,6 +150,8 @@ int av1_decode(struct viddec_state *vds, struct vidframe *frame,
 	struct av1_aggr_hdr hdr;
 	struct mbuf *mb2 = NULL;
 	int err;
+
+	(void)ts;
 
 	if (!vds || !frame || !intra || !mb)
 		return EINVAL;

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -40,9 +40,11 @@ struct viddec_state;
 int avcodec_decode_update(struct viddec_state **vdsp,
 			  const struct vidcodec *vc, const char *fmtp);
 int avcodec_decode_h264(struct viddec_state *st, struct vidframe *frame,
-		bool *intra, bool eof, uint16_t seq, struct mbuf *src);
+			bool *intra, bool eof, uint16_t seq, uint64_t ts,
+			struct mbuf *src);
 int avcodec_decode_h265(struct viddec_state *st, struct vidframe *frame,
-			bool *intra, bool eof, uint16_t seq, struct mbuf *src);
+			bool *intra, bool eof, uint16_t seq, uint64_t ts,
+			struct mbuf *src);
 
 
 int avcodec_resolve_codecid(const char *s);

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -293,12 +293,14 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 
 
 int avcodec_decode_h264(struct viddec_state *st, struct vidframe *frame,
-			bool *intra, bool marker, uint16_t seq,
+			bool *intra, bool marker, uint16_t seq, uint64_t ts,
 			struct mbuf *src)
 {
 	struct h264_nal_header h264_hdr;
 	const uint8_t nal_seq[3] = {0, 0, 1};
 	int err;
+
+	(void)ts;
 
 	if (!st || !frame || !intra || !src)
 		return EINVAL;
@@ -488,11 +490,14 @@ static inline int h265_fu_decode(struct h265_fu *fu, struct mbuf *mb)
 
 
 int avcodec_decode_h265(struct viddec_state *vds, struct vidframe *frame,
-		       bool *intra, bool marker, uint16_t seq, struct mbuf *mb)
+			bool *intra, bool marker, uint16_t seq, uint64_t ts,
+			struct mbuf *mb)
 {
 	static const uint8_t nal_seq[3] = {0, 0, 1};
 	struct h265_nal hdr;
 	int err;
+
+	(void)ts;
 
 	if (!vds || !frame || !intra || !mb)
 		return EINVAL;

--- a/modules/vp8/decode.c
+++ b/modules/vp8/decode.c
@@ -185,14 +185,16 @@ static inline bool is_keyframe(struct mbuf *mb)
 }
 
 
-int vp8_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb)
+int vp8_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb)
 {
 	vpx_codec_iter_t iter = NULL;
 	vpx_codec_err_t res;
 	vpx_image_t *img;
 	struct hdr hdr;
 	int err, i;
+
+	(void)ts;
 
 	if (!vds || !frame || !intra || !mb)
 		return EINVAL;

--- a/modules/vp8/vp8.h
+++ b/modules/vp8/vp8.h
@@ -22,8 +22,8 @@ int vp8_encode_packetize(struct videnc_state *ves,
 /* Decode */
 int vp8_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
 		      const char *fmtp);
-int vp8_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
+int vp8_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb);
 
 
 /* SDP */

--- a/modules/vp9/decode.c
+++ b/modules/vp9/decode.c
@@ -261,14 +261,16 @@ static inline bool is_keyframe(const struct mbuf *mb)
 }
 
 
-int vp9_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb)
+int vp9_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb)
 {
 	vpx_codec_iter_t iter = NULL;
 	vpx_codec_err_t res;
 	vpx_image_t *img;
 	struct hdr hdr;
 	int err, i;
+
+	(void)ts;
 
 	if (!vds || !frame || !intra || !mb)
 		return EINVAL;

--- a/modules/vp9/vp9.h
+++ b/modules/vp9/vp9.h
@@ -22,9 +22,8 @@ int vp9_encode_packetize(struct videnc_state *ves,
 /* Decode */
 int vp9_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
 		      const char *fmtp);
-int vp9_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
-
+int vp9_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, uint64_t ts, struct mbuf *mb);
 
 /* SDP */
 uint32_t vp9_max_fs(const char *fmtp);

--- a/src/video.c
+++ b/src/video.c
@@ -763,7 +763,8 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	vidframe_clear(frame);
 
-	err = vrx->vc->dech(vrx->dec, frame, &intra, hdr->m, hdr->seq, mb);
+	err = vrx->vc->dech(vrx->dec, frame, &intra, hdr->m, hdr->seq,
+			    timestamp, mb);
 	if (err) {
 
 		if (err != EPROTO) {

--- a/test/mock/mock_vidcodec.c
+++ b/test/mock/mock_vidcodec.c
@@ -142,13 +142,15 @@ static int mock_decode_update(struct viddec_state **vdsp,
 
 
 static int mock_decode(struct viddec_state *vds, struct vidframe *frame,
-		       bool *intra, bool marker, uint16_t seq, struct mbuf *mb)
+		       bool *intra, bool marker, uint16_t seq, uint64_t ts,
+		       struct mbuf *mb)
 {
 	struct vidsz size;
 	struct hdr hdr;
 	int err, i;
 	(void)marker;
 	(void)seq;
+	(void)ts;
 
 	if (!vds || !frame || !intra || !mb)
 		return EINVAL;


### PR DESCRIPTION
It can be useful to have access to the timestamp when decoding. For example a codec module can forward packets directly, like a SFU (Selective Forwarding Unit).