### PR TITLE
webrtc: remove G711 module

### DIFF
--- a/webrtc/src/main.c
+++ b/webrtc/src/main.c
@@ -32,7 +32,6 @@ static const char *modv[] = {
 	/* audio */
 	"opus",
 	"g722",
-	"g711",
 	"ausine",
 
 	/* video */


### PR DESCRIPTION
The Opus audio codec is used most of the time.