### PR TITLE
video,stream: stop natpinhole timer on re-invite

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1429,7 +1429,6 @@ int  stream_start_mediaenc(struct stream *strm);
 int  stream_start_rtcp(const struct stream *strm);
 int  stream_enable(struct stream *strm, bool enable);
 int  stream_enable_tx(struct stream *strm, bool enable);
-int stream_open_natpinhole(struct stream *strm);
 void stream_mnat_attr(struct stream *strm, const char *name,
 		      const char *value);
 void stream_set_session_handlers(struct stream *strm,

--- a/src/core.h
+++ b/src/core.h
@@ -314,6 +314,8 @@ struct bundle *stream_bundle(const struct stream *strm);
 void stream_parse_mid(struct stream *strm);
 void stream_enable_bundle(struct stream *strm, enum bundle_state st);
 void stream_enable_natpinhole(struct stream *strm, bool enable);
+void stream_open_natpinhole(struct stream *strm);
+void stream_stop_natpinhole(struct stream *strm);
 
 
 /*

--- a/src/stream.c
+++ b/src/stream.c
@@ -1622,18 +1622,23 @@ int stream_enable(struct stream *strm, bool enable)
  * Open NAT-pinhole via RTP empty package
  *
  * @param strm	Stream object
- *
- * @return int 0 if success, otherwise errorcode
  */
-int stream_open_natpinhole(struct stream *strm)
+void stream_open_natpinhole(struct stream *strm)
 {
 	if (!strm)
-		return EINVAL;
+		return;
 
 	if (strm->pinhole)
 		tmr_start(&strm->tmr_natph, 10, natpinhole_handler, strm);
+}
 
-	return 0;
+
+void stream_stop_natpinhole(struct stream *strm)
+{
+	if (!strm)
+		return;
+
+	tmr_cancel(&strm->tmr_natph);
 }
 
 

--- a/src/video.c
+++ b/src/video.c
@@ -1277,7 +1277,9 @@ int video_update(struct video *v, const char *peer)
 		video_stop_source(v);
 
 	if (dir == SDP_RECVONLY)
-		err |= stream_open_natpinhole(v->strm);
+		stream_open_natpinhole(v->strm);
+	else
+		stream_stop_natpinhole(v->strm);
 
 	if (dir & SDP_RECVONLY) {
 		err |= video_start_display(v, peer);


### PR DESCRIPTION
- If the video stream direction changes from receive only to send-receive,
send-only or inactive, we should stop sending dummy packets.

- Function `stream_open_natpinhole()` is not needed in the API and it doesn't
need to return an error because it can't fail.
