### PR TITLE
test call cancel rules

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -216,37 +216,69 @@ static void process_rules(struct agent *ag, enum ua_event ev, const char *prm)
 			continue;
 
 		if (str_isset(rule->prm) &&
-		    str_casecmp(prm, rule->prm))
+		    str_casecmp(prm, rule->prm)) {
+			info("test: event %s prm=%s (expected %s)\n",
+			     uag_event_str(ev), prm, rule->prm);
 			continue;
+		}
 
 		if (rule->ua &&
-		    ag->ua != rule->ua)
+		    ag->ua != rule->ua) {
+			info("test: event %s ua=[%s] (expected [%s]\n",
+			     uag_event_str(ev),
+			     account_aor(ua_account(ag->ua)),
+			     account_aor(ua_account(rule->ua)));
 			continue;
+		}
 
 		if (rule->n_incoming &&
-		    ag->n_incoming != rule->n_incoming)
+		    ag->n_incoming != rule->n_incoming) {
+			info("test: event %s n_incoming=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     ag->n_incoming, rule->n_incoming);
 			continue;
+		}
 
 		if (rule->n_progress &&
-		    ag->n_progress != rule->n_progress)
+		    ag->n_progress != rule->n_progress) {
+			info("test: event %s n_progress=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     ag->n_progress, rule->n_progress);
 			continue;
+		}
 
 		if (rule->n_established &&
-		    ag->n_established != rule->n_established)
+		    ag->n_established != rule->n_established) {
+			info("test: event %s n_established=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     ag->n_established, rule->n_established);
 			continue;
+		}
 
 		if (rule->n_audio_estab &&
-		    ag->n_audio_estab != rule->n_audio_estab)
+		    ag->n_audio_estab != rule->n_audio_estab) {
+			info("test: event %s n_audio_estab=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     ag->n_audio_estab, rule->n_audio_estab);
 			continue;
+		}
 
 		if (rule->n_video_estab &&
-		    ag->n_video_estab != rule->n_video_estab)
+		    ag->n_video_estab != rule->n_video_estab) {
+			info("test: event %s n_video_estab=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     ag->n_video_estab, rule->n_video_estab);
 			continue;
+		}
 
 		++f->n_rules_ok;
 		if (rule->n_rules_ok &&
-		    rule->n_rules_ok < f->n_rules_ok)
+		    rule->n_rules_ok < f->n_rules_ok) {
+			info("test: event %s n_rules_ok=%u (expected %u)\n",
+			     uag_event_str(ev),
+			     f->n_rules_ok, rule->n_rules_ok);
 			continue;
+		}
 
 		re_cancel();
 	}

--- a/test/call.c
+++ b/test/call.c
@@ -172,6 +172,7 @@ struct fixture {
 
 static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
 						   enum ua_event ev,
+						   struct ua *ua,
 						   unsigned n_incoming,
 						   unsigned n_progress,
 						   unsigned n_established)
@@ -181,6 +182,7 @@ static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
 		return NULL;
 
 	r->ev = ev;
+	r->ua = ua;
 	r->n_incoming    = n_incoming;
 	r->n_progress    = n_progress;
 	r->n_established = n_established;
@@ -190,8 +192,8 @@ static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
 }
 
 
-#define fixture_cancel_rule(f, ev, n_incoming, n_progress, n_established) \
-	cr = fixture_add_cancel_rule(f, ev, n_incoming, n_progress,	  \
+#define cancel_rule_new(ev, ua, n_incoming, n_progress, n_established)    \
+	cr = fixture_add_cancel_rule(f, ev, ua, n_incoming, n_progress,   \
 				     n_established);			  \
 	if (!cr) {							  \
 		err = ENOMEM;						  \
@@ -1050,7 +1052,7 @@ int test_call_change_videodir(void)
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
 
 	fixture_init(f);
-	fixture_cancel_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
+	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
 
 	/* to enable video, we need one vidsrc and vidcodec */
 	mock_vidcodec_register();
@@ -1216,7 +1218,7 @@ int test_call_progress(void)
 	int err = 0;
 
 	fixture_init(f);
-	fixture_cancel_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
+	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
 
 	f->behaviour = BEHAVIOUR_PROGRESS;
 

--- a/test/call.c
+++ b/test/call.c
@@ -46,7 +46,6 @@ struct cancel_rule {
 	unsigned n_video_estab;
 	unsigned n_offer_cnt;
 	unsigned n_answer_cnt;
-	unsigned n_rules_ok;
 };
 
 
@@ -94,7 +93,6 @@ struct fixture {
 	bool stop_on_audio_video;
 	bool accept_session_updates;
 	struct list rules;
-	unsigned n_rules_ok;
 };
 
 
@@ -277,15 +275,6 @@ static void process_rules(struct agent *ag, enum ua_event ev, const char *prm)
 			info("test: event %s n_video_estab=%u (expected %u)\n",
 			     uag_event_str(ev),
 			     ag->n_video_estab, rule->n_video_estab);
-			continue;
-		}
-
-		++f->n_rules_ok;
-		if (rule->n_rules_ok &&
-		    rule->n_rules_ok < f->n_rules_ok) {
-			info("test: event %s n_rules_ok=%u (expected %u)\n",
-			     uag_event_str(ev),
-			     f->n_rules_ok, rule->n_rules_ok);
 			continue;
 		}
 

--- a/test/call.c
+++ b/test/call.c
@@ -172,11 +172,11 @@ struct fixture {
 	} while (0)
 
 
-static struct cancel_rule *fixture_add_rule(struct fixture *f,
-					  enum ua_event ev,
-					  unsigned n_incoming,
-					  unsigned n_progress,
-					  unsigned n_established)
+static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
+						   enum ua_event ev,
+						   unsigned n_incoming,
+						   unsigned n_progress,
+						   unsigned n_established)
 {
 	struct cancel_rule *r = mem_zalloc(sizeof(*r), NULL);
 	if (!r)
@@ -190,6 +190,15 @@ static struct cancel_rule *fixture_add_rule(struct fixture *f,
 	list_append(&f->rules, &r->le, r);
 	return r;
 }
+
+
+#define fixture_cancel_rule(f, ev, n_incoming, n_progress, n_established) \
+	cr = fixture_add_cancel_rule(f, ev, n_incoming, n_progress,	  \
+				     n_established);			  \
+	if (!cr) {							  \
+		err = ENOMEM;						  \
+		goto out;						  \
+	}
 
 
 static const struct list *hdrs;
@@ -1045,13 +1054,14 @@ int test_call_change_videodir(void)
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
 	enum sdp_dir a_video_ldir, a_video_rdir, b_video_ldir, b_video_rdir;
+	struct cancel_rule *cr;
 	int err = 0;
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
 
 	fixture_init(f);
-	fixture_add_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
+	fixture_cancel_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
 
 	/* to enable video, we need one vidsrc and vidcodec */
 	mock_vidcodec_register();
@@ -1213,10 +1223,11 @@ int test_call_aulevel(void)
 int test_call_progress(void)
 {
 	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
 	int err = 0;
 
 	fixture_init(f);
-	fixture_add_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
+	fixture_cancel_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
 
 	f->behaviour = BEHAVIOUR_PROGRESS;
 

--- a/test/call.c
+++ b/test/call.c
@@ -328,7 +328,6 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 	case UA_EVENT_CALL_PROGRESS:
 		++ag->n_progress;
 
-		re_cancel();
 		break;
 
 	case UA_EVENT_CALL_ESTABLISHED:
@@ -1020,6 +1019,7 @@ int test_call_change_videodir(void)
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
 
 	fixture_init(f);
+	fixture_add_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
 
 	/* to enable video, we need one vidsrc and vidcodec */
 	mock_vidcodec_register();
@@ -1184,6 +1184,7 @@ int test_call_progress(void)
 	int err = 0;
 
 	fixture_init(f);
+	fixture_add_rule(f, UA_EVENT_CALL_PROGRESS, 0, 1, 0);
 
 	f->behaviour = BEHAVIOUR_PROGRESS;
 


### PR DESCRIPTION
Rules can be added to a test fixture when to cancel the re main loop. This should simplify the UA event handler and keep the business logic of the test-case in the test function.

This PR adds a first cancel rule for the CALL_PROGRESS event.  More rules that will simplify the event handler will follow.

- test: call - rules for re_cancel
- test: call - use rule to cancel on UA_EVENT_CALL_PROGRESS
- test: call - print info if rule does not match

Note: We plan to simplify `test_call_change_videodir()`. Then add more early media tests, 100rel tests, audio codec switches, SIP UPDATE.  This should ensure stability of https://github.com/baresip/baresip/pull/2454.

Here is a branch with more commits based on this: https://github.com/cspiel1/baresip/tree/test_call_simplify1