### PR TITLE
video: use const struct video for videnc_update_h and viddec_update_h

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1198,12 +1198,12 @@ struct vidcodec;
 typedef int (videnc_packet_h)(bool marker, uint64_t rtp_ts,
 			      const uint8_t *hdr, size_t hdr_len,
 			      const uint8_t *pld, size_t pld_len,
-			      void *arg);
+			      const struct video *vid);
 
 typedef int (videnc_update_h)(struct videnc_state **vesp,
 			      const struct vidcodec *vc,
 			      struct videnc_param *prm, const char *fmtp,
-			      videnc_packet_h *pkth, void *arg);
+			      videnc_packet_h *pkth, const struct video *vid);
 
 typedef int (videnc_encode_h)(struct videnc_state *ves, bool update,
 			      const struct vidframe *frame,
@@ -1212,8 +1212,10 @@ typedef int (videnc_encode_h)(struct videnc_state *ves, bool update,
 typedef int (videnc_packetize_h)(struct videnc_state *ves,
 				 const struct vidpacket *packet);
 
-typedef int (viddec_update_h)(struct viddec_state **vdsp,
-			      const struct vidcodec *vc, const char *fmtp);
+typedef int(viddec_update_h)(struct viddec_state **vdsp,
+			     const struct vidcodec *vc, const char *fmtp,
+			     const struct video *vid);
+
 typedef int (viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
                               bool *intra, bool marker, uint16_t seq,
                               struct mbuf *mb);

--- a/modules/av1/av1.h
+++ b/modules/av1/av1.h
@@ -8,7 +8,7 @@
 /* Encode */
 int av1_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
-		      videnc_packet_h *pkth, void *arg);
+		      videnc_packet_h *pkth, const struct video *vid);
 int av1_encode_packet(struct videnc_state *ves, bool update,
 		      const struct vidframe *frame, uint64_t timestamp);
 int av1_encode_packetize(struct videnc_state *ves,
@@ -17,6 +17,6 @@ int av1_encode_packetize(struct videnc_state *ves,
 
 /* Decode */
 int av1_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		      const char *fmtp);
-int av1_decode(struct viddec_state *vds, struct vidframe *frame,
-	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
+		      const char *fmtp, const struct video *vid);
+int av1_decode(struct viddec_state *vds, struct vidframe *frame, bool *intra,
+	       bool marker, uint16_t seq, struct mbuf *mb);

--- a/modules/av1/decode.c
+++ b/modules/av1/decode.c
@@ -42,7 +42,7 @@ static void destructor(void *arg)
 
 
 int av1_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		       const char *fmtp)
+		       const char *fmtp, const struct video *vid)
 {
 	struct viddec_state *vds;
 	aom_codec_dec_cfg_t cfg = {
@@ -52,6 +52,7 @@ int av1_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
 	int err = 0;
 	(void)vc;
 	(void)fmtp;
+	(void)vid;
 
 	if (!vdsp)
 		return EINVAL;

--- a/modules/av1/encode.c
+++ b/modules/av1/encode.c
@@ -28,7 +28,7 @@ struct videnc_state {
 	unsigned pktsize;
 	bool ctxup;
 	videnc_packet_h *pkth;
-	void *arg;
+	const struct video *vid;
 };
 
 
@@ -43,7 +43,7 @@ static void destructor(void *arg)
 
 int av1_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
-		      videnc_packet_h *pkth, void *arg)
+		      videnc_packet_h *pkth, const struct video *vid)
 {
 	struct videnc_state *ves;
 	(void)fmtp;
@@ -74,7 +74,7 @@ int av1_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 	ves->pktsize = prm->pktsize;
 	ves->fps     = prm->fps;
 	ves->pkth    = pkth;
-	ves->arg     = arg;
+	ves->vid     = vid;
 
 	return 0;
 }
@@ -138,7 +138,8 @@ static int packetize_rtp(struct videnc_state *ves,
 	bool new_flag = keyframe;
 
 	return av1_packetize_high(&new_flag, true, rtp_ts, buf, size,
-				ves->pktsize, ves->pkth, ves->arg);
+				  ves->pktsize, (av1_packet_h *)ves->pkth,
+				  (void *)ves->vid);
 }
 
 

--- a/modules/avcodec/avcodec.h
+++ b/modules/avcodec/avcodec.h
@@ -23,9 +23,9 @@ extern enum AVHWDeviceType avcodec_hw_type;
 struct videnc_state;
 
 int avcodec_encode_update(struct videnc_state **vesp,
-			  const struct vidcodec *vc,
-			  struct videnc_param *prm, const char *fmtp,
-			  videnc_packet_h *pkth, void *arg);
+			  const struct vidcodec *vc, struct videnc_param *prm,
+			  const char *fmtp, videnc_packet_h *pkth,
+			  const struct video *vid);
 int avcodec_encode(struct videnc_state *st, bool update,
 		   const struct vidframe *frame, uint64_t timestamp);
 int avcodec_packetize(struct videnc_state *st, const struct vidpacket *packet);
@@ -38,7 +38,8 @@ int avcodec_packetize(struct videnc_state *st, const struct vidpacket *packet);
 struct viddec_state;
 
 int avcodec_decode_update(struct viddec_state **vdsp,
-			  const struct vidcodec *vc, const char *fmtp);
+			  const struct vidcodec *vc, const char *fmtp,
+			  const struct video *vid);
 int avcodec_decode_h264(struct viddec_state *st, struct vidframe *frame,
 		bool *intra, bool eof, uint16_t seq, struct mbuf *src);
 int avcodec_decode_h265(struct viddec_state *st, struct vidframe *frame,

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -157,7 +157,8 @@ static int init_decoder(struct viddec_state *st, const char *name)
 
 
 int avcodec_decode_update(struct viddec_state **vdsp,
-			  const struct vidcodec *vc, const char *fmtp)
+			  const struct vidcodec *vc, const char *fmtp,
+			  const struct video *vid)
 {
 	struct viddec_state *st;
 	int err = 0;
@@ -169,6 +170,7 @@ int avcodec_decode_update(struct viddec_state **vdsp,
 		return 0;
 
 	(void)fmtp;
+	(void)vid;
 
 	st = mem_zalloc(sizeof(*st), destructor);
 	if (!st)

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -33,7 +33,7 @@ struct videnc_state {
 	enum vidfmt fmt;
 	enum AVCodecID codec_id;
 	videnc_packet_h *pkth;
-	void *arg;
+	const struct video *vid;
 
 	union {
 		struct {
@@ -323,9 +323,9 @@ static void param_handler(const struct pl *name, const struct pl *val,
 
 
 int avcodec_encode_update(struct videnc_state **vesp,
-			  const struct vidcodec *vc,
-			  struct videnc_param *prm, const char *fmtp,
-			  videnc_packet_h *pkth, void *arg)
+			  const struct vidcodec *vc, struct videnc_param *prm,
+			  const char *fmtp, videnc_packet_h *pkth,
+			  const struct video *vid)
 {
 	struct videnc_state *st;
 	int err = 0;
@@ -341,8 +341,8 @@ int avcodec_encode_update(struct videnc_state **vesp,
 		return ENOMEM;
 
 	st->encprm = *prm;
-	st->pkth = pkth;
-	st->arg = arg;
+	st->pkth   = pkth;
+	st->vid	   = vid;
 
 	st->codec_id = avcodec_resolve_codecid(vc->name);
 	if (st->codec_id == AV_CODEC_ID_NONE) {
@@ -498,16 +498,16 @@ int avcodec_encode(struct videnc_state *st, bool update,
 	switch (st->codec_id) {
 
 	case AV_CODEC_ID_H264:
-		err = h264_packetize(ts, pkt->data, pkt->size,
-				     st->encprm.pktsize,
-				     st->pkth, st->arg);
+		err = h264_packetize(
+			ts, pkt->data, pkt->size, st->encprm.pktsize,
+			(h264_packet_h *)st->pkth, (void *)st->vid);
 		break;
 
 #ifdef AV_CODEC_ID_H265
 	case AV_CODEC_ID_H265:
-		err = h265_packetize(ts, pkt->data, pkt->size,
-				     st->encprm.pktsize,
-				     st->pkth, st->arg);
+		err = h265_packetize(
+			ts, pkt->data, pkt->size, st->encprm.pktsize,
+			(h265_packet_h *)st->pkth, (void *)st->vid);
 		break;
 #endif
 
@@ -540,16 +540,16 @@ int avcodec_packetize(struct videnc_state *st, const struct vidpacket *packet)
 	switch (st->codec_id) {
 
 	case AV_CODEC_ID_H264:
-		err = h264_packetize(ts, packet->buf, packet->size,
-				     st->encprm.pktsize,
-				     st->pkth, st->arg);
+		err = h264_packetize(
+			ts, packet->buf, packet->size, st->encprm.pktsize,
+			(h264_packet_h *)st->pkth, (void *)st->vid);
 		break;
 
 #ifdef AV_CODEC_ID_H265
 	case AV_CODEC_ID_H265:
-		err = h265_packetize(ts, packet->buf, packet->size,
-				     st->encprm.pktsize,
-				     st->pkth, st->arg);
+		err = h265_packetize(
+			ts, packet->buf, packet->size, st->encprm.pktsize,
+			(h265_packet_h *)st->pkth, (void *)st->vid);
 		break;
 #endif
 

--- a/modules/vp8/decode.c
+++ b/modules/vp8/decode.c
@@ -56,13 +56,14 @@ static void destructor(void *arg)
 
 
 int vp8_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		       const char *fmtp)
+		      const char *fmtp, const struct video *vid)
 {
 	struct viddec_state *vds;
 	vpx_codec_err_t res;
 	int err = 0;
 	(void)vc;
 	(void)fmtp;
+	(void)vid;
 
 	if (!vdsp)
 		return EINVAL;

--- a/modules/vp8/vp8.h
+++ b/modules/vp8/vp8.h
@@ -12,7 +12,7 @@ struct vp8_vidcodec {
 /* Encode */
 int vp8_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
-		      videnc_packet_h *pkth, void *arg);
+		      videnc_packet_h *pkth, const struct video *vid);
 int vp8_encode(struct videnc_state *ves, bool update,
 	       const struct vidframe *frame, uint64_t timestamp);
 int vp8_encode_packetize(struct videnc_state *ves,
@@ -21,7 +21,7 @@ int vp8_encode_packetize(struct videnc_state *ves,
 
 /* Decode */
 int vp8_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		      const char *fmtp);
+		      const char *fmtp, const struct video *vid);
 int vp8_decode(struct viddec_state *vds, struct vidframe *frame,
 	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
 

--- a/modules/vp9/decode.c
+++ b/modules/vp9/decode.c
@@ -68,13 +68,14 @@ static void destructor(void *arg)
 
 
 int vp9_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		       const char *fmtp)
+		      const char *fmtp, const struct video *vid)
 {
 	struct viddec_state *vds;
 	vpx_codec_err_t res;
 	int err = 0;
 	(void)vc;
 	(void)fmtp;
+	(void)vid;
 
 	if (!vdsp)
 		return EINVAL;

--- a/modules/vp9/encode.c
+++ b/modules/vp9/encode.c
@@ -27,7 +27,7 @@ struct videnc_state {
 	bool ctxup;
 	uint16_t picid;
 	videnc_packet_h *pkth;
-	void *arg;
+	const struct video *vid;
 
 	unsigned n_frames;
 	unsigned n_key_frames;
@@ -54,7 +54,7 @@ static void destructor(void *arg)
 
 int vp9_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
-		      videnc_packet_h *pkth, void *arg)
+		      videnc_packet_h *pkth, const struct video *vid)
 {
 	const struct vp9_vidcodec *vp9 = (struct vp9_vidcodec *)vc;
 	struct videnc_state *ves;
@@ -89,7 +89,7 @@ int vp9_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 	ves->pktsize = prm->pktsize;
 	ves->fps     = prm->fps;
 	ves->pkth    = pkth;
-	ves->arg     = arg;
+	ves->vid     = vid;
 
 	max_fs = vp9_max_fs(fmtp);
 	if (max_fs > 0)
@@ -176,7 +176,7 @@ static int send_packet(struct videnc_state *ves, bool marker,
 	ves->n_bytes += (hdr_len + pld_len);
 
 	return ves->pkth(marker, rtp_ts, hdr, hdr_len, pld, pld_len,
-			 ves->arg);
+			 ves->vid);
 }
 
 

--- a/modules/vp9/vp9.h
+++ b/modules/vp9/vp9.h
@@ -12,7 +12,7 @@ struct vp9_vidcodec {
 /* Encode */
 int vp9_encode_update(struct videnc_state **vesp, const struct vidcodec *vc,
 		      struct videnc_param *prm, const char *fmtp,
-		      videnc_packet_h *pkth, void *arg);
+		      videnc_packet_h *pkth, const struct video *vid);
 int vp9_encode(struct videnc_state *ves, bool update,
 	       const struct vidframe *frame, uint64_t timestamp);
 int vp9_encode_packetize(struct videnc_state *ves,
@@ -21,7 +21,7 @@ int vp9_encode_packetize(struct videnc_state *ves,
 
 /* Decode */
 int vp9_decode_update(struct viddec_state **vdsp, const struct vidcodec *vc,
-		      const char *fmtp);
+		      const char *fmtp, const struct video *vid);
 int vp9_decode(struct viddec_state *vds, struct vidframe *frame,
 	       bool *intra, bool marker, uint16_t seq, struct mbuf *mb);
 

--- a/src/video.c
+++ b/src/video.c
@@ -329,15 +329,15 @@ static double get_fps(const struct video *v)
 static int packet_handler(bool marker, uint64_t ts,
 			  const uint8_t *hdr, size_t hdr_len,
 			  const uint8_t *pld, size_t pld_len,
-			  void *arg)
+			  const struct video *vid)
 {
-	struct vtx *vtx = arg;
-	struct stream *strm = vtx->video->strm;
+	struct vtx *vtx = (struct vtx *)&vid->vtx;
+	struct stream *strm = vid->strm;
 	struct vidqent *qent;
 	uint32_t rtp_ts;
 	int err;
 
-	MAGIC_CHECK(vtx->video);
+	MAGIC_CHECK(vid);
 
 	if (!vtx->ts_base)
 		vtx->ts_base = ts;
@@ -1554,7 +1554,7 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 
 		vtx->enc = mem_deref(vtx->enc);
 		err = vc->encupdh(&vtx->enc, vc, &prm, params,
-				  packet_handler, vtx);
+				  packet_handler, v);
 		if (err) {
 			warning("video: encoder alloc: %m\n", err);
 			goto out;
@@ -1609,7 +1609,7 @@ int video_decoder_set(struct video *v, struct vidcodec *vc, int pt_rx,
 
 		vrx->dec = mem_deref(vrx->dec);
 
-		err = vc->decupdh(&vrx->dec, vc, fmtp);
+		err = vc->decupdh(&vrx->dec, vc, fmtp, v);
 		if (err) {
 			warning("video: decoder alloc: %m\n", err);
 			return err;

--- a/test/mock/mock_vidcodec.c
+++ b/test/mock/mock_vidcodec.c
@@ -23,7 +23,7 @@ struct hdr {
 struct videnc_state {
 	double fps;
 	videnc_packet_h *pkth;
-	void *arg;
+	const struct video *vid;
 };
 
 struct viddec_state {
@@ -55,7 +55,7 @@ static void decode_destructor(void *arg)
 static int mock_encode_update(struct videnc_state **vesp,
 			      const struct vidcodec *vc,
 			      struct videnc_param *prm, const char *fmtp,
-			      videnc_packet_h *pkth, void *arg)
+			      videnc_packet_h *pkth, const struct video *vid)
 {
 	struct videnc_state *ves;
 	(void)fmtp;
@@ -76,7 +76,7 @@ static int mock_encode_update(struct videnc_state **vesp,
 
 	ves->fps     = prm->fps;
 	ves->pkth    = pkth;
-	ves->arg     = arg;
+	ves->vid     = vid;
 
 	return 0;
 }
@@ -105,7 +105,7 @@ static int mock_encode(struct videnc_state *ves, bool update,
 	rtp_ts = video_calc_rtp_timestamp_fix(timestamp);
 
 	err = ves->pkth(true, rtp_ts, hdr->buf, hdr->end,
-			payload, sizeof(payload), ves->arg);
+			payload, sizeof(payload), ves->vid);
 	if (err)
 		goto out;
 
@@ -117,11 +117,13 @@ static int mock_encode(struct videnc_state *ves, bool update,
 
 
 static int mock_decode_update(struct viddec_state **vdsp,
-			      const struct vidcodec *vc, const char *fmtp)
+			      const struct vidcodec *vc, const char *fmtp,
+			      const struct video *vid)
 {
 	struct viddec_state *vds;
 	(void)vc;
 	(void)fmtp;
+	(void)vid;
 
 	if (!vdsp)
 		return EINVAL;


### PR DESCRIPTION
With this change it's possible to use `video` getters within codec update callbacks.