### PR TITLE
call: fix Refer-To URI angle brackets

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2823,7 +2823,7 @@ int call_replace_transfer(struct call *call, struct call *source_call)
 			      sipsess_dialog(call->sess), ua_cuser(call->ua),
 			      auth_handler, call->acc, true,
 			      sipsub_notify_handler, sipsub_close_handler,
-			      call, "Refer-To: %s?Replaces=%s\r\n",
+			      call, "Refer-To: <%s?Replaces=%s>\r\n",
 			      source_call->peer_uri, source_call->id);
 	if (err) {
 		warning("call: sipevent_drefer: %m\n", err);


### PR DESCRIPTION
"The Contact, From, and To header fields contain a URI.  If the URI contains a comma, question mark or semicolon, the URI MUST be enclosed in angle brackets (< and >).  Any URI parameters are contained within these brackets.  If the URI is not enclosed in angle brackets, any semicolon-delimited parameters are header-parameters, not URI parameters."

Refs #2676