### PR TITLE
second part of RX thread based on rx_thread_1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(SRCS
   src/audio.c
   src/aufilt.c
   src/auplay.c
+  src/aureceiver.c
   src/ausrc.c
   src/baresip.c
   src/bundle.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ set(SRCS
   src/peerconn.c
   src/play.c
   src/reg.c
+  src/rtprecv.c
   src/rtpstat.c
   src/sdp.c
   src/sipreq.c

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -72,6 +72,7 @@ video_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
 rtp_stats		no
 #rtp_timeout		60
 #avt_bundle		no
+#rtp_rxmode		main            # main,thread
 
 # Network
 #dns_server		1.1.1.1:53

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1183,6 +1183,7 @@ void aucodec_unregister(struct aucodec *ac);
 const struct aucodec *aucodec_find(const struct list *aucodecl,
 				   const char *name, uint32_t srate,
 				   uint8_t ch);
+int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1183,7 +1183,6 @@ void aucodec_unregister(struct aucodec *ac);
 const struct aucodec *aucodec_find(const struct list *aucodecl,
 				   const char *name, uint32_t srate,
 				   uint8_t ch);
-int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -317,6 +317,11 @@ enum audio_mode {
 	AUDIO_MODE_THREAD,           /**< Use dedicated thread          */
 };
 
+/** RTP receive mode */
+enum rtp_receive_mode {
+	RECEIVE_MODE_MAIN = 0,  /**< RTP RX is processed in main thread      */
+	RECEIVE_MODE_THREAD,    /**< RTP RX is processed in separate thread  */
+};
 
 /** SIP User-Agent */
 struct config_sip {
@@ -396,6 +401,7 @@ struct config_avt {
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 	bool bundle;            /**< Media Multiplexing (BUNDLE)    */
+	enum rtp_receive_mode rxmode;   /**< RTP RX processing mode */
 };
 
 /** Network Configuration */
@@ -1431,6 +1437,7 @@ int  stream_start_mediaenc(struct stream *strm);
 int  stream_start_rtcp(const struct stream *strm);
 int  stream_enable(struct stream *strm, bool enable);
 int  stream_enable_tx(struct stream *strm, bool enable);
+int  stream_enable_rx(struct stream *strm, bool enable);
 void stream_mnat_attr(struct stream *strm, const char *name,
 		      const char *value);
 void stream_set_session_handlers(struct stream *strm,

--- a/src/audio.c
+++ b/src/audio.c
@@ -224,6 +224,7 @@ static void audio_destructor(void *arg)
 
 	debug("audio: destroyed (started=%d)\n", a->started);
 
+	stream_enable(a->strm, false);
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -569,9 +569,6 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	struct auframe afr;
 	struct aurx *rx = &a->rx;
 
-	if (!rx->auplay)
-		return;
-
 	if (!rx->first_write)
 		afr = *af;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -127,12 +127,12 @@ struct aurx {
 	int pt;                       /**< Payload type for incoming RTP   */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
 
-	struct aurpipe *aup;          /**< Audio receive pipeline          */
+	struct audio_recv *aup;       /**< Audio receive pipeline          */
 	bool first_write;             /**< First write to auplay           */
 };
 
 
-struct aurpipe;
+struct audio_recv;
 
 
 /** Generic Audio stream */
@@ -536,14 +536,14 @@ static void check_plframe(struct auframe *af1, struct auframe *af2)
 {
 	if ((af1->srate && af1->srate != af2->srate) ||
 	    (af1->ch    && af1->ch    != af2->ch   )) {
-		warning("aurpipe: srate/ch of frame %u/%u vs "
+		warning("audio_recv: srate/ch of frame %u/%u vs "
 			"player %u/%u. Use module auresamp!\n",
 			af1->srate, af1->ch,
 			af2->srate, af2->ch);
 	}
 
 	if (af1->fmt != af2->fmt) {
-		warning("aurpipe: invalid sample formats (%s -> %s). "
+		warning("audio_recv: invalid sample formats (%s -> %s). "
 			"%s\n",
 			aufmt_name(af1->fmt), aufmt_name(af2->fmt),
 			af1->fmt == AUFMT_S16LE ?
@@ -1764,7 +1764,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	const struct aurpipe *aup;
+	const struct audio_recv *aup;
 	size_t sztx;
 	int err;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -117,61 +117,29 @@ struct autx {
 };
 
 
-/**
- * Audio receive/decoder
- *
- \verbatim
-
- Processing decoder pipeline:
-
-       .--------.   .-------.   .--------.   .--------.
- |\    |        |   |       |   |        |   |        |
- | |<--| auplay |<--| aubuf |<--| aufilt |<--| decode |<--- RTP
- |/    |        |   |       |   |        |   |        |
-       '--------'   '-------'   '--------'   '--------'
-
- \endverbatim
- */
 struct aurx {
 	const struct auplay *ap;      /**< Audio Player module             */
 	struct auplay_st *auplay;     /**< Audio Player                    */
 	struct auplay_prm auplay_prm; /**< Audio Player parameters         */
-	const struct aucodec *ac;     /**< Current audio decoder           */
-	struct audec_state *dec;      /**< Audio decoder state (optional)  */
-	struct aubuf *aubuf;          /**< Audio buffer before auplay      */
-	uint32_t ssrc;                /**< Incoming synchronization source */
-	size_t aubuf_minsz;           /**< Minimum aubuf size in [bytes]   */
-	size_t aubuf_maxsz;           /**< Maximum aubuf size in [bytes]   */
-	size_t num_bytes;             /**< Size of one frame in [bytes]    */
-	volatile bool aubuf_started;  /**< Aubuf was started flag          */
-	struct list filtl;            /**< Audio filters in decoding order */
 	char *module;                 /**< Audio player module name        */
 	char *device;                 /**< Audio player device name        */
-	void *sampv;                  /**< Sample buffer                   */
 	uint32_t ptime;               /**< Packet time for receiving       */
 	int pt;                       /**< Payload type for incoming RTP   */
-	double level_last;            /**< Last audio level value [dBov]   */
-	bool level_set;               /**< True if level_last is set       */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
-	enum aufmt dec_fmt;           /**< Sample format for decoder       */
-	struct timestamp_recv ts_recv;/**< Receive timestamp state         */
 
-	struct {
-		uint64_t aubuf_overrun;
-		uint64_t aubuf_underrun;
-		uint64_t n_discard;
-	} stats;
-
-	mtx_t *mtx;
-
+	struct aurpipe *aup;          /**< Audio receive pipeline          */
+	bool first_write;             /**< First write to auplay           */
 };
+
+
+struct aurpipe;
 
 
 /** Generic Audio stream */
 struct audio {
 	MAGIC_DECL                    /**< Magic number for debugging      */
 	struct autx tx;               /**< Transmit                        */
-	struct aurx rx;               /**< Receive                         */
+	struct aurx rx;               /**< Audio Receiver                  */
 	struct stream *strm;          /**< Generic media stream            */
 	struct telev *telev;          /**< Telephony events                */
 	struct config_audio cfg;      /**< Audio configuration             */
@@ -200,29 +168,10 @@ static const char *uri_aulevel = "urn:ietf:params:rtp-hdrext:ssrc-audio-level";
  */
 uint64_t audio_jb_current_value(const struct audio *au)
 {
-	const struct aurx *rx;
-
 	if (!au)
 		return 0;
 
-	rx = &au->rx;
-
-	if (rx->aubuf) {
-		uint64_t b_p_ms;  /* bytes per ms */
-
-		b_p_ms = aufmt_sample_size(rx->play_fmt) *
-			rx->auplay_prm.srate * rx->auplay_prm.ch / 1000;
-
-		if (b_p_ms) {
-			uint64_t val;
-
-			val = aubuf_cur_size(rx->aubuf) / b_p_ms;
-
-			return val;
-		}
-	}
-
-	return 0;
+	return aup_latency(au->rx.aup);
 }
 
 
@@ -236,19 +185,6 @@ static double autx_calc_seconds(const struct autx *autx)
 	dur = autx->ts_ext - autx->ts_base;
 
 	return timestamp_calc_seconds(dur, autx->ac->crate);
-}
-
-
-static double aurx_calc_seconds(const struct aurx *aurx)
-{
-	uint64_t dur;
-
-	if (!aurx->ac)
-		return .0;
-
-	dur = timestamp_duration(&aurx->ts_recv);
-
-	return timestamp_calc_seconds(dur, aurx->ac->crate);
 }
 
 
@@ -278,13 +214,7 @@ static void stop_rx(struct aurx *rx)
 
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
-	rx->aubuf  = mem_deref(rx->aubuf);
-	if (rx->mtx)
-		mtx_lock(rx->mtx);
-
-	list_flush(&rx->filtl);
-	if (rx->mtx)
-		mtx_unlock(rx->mtx);
+	aup_stop(rx->aup);
 }
 
 
@@ -298,12 +228,9 @@ static void audio_destructor(void *arg)
 	stop_rx(&a->rx);
 
 	mem_deref(a->tx.enc);
-	mem_deref(a->rx.dec);
 	mem_deref(a->tx.aubuf);
 	mem_deref(a->tx.mb);
 	mem_deref(a->tx.sampv);
-	mem_deref(a->rx.sampv);
-	mem_deref(a->rx.aubuf);
 	mem_deref(a->tx.module);
 	mem_deref(a->tx.device);
 	mem_deref(a->rx.module);
@@ -313,9 +240,9 @@ static void audio_destructor(void *arg)
 
 	mem_deref(a->strm);
 	mem_deref(a->telev);
+	mem_deref(a->rx.aup);
 
 	mem_deref(a->tx.mtx);
-	mem_deref(a->rx.mtx);
 }
 
 
@@ -604,9 +531,28 @@ bool audio_txtelev_empty(const struct audio *au)
 }
 
 
+static void check_plframe(struct auframe *af1, struct auframe *af2)
+{
+	if ((af1->srate && af1->srate != af2->srate) ||
+	    (af1->ch    && af1->ch    != af2->ch   )) {
+		warning("aurpipe: srate/ch of frame %u/%u vs "
+			"player %u/%u. Use module auresamp!\n",
+			af1->srate, af1->ch,
+			af2->srate, af2->ch);
+	}
+
+	if (af1->fmt != af2->fmt) {
+		warning("aurpipe: invalid sample formats (%s -> %s). "
+			"%s\n",
+			aufmt_name(af1->fmt), aufmt_name(af2->fmt),
+			af1->fmt == AUFMT_S16LE ?
+			"Use module auconv!" : "");
+	}
+}
+
+
 /*
- * Write samples to Audio Player. This version of the write handler is used
- * for the configuration jitter_buffer_type JBUF_FIXED.
+ * Write samples to Audio Player.
  *
  * @note This function has REAL-TIME properties
  *
@@ -620,22 +566,21 @@ bool audio_txtelev_empty(const struct audio *au)
 static void auplay_write_handler(struct auframe *af, void *arg)
 {
 	struct audio *a = arg;
+	struct auframe afr;
 	struct aurx *rx = &a->rx;
-	size_t num_bytes = auframe_size(af);
 
-	mtx_lock(rx->mtx);
-	if (rx->aubuf_started && aubuf_cur_size(rx->aubuf) < num_bytes) {
+	if (!rx->auplay)
+		return;
 
-		++rx->stats.aubuf_underrun;
+	if (!rx->first_write)
+		afr = *af;
 
-#if 0
-		debug("audio: rx aubuf underrun (total %llu)\n",
-			rx->stats.aubuf_underrun);
-#endif
+	aup_read(rx->aup, af);
+
+	if (!rx->first_write) {
+		(void)check_plframe(&afr, af);
+		rx->first_write = true;
 	}
-
-	mtx_unlock(rx->mtx);
-	aubuf_read_auframe(rx->aubuf, af);
 }
 
 
@@ -726,15 +671,6 @@ static void handle_telev(struct audio *a, struct mbuf *mb)
 }
 
 
-static bool audio_is_telev(struct audio *a, int pt)
-{
-	const struct sdp_format *lc;
-
-	lc = sdp_media_lformat(stream_sdpmedia(a->strm), pt);
-	return  lc && !str_casecmp(lc->name, "telephone-event");
-}
-
-
 static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 {
 	struct audio *a = arg;
@@ -763,233 +699,22 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 }
 
 
-static int process_decfilt(struct aurx *rx, struct auframe *af)
-{
-	int err = 0;
-
-	/* Process exactly one audio-frame in reverse list order */
-	mtx_lock(rx->mtx);
-	for (struct le *le = rx->filtl.tail; le; le = le->prev) {
-		struct aufilt_dec_st *st = le->data;
-
-		if (st->af && st->af->dech)
-			err = st->af->dech(st, af);
-
-		if (err)
-			break;
-	}
-
-	mtx_unlock(rx->mtx);
-	return err;
-}
-
-
-static int rx_push_aubuf(struct aurx *rx, const struct auframe *af)
-{
-	int err;
-
-	if (aubuf_cur_size(rx->aubuf) >= rx->aubuf_maxsz) {
-
-		++rx->stats.aubuf_overrun;
-
-#if 0
-		debug("audio: rx aubuf overrun (total %llu)\n",
-		      rx->stats.aubuf_overrun);
-#endif
-	}
-
-	if (rx->auplay_prm.srate != af->srate || rx->auplay_prm.ch != af->ch) {
-		warning("audio: srate/ch of frame %u/%u vs player %u/%u. Use "
-			"module auresamp!\n",
-			af->srate, af->ch,
-			rx->auplay_prm.srate, rx->auplay_prm.ch);
-	}
-
-	if (af->fmt != rx->play_fmt) {
-		warning("audio: rx: invalid sample formats (%s -> %s). %s\n",
-			aufmt_name(af->fmt), aufmt_name(rx->play_fmt),
-			rx->play_fmt == AUFMT_S16LE ? "Use module auconv!" : ""
-		       );
-	}
-
-	err = aubuf_write_auframe(rx->aubuf, af);
-	if (err)
-		return err;
-
-	mtx_lock(rx->mtx);
-	if (!rx->aubuf_started &&
-	    (aubuf_cur_size(rx->aubuf) >= rx->aubuf_minsz))
-		rx->aubuf_started = true;
-
-	mtx_unlock(rx->mtx);
-
-	return 0;
-}
-
-
-static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
-			      struct mbuf *mb, unsigned lostc, bool drop)
-{
-	struct auframe af;
-	size_t sampc = AUDIO_SAMPSZ;
-	bool marker = hdr->m;
-	int err = 0;
-	const struct aucodec *ac = rx->ac;
-	bool flush = rx->ssrc != hdr->ssrc;
-
-	/* No decoder set */
-	if (!ac)
-		return 0;
-
-	rx->ssrc = hdr->ssrc;
-
-	/* TODO: PLC */
-	if (lostc && ac->plch) {
-
-		err = ac->plch(rx->dec,
-				   rx->dec_fmt, rx->sampv, &sampc,
-				   mbuf_buf(mb), mbuf_get_left(mb));
-		if (err) {
-			warning("audio: %s codec decode %u bytes: %m\n",
-				ac->name, mbuf_get_left(mb), err);
-			goto out;
-		}
-	}
-	else if (mbuf_get_left(mb)) {
-
-		err = ac->dech(rx->dec,
-				   rx->dec_fmt, rx->sampv, &sampc,
-				   marker, mbuf_buf(mb), mbuf_get_left(mb));
-		if (err) {
-			warning("audio: %s codec decode %u bytes: %m\n",
-				ac->name, mbuf_get_left(mb), err);
-			goto out;
-		}
-	}
-	else {
-		/* no PLC in the codec, might be done in filters below */
-		sampc = 0;
-	}
-
-	auframe_init(&af, rx->dec_fmt, rx->sampv, sampc, ac->srate, ac->ch);
-	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
-
-	if (drop) {
-		aubuf_drop_auframe(rx->aubuf, &af);
-		goto out;
-	}
-
-	if (flush)
-		aubuf_flush(rx->aubuf);
-
-	err = process_decfilt(rx, &af);
-	if (err)
-		goto out;
-
-	if (!rx->aubuf)
-		goto out;
-
-	err = rx_push_aubuf(rx, &af);
- out:
-	return err;
-}
-
-
-/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
-static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
-					uint8_t id)
-{
-	for (size_t i=0; i<extc; i++) {
-		const struct rtpext *rtpext = &extv[i];
-
-		if (rtpext->id == id)
-			return rtpext;
-	}
-
-	return NULL;
-}
-
-
-/* Handle incoming stream data from the network */
+/**
+ * Stream receive handler for audio is called from RX thread if enabled
+ */
 static void stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc, bool *ignore,
 				void *arg)
 {
 	struct audio *a = arg;
-	struct aurx *rx = &a->rx;
-	bool discard = false;
-	bool drop = *ignore;
-	int wrap;
-	(void) lostc;
 
 	MAGIC_CHECK(a);
 
-	if (!mb)
-		goto out;
-
-	if (audio_is_telev(a, hdr->pt)) {
-		*ignore = true;
+	if (!a->rx.aup)
 		return;
-	}
 
-	*ignore = false;
-
-	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
-	const struct rtpext *ext = rtpext_find(extv, extc, a->extmap_aulevel);
-	if (ext) {
-		rx->level_last = -(double)(ext->data[0] & 0x7f);
-		rx->level_set = true;
-	}
-
-	/* Save timestamp for incoming RTP packets */
-
-	if (!rx->ts_recv.is_set)
-		timestamp_set(&rx->ts_recv, hdr->ts);
-
-	wrap = timestamp_wrap(hdr->ts, rx->ts_recv.last);
-
-	switch (wrap) {
-
-	case -1:
-		warning("audio: rtp timestamp wraps backwards"
-			" (delta = %d) -- discard\n",
-			(int32_t)(rx->ts_recv.last - hdr->ts));
-		discard = true;
-		break;
-
-	case 0:
-		break;
-
-	case 1:
-		++rx->ts_recv.num_wraps;
-		break;
-
-	default:
-		break;
-	}
-
-	rx->ts_recv.last = hdr->ts;
-
-#if 0
-	re_printf("[time=%.3f]    wrap=%d  discard=%d\n",
-		  aurx_calc_seconds(rx), wrap, discard);
-#endif
-
-	if (discard) {
-		++rx->stats.n_discard;
-		return;
-	}
-
- out:
-	/* TODO:  what if lostc > 1 ?*/
-	/* PLC should generate lostc frames here. Not only one.
-	 * aubuf should replace PLC frames with late arriving real frames.
-	 * It should use timestamp to decide if a frame should be replaced. */
-/*        if (lostc)*/
-/*                (void)aurx_stream_decode(&a->rx, hdr, mb, lostc, drop);*/
-
-	(void)aurx_stream_decode(&a->rx, hdr, mb, 0, drop);
+	aup_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
 }
 
 
@@ -999,19 +724,23 @@ static int add_telev_codec(struct audio *a)
 	struct sdp_format *sf;
 	uint32_t pt = a->cfg.telev_pt;
 	char pts[11];
+	bool add = !sdp_media_lformat(m, pt);
 	int err;
 
 	(void)re_snprintf(pts, sizeof(pts), "%u", pt);
 
 	/* Use payload-type 101 if available, for CiscoGW interop */
 	err = sdp_format_add(&sf, m, false,
-			     (!sdp_media_lformat(m, pt)) ? pts : NULL,
+			     add ? pts : NULL,
 			     telev_rtpfmt, TELEV_SRATE, 1, NULL,
 			     NULL, NULL, false, "0-15");
 	if (err)
 		return err;
 
-	return err;
+	if (add)
+		aup_set_telev_pt(a->rx.aup, pt);
+
+	return 0;
 }
 
 
@@ -1076,15 +805,18 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 
 	tx->src_fmt = cfg->audio.src_fmt;
 	rx->play_fmt = cfg->audio.play_fmt;
-
 	tx->enc_fmt = cfg->audio.enc_fmt;
-	rx->dec_fmt = cfg->audio.dec_fmt;
 
 	err = stream_alloc(&a->strm, streaml,
 			   stream_prm, &cfg->avt, sdp_sess,
 			   MEDIA_AUDIO,
 			   mnat, mnat_sess, menc, menc_sess, offerer,
-			   stream_recv_handler, NULL, stream_pt_handler, a);
+			   stream_recv_handler, NULL, stream_pt_handler,
+			   a);
+	if (err)
+		goto out;
+
+	err = aup_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
 	if (err)
 		goto out;
 
@@ -1117,6 +849,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (cfg->audio.level && offerer) {
 
 		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
+		aup_set_extmap(a->rx.aup, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 					  "extmap",
@@ -1130,9 +863,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	tx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(tx->enc_fmt),
 			       NULL);
 
-	rx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(rx->dec_fmt),
-			       NULL);
-	if (!tx->mb || !tx->sampv || !rx->sampv) {
+	if (!tx->mb || !tx->sampv) {
 		err = ENOMEM;
 		goto out;
 	}
@@ -1186,7 +917,6 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	rx->ptime  = ptime;
 
 	err  = mutex_alloc(&tx->mtx);
-	err |= mutex_alloc(&rx->mtx);
 	if (err)
 		goto out;
 
@@ -1293,7 +1023,7 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 			err |= re_hprintf(pf, " ---> %s", st->af->name);
 	}
 
-	err |= re_hprintf(pf, " ---> %s\n",
+	err |= re_hprintf(pf, " ---> %s",
 			  autx->ac ? autx->ac->name : "(encoder)");
 
 	return err;
@@ -1302,7 +1032,6 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 
 static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 {
-	struct le *le;
 	int err;
 
 	if (!rx)
@@ -1310,19 +1039,6 @@ static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 
 	err = re_hprintf(pf, "audio rx pipeline:  %10s",
 			 rx->ap ? rx->ap->name : "(play)");
-
-	err |= re_hprintf(pf, " <--- aubuf");
-	mtx_lock(rx->mtx);
-	for (le = list_head(&rx->filtl); le; le = le->next) {
-		struct aufilt_dec_st *st = le->data;
-
-		if (st->af->dech)
-			err |= re_hprintf(pf, " <--- %s", st->af->name);
-	}
-
-	mtx_unlock(rx->mtx);
-	err |= re_hprintf(pf, " <--- %s\n",
-			  rx->ac ? rx->ac->name : "(decoder)");
 
 	return err;
 }
@@ -1343,23 +1059,18 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 	struct autx *tx = &a->tx;
 	struct aurx *rx = &a->rx;
 	struct le *le;
-	bool update_enc = false, update_dec = false;
+	bool update_enc, update_dec;
 	int err = 0;
 
 	/* wait until we have both Encoder and Decoder */
-	if (!tx->ac || !rx->ac)
+	if (!tx->ac || !aup_codec(rx->aup))
 		return 0;
 
-	if (list_isempty(&tx->filtl))
-		update_enc = true;
+	update_dec = aup_filt_empty(rx->aup);
+	update_enc = list_isempty(&tx->filtl);
 
-	mtx_lock(rx->mtx);
-	if (list_isempty(&rx->filtl))
-		update_dec = true;
-
-	mtx_unlock(rx->mtx);
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&plprm, rx->ac, rx->dec_fmt);
+	aufilt_param_set(&plprm, aup_codec(rx->aup), a->cfg.play_fmt);
 	if (a->cfg.srate_play && a->cfg.srate_play != plprm.srate) {
 		plprm.srate = a->cfg.srate_play;
 	}
@@ -1395,9 +1106,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			}
 			else {
 				decst->af = af;
-				mtx_lock(rx->mtx);
-				list_append(&rx->filtl, &decst->le, decst);
-				mtx_unlock(rx->mtx);
+				aup_filt_append(rx->aup, decst);
 			}
 		}
 
@@ -1415,12 +1124,9 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
-	const struct aucodec *ac = rx->ac;
+	const struct aucodec *ac = aup_codec(rx->aup);
 	uint32_t srate_dsp;
 	uint32_t channels_dsp;
-	size_t sz;
-	size_t min_sz;
-	size_t max_sz;
 	int err = 0;
 
 	if (!ac)
@@ -1446,36 +1152,6 @@ static int start_player(struct aurx *rx, struct audio *a,
 		prm.ptime      = rx->ptime;
 		prm.fmt        = rx->play_fmt;
 
-		if (!rx->aubuf) {
-			const uint16_t ptime_min = (uint16_t)a->cfg.buffer.min;
-			const uint16_t ptime_max = (uint16_t)a->cfg.buffer.max;
-			sz = aufmt_sample_size(rx->play_fmt);
-
-			if (!ptime_min || !ptime_max)
-				return EINVAL;
-
-			min_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_min);
-			max_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_max);
-
-			debug("audio: create auplay buffer"
-			      " [%u - %u ms]"
-			      " [%zu - %zu bytes]\n",
-			      ptime_min, ptime_max, min_sz, max_sz);
-
-			err = aubuf_alloc(&rx->aubuf, min_sz, max_sz);
-			if (err) {
-				warning("audio: aubuf alloc error (%m)\n",
-					err);
-				return err;
-			}
-
-			aubuf_set_mode(rx->aubuf, a->cfg.adaptive ?
-				       AUBUF_ADAPTIVE : AUBUF_FIXED);
-			aubuf_set_silence(rx->aubuf, a->cfg.silence);
-			rx->aubuf_minsz = min_sz;
-			rx->aubuf_maxsz = max_sz;
-		}
-
 		rx->auplay_prm = prm;
 		err = auplay_alloc(&rx->auplay, auplayl,
 				   rx->module,
@@ -1495,8 +1171,6 @@ static int start_player(struct aurx *rx, struct audio *a,
 	}
 
 out:
-	if (err)
-		rx->aubuf    = mem_deref(rx->aubuf);
 
 	return 0;
 }
@@ -1616,9 +1290,7 @@ static void audio_flush_filters(struct audio *a)
 	struct aurx *rx = &a->rx;
 	struct autx *tx = &a->tx;
 
-	mtx_lock(rx->mtx);
-	list_flush(&rx->filtl);
-	mtx_unlock(rx->mtx);
+	aup_flush(rx->aup);
 
 	mtx_lock(a->tx.mtx);
 	list_flush(&tx->filtl);
@@ -1665,12 +1337,13 @@ int audio_start(struct audio *a)
 		return err;
 	}
 
-	if (a->tx.ac && a->rx.ac) {
+	if (a->tx.ac && aup_codec(a->rx.aup)) {
 
 		if (!a->started) {
-			info("%H%H",
+			info("%H\n%H%H",
 			     autx_print_pipeline, &a->tx,
-			     aurx_print_pipeline, &a->rx);
+			     aurx_print_pipeline, &a->rx,
+			     aup_print_pipeline, a->rx.aup);
 		}
 
 		a->started = true;
@@ -1841,36 +1514,25 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		return EINVAL;
 
 	rx = &a->rx;
+	rx->pt = pt_rx;
 
-	if (ac != rx->ac) {
+	if (ac != aup_codec(rx->aup)) {
 		struct sdp_media *m;
 		bool reset;
 
 		m = stream_sdpmedia(audio_strm(a));
-		reset  = !aucodec_equal(ac, rx->ac);
+		reset  = !aucodec_equal(ac, aup_codec(rx->aup));
 		reset |= !(sdp_media_dir(m) & SDP_RECVONLY);
 		if (reset) {
 			rx->auplay = mem_deref(rx->auplay);
 			audio_flush_filters(a);
-			aubuf_flush(rx->aubuf);
 			stream_flush(a->strm);
 		}
-
-		info("audio: Set audio decoder: %s %uHz %dch\n",
-		     ac->name, ac->srate, ac->ch);
-
-		rx->pt = pt_rx;
-		rx->ac = ac;
-		rx->dec = mem_deref(rx->dec);
 	}
 
-	if (ac->decupdh) {
-		err = ac->decupdh(&rx->dec, ac, params);
-		if (err) {
-			warning("audio: alloc decoder: %m\n", err);
-			return err;
-		}
-	}
+	err = aup_decoder_set(rx->aup, ac, params);
+	if (err)
+		return err;
 
 	stream_set_srate(a->strm, 0, ac->crate);
 
@@ -1985,6 +1647,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		}
 
 		au->extmap_aulevel = extmap.id;
+		aup_set_extmap(au->rx.aup, au->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
@@ -2081,11 +1744,11 @@ int audio_level_get(const struct audio *au, double *levelp)
 	if (!au->level_enabled)
 		return ENOTSUP;
 
-	if (!au->rx.level_set)
+	if (!aup_level_set(au->rx.aup))
 		return ENOENT;
 
 	if (levelp)
-		*levelp = au->rx.level_last;
+		*levelp = aup_level(au->rx.aup);
 
 	return 0;
 }
@@ -2103,7 +1766,8 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	size_t sztx, szrx;
+	const struct aurpipe *aup;
+	size_t sztx;
 	int err;
 
 	if (!a)
@@ -2111,9 +1775,9 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	tx = &a->tx;
 	rx = &a->rx;
+	aup = a->rx.aup;
 
 	sztx = aufmt_sample_size(tx->src_fmt);
-	szrx = aufmt_sample_size(rx->play_fmt);
 
 	err  = re_hprintf(pf, "\n--- Audio stream ---\n");
 
@@ -2139,44 +1803,18 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
 			  autx_calc_seconds(tx));
 
-	err |= re_hprintf(pf,
-			  " rx:   decode: %H %s\n",
-			  aucodec_print, rx->ac, aufmt_name(rx->dec_fmt));
-	err |= re_hprintf(pf, "       aubuf: %H"
-			  " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
-			  aubuf_debug, rx->aubuf,
-			  calc_ptime(aubuf_cur_size(rx->aubuf)/szrx,
-				     rx->auplay_prm.srate,
-				     rx->auplay_prm.ch),
-			  calc_ptime(rx->aubuf_maxsz/szrx,
-				     rx->auplay_prm.srate,
-				     rx->auplay_prm.ch),
-			  rx->stats.aubuf_overrun,
-			  rx->stats.aubuf_underrun
-			  );
+	err |= aup_debug(pf, aup);
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,
 			  aufmt_name(rx->play_fmt));
-	err |= re_hprintf(pf, "       n_discard:%llu\n",
-			  rx->stats.n_discard);
-	if (rx->level_set) {
-		err |= re_hprintf(pf, "       level %.3f dBov\n",
-				  rx->level_last);
-	}
-	if (rx->ts_recv.is_set) {
-		err |= re_hprintf(pf, "       time = %.3f sec\n",
-				  aurx_calc_seconds(rx));
-	}
-	else {
-		err |= re_hprintf(pf, "       time = (not started)\n");
-	}
 
 	err |= re_hprintf(pf,
-			  " %H"
-			  " %H",
+			  " %H\n"
+			  " %H%H",
 			  autx_print_pipeline, tx,
-			  aurx_print_pipeline, rx);
+			  aurx_print_pipeline, rx,
+			  aup_print_pipeline, aup);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -2348,14 +1986,10 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
  */
 bool audio_rxaubuf_started(const struct audio *au)
 {
-	const struct aurx *rx;
-
-	if (!au)
+	if (!au || !au->rx.aup)
 		return false;
 
-	rx = &au->rx;
-
-	return rx->aubuf_started;
+	return aup_started(au->rx.aup);
 }
 
 
@@ -2419,7 +2053,7 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 	if (!au)
 		return NULL;
 
-	return tx ? au->tx.ac : au->rx.ac;
+	return tx ? au->tx.ac : aup_codec(au->rx.aup);
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -127,7 +127,7 @@ struct aurx {
 	int pt;                       /**< Payload type for incoming RTP   */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
 
-	struct audio_recv *aup;       /**< Audio receive pipeline          */
+	struct audio_recv *aur;       /**< Audio receive pipeline          */
 	bool first_write;             /**< First write to auplay           */
 };
 
@@ -171,7 +171,7 @@ uint64_t audio_jb_current_value(const struct audio *au)
 	if (!au)
 		return 0;
 
-	return aur_latency(au->rx.aup);
+	return aur_latency(au->rx.aur);
 }
 
 
@@ -214,7 +214,7 @@ static void stop_rx(struct aurx *rx)
 
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
-	aur_stop(rx->aup);
+	aur_stop(rx->aur);
 }
 
 
@@ -241,7 +241,7 @@ static void audio_destructor(void *arg)
 
 	mem_deref(a->strm);
 	mem_deref(a->telev);
-	mem_deref(a->rx.aup);
+	mem_deref(a->rx.aur);
 
 	mem_deref(a->tx.mtx);
 }
@@ -573,7 +573,7 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	if (!rx->first_write)
 		afr = *af;
 
-	aur_read(rx->aup, af);
+	aur_read(rx->aur, af);
 
 	if (!rx->first_write) {
 		(void)check_plframe(&afr, af);
@@ -709,10 +709,10 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 
 	MAGIC_CHECK(a);
 
-	if (!a->rx.aup)
+	if (!a->rx.aur)
 		return;
 
-	aur_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
+	aur_receive(a->rx.aur, hdr, extv, extc, mb, lostc, ignore);
 }
 
 
@@ -736,7 +736,7 @@ static int add_telev_codec(struct audio *a)
 		return err;
 
 	if (add)
-		aur_set_telev_pt(a->rx.aup, pt);
+		aur_set_telev_pt(a->rx.aur, pt);
 
 	return 0;
 }
@@ -814,7 +814,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ, ptime);
+	err = aur_alloc(&a->rx.aur, &a->cfg, AUDIO_SAMPSZ, ptime);
 	if (err)
 		goto out;
 
@@ -847,7 +847,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (cfg->audio.level && offerer) {
 
 		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
-		aur_set_extmap(a->rx.aup, a->extmap_aulevel);
+		aur_set_extmap(a->rx.aur, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 					  "extmap",
@@ -1061,14 +1061,14 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 	int err = 0;
 
 	/* wait until we have both Encoder and Decoder */
-	if (!tx->ac || !aur_codec(rx->aup))
+	if (!tx->ac || !aur_codec(rx->aur))
 		return 0;
 
-	update_dec = aur_filt_empty(rx->aup);
+	update_dec = aur_filt_empty(rx->aur);
 	update_enc = list_isempty(&tx->filtl);
 
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&plprm, aur_codec(rx->aup), a->cfg.play_fmt);
+	aufilt_param_set(&plprm, aur_codec(rx->aur), a->cfg.play_fmt);
 	if (a->cfg.srate_play && a->cfg.srate_play != plprm.srate) {
 		plprm.srate = a->cfg.srate_play;
 	}
@@ -1104,7 +1104,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			}
 			else {
 				decst->af = af;
-				aur_filt_append(rx->aup, decst);
+				aur_filt_append(rx->aur, decst);
 			}
 		}
 
@@ -1122,7 +1122,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
-	const struct aucodec *ac = aur_codec(rx->aup);
+	const struct aucodec *ac = aur_codec(rx->aur);
 	uint32_t srate_dsp;
 	uint32_t channels_dsp;
 	int err = 0;
@@ -1288,7 +1288,7 @@ static void audio_flush_filters(struct audio *a)
 	struct aurx *rx = &a->rx;
 	struct autx *tx = &a->tx;
 
-	aur_flush(rx->aup);
+	aur_flush(rx->aur);
 
 	mtx_lock(a->tx.mtx);
 	list_flush(&tx->filtl);
@@ -1335,13 +1335,13 @@ int audio_start(struct audio *a)
 		return err;
 	}
 
-	if (a->tx.ac && aur_codec(a->rx.aup)) {
+	if (a->tx.ac && aur_codec(a->rx.aur)) {
 
 		if (!a->started) {
 			info("%H\n%H%H",
 			     autx_print_pipeline, &a->tx,
 			     aurx_print_pipeline, &a->rx,
-			     aur_print_pipeline, a->rx.aup);
+			     aur_print_pipeline, a->rx.aur);
 		}
 
 		a->started = true;
@@ -1514,12 +1514,12 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 	rx = &a->rx;
 	rx->pt = pt_rx;
 
-	if (ac != aur_codec(rx->aup)) {
+	if (ac != aur_codec(rx->aur)) {
 		struct sdp_media *m;
 		bool reset;
 
 		m = stream_sdpmedia(audio_strm(a));
-		reset  = !aucodec_equal(ac, aur_codec(rx->aup));
+		reset  = !aucodec_equal(ac, aur_codec(rx->aur));
 		reset |= !(sdp_media_dir(m) & SDP_RECVONLY);
 		if (reset) {
 			rx->auplay = mem_deref(rx->auplay);
@@ -1528,7 +1528,7 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		}
 	}
 
-	err = aur_decoder_set(rx->aup, ac, params);
+	err = aur_decoder_set(rx->aur, ac, params);
 	if (err)
 		return err;
 
@@ -1645,7 +1645,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		}
 
 		au->extmap_aulevel = extmap.id;
-		aur_set_extmap(au->rx.aup, au->extmap_aulevel);
+		aur_set_extmap(au->rx.aur, au->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
@@ -1742,11 +1742,11 @@ int audio_level_get(const struct audio *au, double *levelp)
 	if (!au->level_enabled)
 		return ENOTSUP;
 
-	if (!aur_level_set(au->rx.aup))
+	if (!aur_level_set(au->rx.aur))
 		return ENOENT;
 
 	if (levelp)
-		*levelp = aur_level(au->rx.aup);
+		*levelp = aur_level(au->rx.aur);
 
 	return 0;
 }
@@ -1764,7 +1764,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	const struct audio_recv *aup;
+	const struct audio_recv *aur;
 	size_t sztx;
 	int err;
 
@@ -1773,7 +1773,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	tx = &a->tx;
 	rx = &a->rx;
-	aup = a->rx.aup;
+	aur = a->rx.aur;
 
 	sztx = aufmt_sample_size(tx->src_fmt);
 
@@ -1801,7 +1801,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
 			  autx_calc_seconds(tx));
 
-	err |= aur_debug(pf, aup);
+	err |= aur_debug(pf, aur);
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,
@@ -1812,7 +1812,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 			  " %H%H",
 			  autx_print_pipeline, tx,
 			  aurx_print_pipeline, rx,
-			  aur_print_pipeline, aup);
+			  aur_print_pipeline, aur);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -1984,10 +1984,10 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
  */
 bool audio_rxaubuf_started(const struct audio *au)
 {
-	if (!au || !au->rx.aup)
+	if (!au || !au->rx.aur)
 		return false;
 
-	return aur_started(au->rx.aup);
+	return aur_started(au->rx.aur);
 }
 
 
@@ -2051,7 +2051,7 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 	if (!au)
 		return NULL;
 
-	return tx ? au->tx.ac : aur_codec(au->rx.aup);
+	return tx ? au->tx.ac : aur_codec(au->rx.aur);
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -814,7 +814,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
+	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ, ptime);
 	if (err)
 		goto out;
 

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -1,0 +1,654 @@
+/**
+ * @file src/aureceiver.c  Audio stream receiver
+ *
+ * Copyright (C) 2023 Alfred E. Heggestad, Christian Spielberger
+ */
+#include <string.h>
+#include <re.h>
+#include <re_atomic.h>
+#include <rem.h>
+#include <baresip.h>
+#include "core.h"
+
+
+/**
+ * Audio receive pipeline
+ *
+ \verbatim
+
+ Processing decoder pipeline:
+
+       .--------.   .-------.   .--------.   .--------.
+ |\    |        |   |       |   |        |   |        |
+ | |<--| auplay |<--| aubuf |<--| aufilt |<--| decode |<--- RTP
+ |/    |        |   |       |   |        |   |        |
+       '--------'   '-------'   '--------'   '--------'
+
+ \endverbatim
+ */
+struct aurpipe {
+	uint32_t srate;               /**< Decoder sample rate               */
+	uint32_t ch;                  /**< Decoder channel number            */
+	enum aufmt fmt;               /**< Decoder sample format             */
+	const struct config_audio *cfg;  /**< Audio configuration            */
+	struct audec_state *dec;      /**< Audio decoder state (optional)    */
+	const struct aucodec *ac;     /**< Current audio decoder             */
+	struct aubuf *aubuf;          /**< Audio buffer before auplay        */
+	size_t aubuf_minsz;           /**< Minimum aubuf size in [bytes]     */
+	size_t aubuf_maxsz;           /**< Maximum aubuf size in [bytes]     */
+	bool aubuf_started;           /**< Aubuf started flag                */
+	uint32_t ssrc;                /**< Incoming synchronization source   */
+	struct list filtl;            /**< Audio filters in decoding order   */
+	void *sampv;                  /**< Sample buffer                     */
+	size_t sampvsz;               /**< Sample buffer size                */
+
+	double level_last;            /**< Last audio level value [dBov]     */
+	bool level_set;               /**< True if level_last is set         */
+	struct timestamp_recv ts_recv;/**< Receive timestamp state           */
+	uint8_t extmap_aulevel;       /**< ID Range 1-14 inclusive           */
+	uint32_t telev_pt;            /**< Payload type for telephone-events */
+
+	struct {
+		uint64_t aubuf_overrun;
+		uint64_t aubuf_underrun;
+		uint64_t n_discard;
+	} stats;
+
+	mtx_t *mtx;
+};
+
+
+static void destructor(void *arg)
+{
+	struct aurpipe *rp = arg;
+
+	mem_deref(rp->dec);
+	mem_deref(rp->aubuf);
+	mem_deref(rp->sampv);
+	mem_deref(rp->mtx);
+	list_flush(&rp->filtl);
+}
+
+
+static int aup_process_decfilt(struct aurpipe *rp, struct auframe *af)
+{
+	int err = 0;
+
+	/* Process exactly one audio-frame in reverse list order */
+	for (struct le *le = rp->filtl.tail; le; le = le->prev) {
+		struct aufilt_dec_st *st = le->data;
+
+		if (st->af && st->af->dech)
+			err = st->af->dech(st, af);
+
+		if (err)
+			break;
+	}
+
+	return err;
+}
+
+
+static double aup_calc_seconds(const struct aurpipe *rp)
+{
+	uint64_t dur;
+	double seconds;
+
+	if (!rp->ac)
+		return .0;
+
+	dur = timestamp_duration(&rp->ts_recv);
+	seconds = timestamp_calc_seconds(dur, rp->ac->crate);
+
+	return seconds;
+}
+
+
+static int aup_alloc_aubuf(struct aurpipe *rp, const struct auframe *af)
+{
+	size_t min_sz;
+	size_t max_sz;
+	size_t sz;
+	const struct config_audio *cfg = rp->cfg;
+	int err;
+
+	sz = aufmt_sample_size(cfg->play_fmt);
+	min_sz = sz * calc_nsamp(af->srate, af->ch, cfg->buffer.min);
+	max_sz = sz * calc_nsamp(af->srate, af->ch, cfg->buffer.max);
+
+	debug("aurpipe: create audio buffer"
+	      " [%u - %u ms]"
+	      " [%zu - %zu bytes]\n",
+	      (unsigned) cfg->buffer.min, (unsigned) cfg->buffer.max,
+	      min_sz, max_sz);
+
+	err = aubuf_alloc(&rp->aubuf, min_sz, max_sz);
+	if (err) {
+		warning("aurpipe: aubuf alloc error (%m)\n",
+			err);
+	}
+
+	aubuf_set_mode(rp->aubuf, cfg->adaptive ?
+		       AUBUF_ADAPTIVE : AUBUF_FIXED);
+	aubuf_set_silence(rp->aubuf, cfg->silence);
+	rp->aubuf_minsz = min_sz;
+	rp->aubuf_maxsz = max_sz;
+	return err;
+}
+
+
+static int aup_push_aubuf(struct aurpipe *rp, const struct auframe *af)
+{
+	int err;
+
+	if (!rp->aubuf) {
+		err = aup_alloc_aubuf(rp, af);
+		if (err)
+			return err;
+	}
+
+	if (aubuf_cur_size(rp->aubuf) >= rp->aubuf_maxsz) {
+
+		++rp->stats.aubuf_overrun;
+
+#if 0
+		debug("audio: rx aubuf overrun (total %llu)\n",
+		      rp->stats.aubuf_overrun);
+#endif
+	}
+
+	err = aubuf_write_auframe(rp->aubuf, af);
+	if (err)
+		return err;
+
+	rp->srate = af->srate;
+	rp->ch    = af->ch;
+	rp->fmt   = af->fmt;
+
+	if (!rp->aubuf_started &&
+	    (aubuf_cur_size(rp->aubuf) >= rp->aubuf_minsz))
+		rp->aubuf_started = true;
+
+	return 0;
+}
+
+
+static int aup_stream_decode(struct aurpipe *rp, const struct rtp_header *hdr,
+			    struct mbuf *mb, unsigned lostc, bool drop)
+{
+	struct auframe af;
+	size_t sampc = rp->sampvsz / aufmt_sample_size(rp->fmt);
+	bool marker = hdr->m;
+	int err = 0;
+	const struct aucodec *ac = rp->ac;
+	bool flush = rp->ssrc != hdr->ssrc;
+
+	/* No decoder set */
+	if (!ac)
+		return 0;
+
+	rp->ssrc = hdr->ssrc;
+
+	/* TODO: PLC */
+	if (lostc && ac->plch) {
+
+		err = ac->plch(rp->dec,
+				   rp->fmt, rp->sampv, &sampc,
+				   mbuf_buf(mb), mbuf_get_left(mb));
+		if (err) {
+			warning("audio: %s codec decode %u bytes: %m\n",
+				ac->name, mbuf_get_left(mb), err);
+			goto out;
+		}
+	}
+	else if (mbuf_get_left(mb)) {
+
+		err = ac->dech(rp->dec,
+				   rp->fmt, rp->sampv, &sampc,
+				   marker, mbuf_buf(mb), mbuf_get_left(mb));
+		if (err) {
+			warning("audio: %s codec decode %u bytes: %m\n",
+				ac->name, mbuf_get_left(mb), err);
+			goto out;
+		}
+	}
+	else {
+		/* no PLC in the codec, might be done in filters below */
+		sampc = 0;
+	}
+
+	auframe_init(&af, rp->fmt, rp->sampv, sampc, ac->srate, ac->ch);
+	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
+
+	if (drop) {
+		aubuf_drop_auframe(rp->aubuf, &af);
+		goto out;
+	}
+
+	if (flush)
+		aubuf_flush(rp->aubuf);
+
+	err = aup_process_decfilt(rp, &af);
+	if (err)
+		goto out;
+
+	err = aup_push_aubuf(rp, &af);
+ out:
+	return err;
+}
+
+
+/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
+static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
+					uint8_t id)
+{
+	for (size_t i=0; i<extc; i++) {
+		const struct rtpext *rtpext = &extv[i];
+
+		if (rtpext->id == id)
+			return rtpext;
+	}
+
+	return NULL;
+}
+
+
+/* Handle incoming stream data from the network */
+void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+		 struct rtpext *extv, size_t extc,
+		 struct mbuf *mb, unsigned lostc, bool *ignore)
+{
+	bool discard = false;
+	bool drop = *ignore;
+	int wrap;
+	(void) lostc;
+
+	if (!mb)
+		goto out;
+
+	mtx_lock(rp->mtx);
+	if (hdr->pt == rp->telev_pt) {
+		mtx_unlock(rp->mtx);
+		*ignore = true;
+		return;
+	}
+
+	*ignore = false;
+
+	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
+	const struct rtpext *ext = rtpext_find(extv, extc, rp->extmap_aulevel);
+	if (ext) {
+		rp->level_last = -(double)(ext->data[0] & 0x7f);
+		rp->level_set = true;
+	}
+
+	/* Save timestamp for incoming RTP packets */
+
+	if (!rp->ts_recv.is_set)
+		timestamp_set(&rp->ts_recv, hdr->ts);
+
+	wrap = timestamp_wrap(hdr->ts, rp->ts_recv.last);
+
+	switch (wrap) {
+
+	case -1:
+		warning("audio: rtp timestamp wraps backwards"
+			" (delta = %d) -- discard\n",
+			(int32_t)(rp->ts_recv.last - hdr->ts));
+		discard = true;
+		break;
+
+	case 0:
+		break;
+
+	case 1:
+		++rp->ts_recv.num_wraps;
+		break;
+
+	default:
+		break;
+	}
+
+	rp->ts_recv.last = hdr->ts;
+
+	if (discard) {
+		++rp->stats.n_discard;
+		goto unlock;
+	}
+
+ out:
+	/* TODO:  what if lostc > 1 ?*/
+	/* PLC should generate lostc frames here. Not only one.
+	 * aubuf should replace PLC frames with late arriving real frames.
+	 * It should use timestamp to decide if a frame should be replaced. */
+/*        if (lostc)*/
+/*                (void)aup_stream_decode(rp, hdr, mb, lostc, drop);*/
+
+	(void)aup_stream_decode(rp, hdr, mb, 0, drop);
+
+unlock:
+	mtx_unlock(rp->mtx);
+}
+
+
+void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->extmap_aulevel = aulevel;
+	mtx_unlock(rp->mtx);
+}
+
+
+void aup_set_telev_pt(struct aurpipe *rp, int pt)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->telev_pt = pt;
+	mtx_unlock(rp->mtx);
+}
+
+
+uint64_t aup_latency(const struct aurpipe *rp)
+{
+	uint64_t bpms;
+	if (!rp || !rp->aubuf)
+		return 0;
+
+	mtx_lock(rp->mtx);
+	bpms = rp->srate * rp->ch * aufmt_sample_size(rp->fmt) / 1000;
+	mtx_unlock(rp->mtx);
+	if (bpms) {
+		uint64_t val = aubuf_cur_size(rp->aubuf) / bpms;
+
+		return val;
+	}
+
+	return 0;
+}
+
+
+int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+	      size_t sampc)
+{
+	struct aurpipe *rp;
+	int err;
+
+	if (!aupp)
+		return EINVAL;
+
+	rp = mem_zalloc(sizeof(*rp), destructor);
+	if (!rp)
+		return ENOMEM;
+
+	rp->cfg = cfg;
+	rp->srate = cfg->srate_play;
+	rp->ch    = cfg->channels_play;
+	rp->fmt   = cfg->play_fmt;
+	rp->sampvsz = sampc * aufmt_sample_size(rp->fmt);
+	rp->sampv   = mem_zalloc(rp->sampvsz, NULL);
+	if (!rp->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	err = mutex_alloc(&rp->mtx);
+
+out:
+	if (err)
+		rp = mem_deref(rp);
+	else
+		*aupp = rp;
+
+	return err;
+}
+
+
+void aup_flush(struct aurpipe *rp)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	aubuf_flush(rp->aubuf);
+
+	/* Reset audio filter chain */
+	list_flush(&rp->filtl);
+	mtx_unlock(rp->mtx);
+}
+
+
+int aup_decoder_set(struct aurpipe *rp,
+		    const struct aucodec *ac, const char *params)
+{
+	int err = 0;
+
+	if (!rp || !ac)
+		return EINVAL;
+
+	info("audio: Set audio decoder: %s %uHz %dch\n",
+	     ac->name, ac->srate, ac->ch);
+
+	mtx_lock(rp->mtx);
+	if (ac != rp->ac) {
+		rp->ac = ac;
+		rp->dec = mem_deref(rp->dec);
+	}
+
+	if (ac->decupdh) {
+		err = ac->decupdh(&rp->dec, ac, params);
+		if (err) {
+			warning("aurpipe: alloc decoder: %m\n", err);
+			goto out;
+		}
+	}
+
+out:
+	mtx_unlock(rp->mtx);
+	return err;
+}
+
+
+int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst)
+{
+	if (!rp || !decst)
+		return EINVAL;
+
+	mtx_lock(rp->mtx);
+	list_append(&rp->filtl, &decst->le, decst);
+	mtx_unlock(rp->mtx);
+
+	return 0;
+}
+
+
+bool aup_filt_empty(const struct aurpipe *rp)
+{
+	bool empty;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	empty = list_isempty(&rp->filtl);
+	mtx_unlock(rp->mtx);
+
+	return empty;
+}
+
+
+bool aup_level_set(const struct aurpipe *rp)
+{
+	bool set;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	set = rp->level_set;
+	mtx_unlock(rp->mtx);
+
+	return set;
+}
+
+
+double aup_level(const struct aurpipe *rp)
+{
+	double v;
+	if (!rp)
+		return 0.0;
+
+	mtx_lock(rp->mtx);
+	v = rp->level_last;
+	mtx_unlock(rp->mtx);
+
+	return v;
+}
+
+
+const struct aucodec *aup_codec(const struct aurpipe *rp)
+{
+	const struct aucodec *ac;
+
+	if (!rp)
+		return NULL;
+
+	mtx_lock(rp->mtx);
+	ac = rp->ac;
+	mtx_unlock(rp->mtx);
+	return ac;
+}
+
+
+void aup_read(struct aurpipe *rp, struct auframe *af)
+{
+	size_t num_bytes = auframe_size(af);
+
+	mtx_lock(rp->mtx);
+	if (rp->aubuf_started && aubuf_cur_size(rp->aubuf) < num_bytes) {
+
+		++rp->stats.aubuf_underrun;
+
+#if 0
+		debug("aurpipe: aubuf underrun (total %llu)\n",
+			rp->stats.aubuf_underrun);
+#endif
+	}
+
+	mtx_unlock(rp->mtx);
+	aubuf_read_auframe(rp->aubuf, af);
+}
+
+
+void aup_stop(struct aurpipe *rp)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->ac = NULL;
+	mtx_unlock(rp->mtx);
+}
+
+
+bool aup_started(const struct aurpipe *rp)
+{
+	bool started;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	started = rp->aubuf_started;
+	mtx_unlock(rp->mtx);
+
+	return started;
+}
+
+
+int aup_debug(struct re_printf *pf, const struct aurpipe *rp)
+{
+	struct mbuf *mb;
+	uint64_t bpms;
+	int err;
+
+	if (!rp)
+		return 0;
+
+	mb = mbuf_alloc(32);
+	if (!mb)
+		return ENOMEM;
+
+	mtx_lock(rp->mtx);
+	bpms = rp->srate * rp->ch * aufmt_sample_size(rp->fmt) / 1000;
+	err  = mbuf_printf(mb,
+			   " rx:   decode: %H %s\n",
+			   aucodec_print, rp->ac,
+			   aufmt_name(rp->fmt));
+	err |= mbuf_printf(mb, "       aubuf: %H"
+			   " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
+			   aubuf_debug, rp->aubuf,
+			   aubuf_cur_size(rp->aubuf) / bpms,
+			   rp->aubuf_maxsz / bpms,
+			   rp->stats.aubuf_overrun,
+			   rp->stats.aubuf_underrun);
+	err |= mbuf_printf(mb, "       n_discard:%llu\n",
+			   rp->stats.n_discard);
+	if (rp->level_set) {
+		err |= mbuf_printf(mb, "       level %.3f dBov\n",
+				   rp->level_last);
+	}
+	if (rp->ts_recv.is_set) {
+		err |= mbuf_printf(mb, "       time = %.3f sec\n",
+				   aup_calc_seconds(rp));
+	}
+	else {
+		err |= mbuf_printf(mb, "       time = (not started)\n");
+	}
+	mtx_unlock(rp->mtx);
+
+	if (err)
+		goto out;
+
+	err = re_hprintf(pf, "%b", mb->buf, mb->pos);
+out:
+	mem_deref(mb);
+	return err;
+}
+
+
+int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp)
+{
+	struct mbuf *mb;
+	struct le *le;
+	int err;
+
+	if (!rp)
+		return 0;
+
+	mb = mbuf_alloc(32);
+	if (!mb)
+		return ENOMEM;
+
+	err = mbuf_printf(mb, " <--- aubuf");
+	mtx_lock(rp->mtx);
+	for (le = list_head(&rp->filtl); le; le = le->next) {
+		struct aufilt_dec_st *st = le->data;
+
+		if (st->af->dech)
+			err |= mbuf_printf(mb, " <--- %s", st->af->name);
+	}
+
+	err |= mbuf_printf(mb, " <--- %s\n",
+			  rp->ac ? rp->ac->name : "(decoder)");
+	mtx_unlock(rp->mtx);
+
+	if (err)
+		goto out;
+
+	err = re_hprintf(pf, "%b", mb->buf, mb->pos);
+out:
+	mem_deref(mb);
+	return err;
+}

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -68,7 +68,7 @@ static void destructor(void *arg)
 }
 
 
-static int aup_process_decfilt(struct audio_recv *ar, struct auframe *af)
+static int aur_process_decfilt(struct audio_recv *ar, struct auframe *af)
 {
 	int err = 0;
 
@@ -87,7 +87,7 @@ static int aup_process_decfilt(struct audio_recv *ar, struct auframe *af)
 }
 
 
-static double aup_calc_seconds(const struct audio_recv *ar)
+static double aur_calc_seconds(const struct audio_recv *ar)
 {
 	uint64_t dur;
 	double seconds;
@@ -102,7 +102,7 @@ static double aup_calc_seconds(const struct audio_recv *ar)
 }
 
 
-static int aup_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
+static int aur_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
 {
 	size_t min_sz;
 	size_t max_sz;
@@ -133,14 +133,14 @@ static int aup_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
 }
 
 
-static int aup_push_aubuf(struct audio_recv *ar, const struct auframe *af)
+static int aur_push_aubuf(struct audio_recv *ar, const struct auframe *af)
 {
 	int err;
 	uint64_t bpms;
 
 	if (!ar->aubuf) {
 		mtx_lock(ar->aubuf_mtx);
-		err = aup_alloc_aubuf(ar, af);
+		err = aur_alloc_aubuf(ar, af);
 		mtx_unlock(ar->aubuf_mtx);
 		if (err)
 			return err;
@@ -163,7 +163,7 @@ static int aup_push_aubuf(struct audio_recv *ar, const struct auframe *af)
 }
 
 
-static int aup_stream_decode(struct audio_recv *ar,
+static int aur_stream_decode(struct audio_recv *ar,
 			     const struct rtp_header *hdr,
 			     struct mbuf *mb, unsigned lostc, bool drop)
 {
@@ -219,11 +219,11 @@ static int aup_stream_decode(struct audio_recv *ar,
 	if (flush)
 		aubuf_flush(ar->aubuf);
 
-	err = aup_process_decfilt(ar, &af);
+	err = aur_process_decfilt(ar, &af);
 	if (err)
 		goto out;
 
-	err = aup_push_aubuf(ar, &af);
+	err = aur_push_aubuf(ar, &af);
  out:
 	return err;
 }
@@ -245,7 +245,7 @@ static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
 
 
 /* Handle incoming stream data from the network */
-void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+void aur_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore)
 {
@@ -313,16 +313,16 @@ void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 	 * aubuf should replace PLC frames with late arriving real frames.
 	 * It should use timestamp to decide if a frame should be replaced. */
 /*        if (lostc)*/
-/*                (void)aup_stream_decode(ar, hdr, mb, lostc, drop);*/
+/*                (void)aur_stream_decode(ar, hdr, mb, lostc, drop);*/
 
-	(void)aup_stream_decode(ar, hdr, mb, 0, drop);
+	(void)aur_stream_decode(ar, hdr, mb, 0, drop);
 
 unlock:
 	mtx_unlock(ar->mtx);
 }
 
 
-void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel)
+void aur_set_extmap(struct audio_recv *ar, uint8_t aulevel)
 {
 	if (!ar)
 		return;
@@ -333,7 +333,7 @@ void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel)
 }
 
 
-void aup_set_telev_pt(struct audio_recv *ar, int pt)
+void aur_set_telev_pt(struct audio_recv *ar, int pt)
 {
 	if (!ar)
 		return;
@@ -344,7 +344,7 @@ void aup_set_telev_pt(struct audio_recv *ar, int pt)
 }
 
 
-uint64_t aup_latency(const struct audio_recv *ar)
+uint64_t aur_latency(const struct audio_recv *ar)
 {
 	if (!ar)
 		return 0;
@@ -353,7 +353,7 @@ uint64_t aup_latency(const struct audio_recv *ar)
 }
 
 
-int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
+int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc)
 {
 	struct audio_recv *ar;
@@ -390,7 +390,7 @@ out:
 }
 
 
-void aup_flush(struct audio_recv *ar)
+void aur_flush(struct audio_recv *ar)
 {
 	if (!ar)
 		return;
@@ -404,7 +404,7 @@ void aup_flush(struct audio_recv *ar)
 }
 
 
-int aup_decoder_set(struct audio_recv *ar,
+int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params)
 {
 	int err = 0;
@@ -435,7 +435,7 @@ out:
 }
 
 
-int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
+int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
 {
 	if (!ar || !decst)
 		return EINVAL;
@@ -448,7 +448,7 @@ int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
 }
 
 
-bool aup_filt_empty(const struct audio_recv *ar)
+bool aur_filt_empty(const struct audio_recv *ar)
 {
 	bool empty;
 	if (!ar)
@@ -462,7 +462,7 @@ bool aup_filt_empty(const struct audio_recv *ar)
 }
 
 
-bool aup_level_set(const struct audio_recv *ar)
+bool aur_level_set(const struct audio_recv *ar)
 {
 	bool set;
 	if (!ar)
@@ -476,7 +476,7 @@ bool aup_level_set(const struct audio_recv *ar)
 }
 
 
-double aup_level(const struct audio_recv *ar)
+double aur_level(const struct audio_recv *ar)
 {
 	double v;
 	if (!ar)
@@ -490,7 +490,7 @@ double aup_level(const struct audio_recv *ar)
 }
 
 
-const struct aucodec *aup_codec(const struct audio_recv *ar)
+const struct aucodec *aur_codec(const struct audio_recv *ar)
 {
 	const struct aucodec *ac;
 
@@ -504,7 +504,7 @@ const struct aucodec *aup_codec(const struct audio_recv *ar)
 }
 
 
-void aup_read(struct audio_recv *ar, struct auframe *af)
+void aur_read(struct audio_recv *ar, struct auframe *af)
 {
 	if (!ar || mtx_trylock(ar->aubuf_mtx) != thrd_success)
 		return;
@@ -514,7 +514,7 @@ void aup_read(struct audio_recv *ar, struct auframe *af)
 }
 
 
-void aup_stop(struct audio_recv *ar)
+void aur_stop(struct audio_recv *ar)
 {
 	if (!ar)
 		return;
@@ -525,7 +525,7 @@ void aup_stop(struct audio_recv *ar)
 }
 
 
-bool aup_started(const struct audio_recv *ar)
+bool aur_started(const struct audio_recv *ar)
 {
 	bool ret;
 
@@ -538,7 +538,7 @@ bool aup_started(const struct audio_recv *ar)
 }
 
 
-int aup_debug(struct re_printf *pf, const struct audio_recv *ar)
+int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
 	uint64_t bpms;
@@ -572,7 +572,7 @@ int aup_debug(struct re_printf *pf, const struct audio_recv *ar)
 	}
 	if (ar->ts_recv.is_set) {
 		err |= mbuf_printf(mb, "       time = %.3f sec\n",
-				   aup_calc_seconds(ar));
+				   aur_calc_seconds(ar));
 	}
 	else {
 		err |= mbuf_printf(mb, "       time = (not started)\n");
@@ -590,7 +590,7 @@ out:
 }
 
 
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar)
+int aur_print_pipeline(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
 	struct le *le;

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -137,7 +137,7 @@ static int aup_push_aubuf(struct aurpipe *rp, const struct auframe *af)
 	int err;
 	uint64_t bpms;
 
-	if (!rp->aubuf) {
+	if (!re_atomic_rlx(&rp->ready)) {
 		err = aup_alloc_aubuf(rp, af);
 		if (err)
 			return err;

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -566,7 +566,7 @@ bool aur_started(const struct audio_recv *ar)
 int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
-	uint64_t bpms;
+	double bpms;
 	int err;
 
 	if (!ar || mtx_trylock(ar->aubuf_mtx) != thrd_success)
@@ -579,7 +579,8 @@ int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 	}
 
 	mtx_lock(ar->mtx);
-	bpms = ar->srate * ar->ch * aufmt_sample_size(ar->fmt) / 1000;
+	bpms = (double) (uint64_t) (ar->srate * ar->ch *
+				    aufmt_sample_size(ar->fmt) / 1000);
 	err  = mbuf_printf(mb,
 			   " rx:   decode: %H %s\n",
 			   aucodec_print, ar->ac,
@@ -590,8 +591,10 @@ int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 			   aubuf_cur_size(ar->aubuf) / bpms,
 			   aubuf_maxsz(ar->aubuf) / bpms);
 #ifndef RELEASE
-	err |= mbuf_printf(mb, "       SW jitter: %u\n", ar->stats.jitter);
-	err |= mbuf_printf(mb, "       deviation: %d\n", ar->stats.dmax);
+	err |= mbuf_printf(mb, "       SW jitter: %.2fms\n",
+			   (double) ar->stats.jitter / 1000);
+	err |= mbuf_printf(mb, "       deviation: %.2fms\n",
+			   (double) ar->stats.dmax / 1000);
 #endif
 	err |= mbuf_printf(mb, "       n_discard: %llu\n",
 			   ar->stats.n_discard);

--- a/src/config.c
+++ b/src/config.c
@@ -98,7 +98,8 @@ static struct config core_config = {
 		},
 		false,
 		0,
-		false
+		false,
+		RECEIVE_MODE_MAIN,
 	},
 
 	/* Network */
@@ -313,6 +314,7 @@ static const char *net_af_str(int af)
 int config_parse_conf(struct config *cfg, const struct conf *conf)
 {
 	struct vidsz size = {0, 0};
+	struct pl rxmode;
 	struct pl txmode;
 	struct pl jbtype;
 	struct pl tr;
@@ -470,6 +472,11 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
+	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
+
+		if (0 == pl_strcasecmp(&rxmode, "thread"))
+			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
+	}
 
 	if (err) {
 		warning("config: configure parse error (%m)\n", err);
@@ -571,6 +578,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "avt_bundle\t\t%s\n"
+			 "rtp_rxmode\t\t\t%s\n"
 			 "\n"
 			 "# Network\n"
 			 "net_interface\t\t%s\n"
@@ -625,6 +633,8 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 			 cfg->avt.bundle ? "yes" : "no",
+			 cfg->avt.rxmode == RECEIVE_MODE_THREAD ? "thread" :
+								  "main",
 
 			 cfg->net.ifname,
 			 net_af_str(cfg->net.af)
@@ -835,6 +845,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "#avt_bundle\t\tno\n"
+			  "#rtp_rxmode\t\tmain\n"
 			  "\n# Network\n"
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"

--- a/src/config.c
+++ b/src/config.c
@@ -474,8 +474,11 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
 	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
 
-		if (0 == pl_strcasecmp(&rxmode, "thread"))
+		if (0 == pl_strcasecmp(&rxmode, "thread")) {
 			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
+			warning("rtp_rxmode thread is currently "
+				"experimental\n");
+		}
 	}
 
 	if (err) {

--- a/src/config.c
+++ b/src/config.c
@@ -474,11 +474,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
 	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
 
-		if (0 == pl_strcasecmp(&rxmode, "thread")) {
+		if (0 == pl_strcasecmp(&rxmode, "thread"))
 			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
-			warning("rtp_rxmode thread is currently "
-				"experimental\n");
-		}
 	}
 
 	if (err) {

--- a/src/core.h
+++ b/src/core.h
@@ -113,6 +113,36 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*
+ * Audio Receiver Pipeline
+ */
+
+struct aurpipe;
+
+int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+	      size_t sampc);
+int aup_decoder_set(struct aurpipe *rp,
+		    const struct aucodec *ac, const char *params);
+int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst);
+void aup_flush(struct aurpipe *rp);
+void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel);
+void aup_set_telev_pt(struct aurpipe *rp, int pt);
+void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+		 struct rtpext *extv, size_t extc,
+		 struct mbuf *mb, unsigned lostc, bool *ignore);
+void aup_read(struct aurpipe *rp, struct auframe *af);
+void aup_stop(struct aurpipe *rp);
+
+const struct aucodec *aup_codec(const struct aurpipe *rp);
+uint64_t aup_latency(const struct aurpipe *rp);
+bool aup_started(const struct aurpipe *rp);
+bool aup_filt_empty(const struct aurpipe *rp);
+bool aup_level_set(const struct aurpipe *rp);
+double aup_level(const struct aurpipe *rp);
+int aup_debug(struct re_printf *pf, const struct aurpipe *rp);
+int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp);
+
+
+/*
  * Call Control
  */
 

--- a/src/core.h
+++ b/src/core.h
@@ -116,30 +116,30 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
  * Audio Receiver Pipeline
  */
 
-struct aurpipe;
+struct audio_recv;
 
-int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct aurpipe *rp,
+int aup_decoder_set(struct audio_recv *rp,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst);
-void aup_flush(struct aurpipe *rp);
-void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel);
-void aup_set_telev_pt(struct aurpipe *rp, int pt);
-void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+int aup_filt_append(struct audio_recv *rp, struct aufilt_dec_st *decst);
+void aup_flush(struct audio_recv *rp);
+void aup_set_extmap(struct audio_recv *rp, uint8_t aulevel);
+void aup_set_telev_pt(struct audio_recv *rp, int pt);
+void aup_receive(struct audio_recv *rp, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct aurpipe *rp, struct auframe *af);
-void aup_stop(struct aurpipe *rp);
+void aup_read(struct audio_recv *rp, struct auframe *af);
+void aup_stop(struct audio_recv *rp);
 
-const struct aucodec *aup_codec(const struct aurpipe *rp);
-uint64_t aup_latency(const struct aurpipe *rp);
-bool aup_started(const struct aurpipe *rp);
-bool aup_filt_empty(const struct aurpipe *rp);
-bool aup_level_set(const struct aurpipe *rp);
-double aup_level(const struct aurpipe *rp);
-int aup_debug(struct re_printf *pf, const struct aurpipe *rp);
-int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp);
+const struct aucodec *aup_codec(const struct audio_recv *rp);
+uint64_t aup_latency(const struct audio_recv *rp);
+bool aup_started(const struct audio_recv *rp);
+bool aup_filt_empty(const struct audio_recv *rp);
+bool aup_level_set(const struct audio_recv *rp);
+double aup_level(const struct audio_recv *rp);
+int aup_debug(struct re_printf *pf, const struct audio_recv *rp);
+int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *rp);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -119,7 +119,7 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 struct audio_recv;
 
 int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
-	      size_t sampc);
+	      size_t sampc, uint32_t ptime);
 int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
 int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);

--- a/src/core.h
+++ b/src/core.h
@@ -120,26 +120,26 @@ struct audio_recv;
 
 int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct audio_recv *rp,
+int aup_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct audio_recv *rp, struct aufilt_dec_st *decst);
-void aup_flush(struct audio_recv *rp);
-void aup_set_extmap(struct audio_recv *rp, uint8_t aulevel);
-void aup_set_telev_pt(struct audio_recv *rp, int pt);
-void aup_receive(struct audio_recv *rp, const struct rtp_header *hdr,
+int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
+void aup_flush(struct audio_recv *ar);
+void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel);
+void aup_set_telev_pt(struct audio_recv *ar, int pt);
+void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct audio_recv *rp, struct auframe *af);
-void aup_stop(struct audio_recv *rp);
+void aup_read(struct audio_recv *ar, struct auframe *af);
+void aup_stop(struct audio_recv *ar);
 
-const struct aucodec *aup_codec(const struct audio_recv *rp);
-uint64_t aup_latency(const struct audio_recv *rp);
-bool aup_started(const struct audio_recv *rp);
-bool aup_filt_empty(const struct audio_recv *rp);
-bool aup_level_set(const struct audio_recv *rp);
-double aup_level(const struct audio_recv *rp);
-int aup_debug(struct re_printf *pf, const struct audio_recv *rp);
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *rp);
+const struct aucodec *aup_codec(const struct audio_recv *ar);
+uint64_t aup_latency(const struct audio_recv *ar);
+bool aup_started(const struct audio_recv *ar);
+bool aup_filt_empty(const struct audio_recv *ar);
+bool aup_level_set(const struct audio_recv *ar);
+double aup_level(const struct audio_recv *ar);
+int aup_debug(struct re_printf *pf, const struct audio_recv *ar);
+int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -118,28 +118,28 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 struct audio_recv;
 
-int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
+int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct audio_recv *ar,
+int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
-void aup_flush(struct audio_recv *ar);
-void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel);
-void aup_set_telev_pt(struct audio_recv *ar, int pt);
-void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
+void aur_flush(struct audio_recv *ar);
+void aur_set_extmap(struct audio_recv *ar, uint8_t aulevel);
+void aur_set_telev_pt(struct audio_recv *ar, int pt);
+void aur_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct audio_recv *ar, struct auframe *af);
-void aup_stop(struct audio_recv *ar);
+void aur_read(struct audio_recv *ar, struct auframe *af);
+void aur_stop(struct audio_recv *ar);
 
-const struct aucodec *aup_codec(const struct audio_recv *ar);
-uint64_t aup_latency(const struct audio_recv *ar);
-bool aup_started(const struct audio_recv *ar);
-bool aup_filt_empty(const struct audio_recv *ar);
-bool aup_level_set(const struct audio_recv *ar);
-double aup_level(const struct audio_recv *ar);
-int aup_debug(struct re_printf *pf, const struct audio_recv *ar);
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
+const struct aucodec *aur_codec(const struct audio_recv *ar);
+uint64_t aur_latency(const struct audio_recv *ar);
+bool aur_started(const struct audio_recv *ar);
+bool aur_filt_empty(const struct audio_recv *ar);
+bool aur_level_set(const struct audio_recv *ar);
+double aur_level(const struct audio_recv *ar);
+int aur_debug(struct re_printf *pf, const struct audio_recv *ar);
+int aur_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -472,6 +472,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 		    struct mbuf *mb, void *arg);
 void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
 			 void *arg);
+void rtprecv_set_socket(struct rtp_receiver *rx, struct rtp_sock *rtp);
 void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc);
 uint64_t rtprecv_ts_last(struct rtp_receiver *rx);
 void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last);
@@ -480,7 +481,7 @@ void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
-int  rtprecv_start_thread(struct rtp_receiver *rx, struct rtp_sock *rtp);
+int  rtprecv_start_thread(struct rtp_receiver *rx);
 void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 				    const struct sa *raddr2, void *arg);
 bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/core.h
+++ b/src/core.h
@@ -261,7 +261,7 @@ enum media_type {
 };
 
 struct sender;
-struct receiver;
+struct rtp_receiver;
 struct stream;
 struct rtp_header;
 
@@ -316,6 +316,9 @@ void stream_enable_bundle(struct stream *strm, enum bundle_state st);
 void stream_enable_natpinhole(struct stream *strm, bool enable);
 void stream_open_natpinhole(struct stream *strm);
 void stream_stop_natpinhole(struct stream *strm);
+void stream_process_rtcp(struct stream *strm, struct rtcp_msg *msg);
+void stream_mnat_connected(struct stream *strm, const struct sa *raddr1,
+			   const struct sa *raddr2);
 
 
 /*
@@ -451,3 +454,33 @@ struct media_track *mediatrack_lookup_media(const struct list *medial,
 					    struct stream *strm);
 void mediatrack_close(struct media_track *media, int err);
 void mediatrack_sdp_attr_decode(struct media_track *media);
+
+/*
+ * Stream RTP receiver
+ */
+int  rtprecv_alloc(struct rtp_receiver **rxp,
+		   struct stream *strm,
+		   const char *name,
+		   const struct config_avt *cfg,
+		   stream_rtp_h *rtph,
+		   stream_pt_h *pth, void *arg);
+void rtprecv_set_handlers(struct rtp_receiver *rx,
+			  stream_rtpestab_h *rtpestabh, void *arg);
+struct metric *rtprecv_metric(struct rtp_receiver *rx);
+struct jbuf *rtprecv_jbuf(struct rtp_receiver *rx);
+void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
+		    struct mbuf *mb, void *arg);
+void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
+			 void *arg);
+void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc);
+uint64_t rtprecv_ts_last(struct rtp_receiver *rx);
+void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last);
+void rtprecv_flush(struct rtp_receiver *rx);
+void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
+int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
+void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
+int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
+int  rtprecv_start_thread(struct rtp_receiver *rx, struct rtp_sock *rtp);
+void rtprecv_mnat_connected_handler(const struct sa *raddr1,
+				    const struct sa *raddr2, void *arg);
+bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -553,16 +553,11 @@ int rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx)
 static void destructor(void *arg)
 {
 	struct rtp_receiver *rx = arg;
-	bool join = false;
 
-	mtx_lock(rx->mtx);
 	if (re_atomic_rlx(&rx->run)) {
-		join = true;
 		re_atomic_rlx_set(&rx->run, false);
-	}
-	mtx_unlock(rx->mtx);
-	if (join)
 		thrd_join(rx->thr, NULL);
+	}
 
 	re_thread_async_main_cancel((intptr_t)rx);
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -1,0 +1,746 @@
+/**
+ * @file rtprecv.c  Generic RTP stream receiver
+ *
+ * Copyright (C) 2023 Alfred E. Heggestad, Christian Spielberger
+ */
+#include <string.h>
+#include <time.h>
+#include <re.h>
+#include <baresip.h>
+#include "core.h"
+
+/** Magic number */
+#define MAGIC 0x00511eb3
+#include "magic.h"
+
+/* Receive */
+struct rtp_receiver {
+#ifndef RELEASE
+	uint32_t magic;                /**< Magic number for debugging       */
+#endif
+	/* Data protected by mtx */
+	char *name;                    /**< Media name                       */
+	struct metric *metric;         /**< Metrics for receiving            */
+	struct jbuf *jbuf;             /**< Jitter Buffer for incoming RTP   */
+	bool enabled;                  /**< True if enabled                  */
+	uint64_t ts_last;              /**< Timestamp of last recv RTP pkt   */
+	uint32_t ssrc;                 /**< Incoming synchronization source  */
+	bool ssrc_set;                 /**< Incoming SSRC is set             */
+	uint32_t pseq;                 /**< Sequence number for incoming RTP */
+	bool pseq_set;                 /**< True if sequence number is set   */
+	bool rtp_estab;                /**< True if RTP stream established   */
+	bool run;                      /**< True if RX thread is running     */
+	mtx_t *mtx;                    /**< Mutex protects above fields      */
+
+	/* Unprotected data */
+	struct stream *strm;           /**< Stream                           */
+	struct rtp_sock *rtp;          /**< RTP Socket                       */
+	stream_pt_h *pth;              /**< Stream payload type handler      */
+	stream_rtp_h *rtph;            /**< Stream RTP handler               */
+	stream_rtpestab_h *rtpestabh;  /**< RTP established handler          */
+	void *arg;                     /**< Stream argument                  */
+	void *sessarg;                 /**< Session argument                 */
+	thrd_t thr;                    /**< RX thread                        */
+	struct tmr tmr;                /**< Timer for stopping RX thread     */
+	int pt;                        /**< Previous payload type            */
+};
+
+
+enum work_type {
+	WORK_RTCP,
+	WORK_RTPESTAB,
+	WORK_PTCHANGED,
+	WORK_MNATCONNH,
+};
+
+
+struct work {
+	enum work_type type;
+	struct rtp_receiver *rx;
+	union {
+		struct rtcp_msg *rtcp;
+		struct {
+			uint8_t pt;
+			struct mbuf *mb;
+		} pt;
+		struct {
+			struct sa raddr1;
+			struct sa raddr2;
+		} mnat;
+	} u;
+};
+
+
+static void async_work_main(int err, void *arg);
+static void work_destructor(void *arg);
+
+
+/*
+ * functions that run in RX thread (if "rxmode thread" is configured)
+ */
+
+
+static void pass_rtcp_work(struct rtp_receiver *rx, struct rtcp_msg *msg)
+{
+	struct work *w;
+
+	if (!rx->run) {
+		stream_process_rtcp(rx->strm, msg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	if (!w)
+		return;
+
+	w->type    = WORK_RTCP;
+	w->rx      = rx;
+	w->u.rtcp  = mem_ref(msg);
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static int pass_pt_work(struct rtp_receiver *rx, uint8_t pt, struct mbuf *mb)
+{
+	struct work *w;
+
+	if (!rx->run)
+		return rx->pth(pt, mb, rx->arg);
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type    = WORK_PTCHANGED;
+	w->rx      = rx;
+	w->u.pt.pt = pt;
+	w->u.pt.mb = mbuf_dup(mb);
+
+	return re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_rtpestab_work(struct rtp_receiver *rx)
+{
+	struct work *w;
+
+	if (!rx->run) {
+		rx->rtpestabh(rx->strm, rx->sessarg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_RTPESTAB;
+	w->rx   = rx;
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_mnat_work(struct rtp_receiver *rx, const struct sa *raddr1,
+			   const struct sa *raddr2)
+{
+	struct work *w;
+
+	if (!rx->run) {
+		stream_mnat_connected(rx->strm, raddr1, raddr2);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_MNATCONNH;
+	w->rx   = rx;
+	sa_cpy(&w->u.mnat.raddr1, raddr1);
+	sa_cpy(&w->u.mnat.raddr2, raddr2);
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void rtprecv_check_stop(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	bool run;
+
+	mtx_lock(rx->mtx);
+	run = rx->run;
+	mtx_unlock(rx->mtx);
+	if (run)
+		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+	else
+		re_cancel();
+}
+
+
+static int rtprecv_thread(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	int err;
+
+	re_thread_init();
+	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+
+	err = udp_thread_attach(rtp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = udp_thread_attach(rtcp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = re_main(NULL);
+
+	tmr_cancel(&rx->tmr);
+	re_thread_close();
+	return err;
+}
+
+
+static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
+{
+	const uint16_t delta = seq - rx->pseq;
+	int lostc;
+
+	if (rx->pseq == (uint32_t)-1)
+		lostc = 0;
+	else if (delta == 0)
+		return -1;
+	else if (delta < 3000)
+		lostc = delta - 1;
+	else if (delta < 0xff9c)
+		lostc = 0;
+	else
+		return -2;
+
+	rx->pseq = seq;
+	return lostc;
+}
+
+
+static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
+		      struct mbuf *mb, unsigned lostc, bool drop)
+{
+	struct rtpext extv[8];
+	size_t extc = 0;
+	bool ignore = drop;
+
+	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
+	if (hdr->ext && hdr->x.len && mb) {
+
+		const size_t pos = mb->pos;
+		const size_t end = mb->end;
+		const size_t ext_stop = mb->pos;
+		size_t i;
+		int err;
+
+		if (hdr->x.type != RTPEXT_TYPE_MAGIC) {
+			debug("stream: unknown ext type ignored (0x%04x)\n",
+			     hdr->x.type);
+			goto handler;
+		}
+
+		size_t ext_len = hdr->x.len*sizeof(uint32_t);
+		if (mb->pos < ext_len) {
+			warning("stream: corrupt rtp packet,"
+				" not enough space for rtpext of %zu bytes\n",
+				ext_len);
+			return 0;
+		}
+
+		mb->pos = mb->pos - ext_len;
+		mb->end = ext_stop;
+
+		for (i=0; i<RE_ARRAY_SIZE(extv) && mbuf_get_left(mb); i++) {
+
+			err = rtpext_decode(&extv[i], mb);
+			if (err) {
+				warning("stream: rtpext_decode failed (%m)\n",
+					err);
+				return 0;
+			}
+		}
+
+		extc = i;
+
+		mb->pos = pos;
+		mb->end = end;
+	}
+
+ handler:
+	stream_stop_natpinhole(rx->strm);
+
+	rx->rtph(hdr, extv, extc, mb, lostc, &ignore, rx->arg);
+	if (ignore)
+		return EAGAIN;
+
+	return 0;
+}
+
+
+/**
+ * Decodes one RTP packet
+ *
+ * @param s The stream
+ *
+ * @return 0 if success, EAGAIN if it should be called again in order to avoid
+ * a jitter buffer overflow, otherwise errorcode
+ */
+static int decode_frame(struct rtp_receiver *rx)
+{
+	struct rtp_header hdr;
+	void *mb;
+	int lostc;
+	int err;
+	int err2;
+
+	if (!rx)
+		return EINVAL;
+
+	if (!rx->jbuf)
+		return ENOENT;
+
+	err = jbuf_get(rx->jbuf, &hdr, &mb);
+	if (err && err != EAGAIN)
+		return ENOENT;
+
+	lostc = lostcalc(rx, hdr.seq);
+
+	err2 = handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0, err == EAGAIN);
+	mem_deref(mb);
+
+	if (err2 == EAGAIN)
+		return err2;
+
+	return err;
+}
+
+
+void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
+		     struct mbuf *mb, void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	uint32_t ssrc0;
+	bool flush = false;
+	bool first = false;
+	int err = 0;
+
+	MAGIC_CHECK(rx);
+	if (!rx)
+		return;
+
+	mtx_lock(rx->mtx);
+	if (!rx->enabled)
+		goto unlock;
+
+	if (rtp_pt_is_rtcp(hdr->pt)) {
+		debug("stream: drop incoming RTCP packet on RTP port"
+		     " (pt=%u)\n", hdr->pt);
+		err = ENOENT;
+		goto unlock;
+	}
+
+	rx->ts_last = tmr_jiffies();
+
+	metric_add_packet(rx->metric, mbuf_get_left(mb));
+
+	if (!rx->rtp_estab) {
+		if (rx->rtpestabh) {
+			debug("stream: incoming rtp for '%s' established, "
+			      "receiving from %J\n", rx->name, src);
+			rx->rtp_estab = true;
+			pass_rtpestab_work(rx);
+		}
+	}
+
+	ssrc0 = rx->ssrc;
+	if (!rx->pseq_set) {
+		rx->ssrc = hdr->ssrc;
+		rx->ssrc_set = true;
+		rx->pseq = hdr->seq - 1;
+		rx->pseq_set = true;
+		first = true;
+	}
+	else if (hdr->ssrc != ssrc0) {
+
+		debug("stream: %s: SSRC changed 0x%x -> 0x%x"
+		     " (%u bytes from %J)\n",
+		     rx->name, ssrc0, hdr->ssrc,
+		     mbuf_get_left(mb), src);
+
+		rx->ssrc = hdr->ssrc;
+		rx->pseq = hdr->seq - 1;
+		flush = true;
+	}
+	mtx_unlock(rx->mtx);
+
+	/* payload-type changed? */
+	if (hdr->pt != rx->pt) {
+		rx->pt = hdr->pt;
+
+		err = pass_pt_work(rx, hdr->pt, mb);
+		if (err && err != ENODATA)
+			goto out;
+	}
+
+	if (rx->jbuf) {
+
+		/* Put frame in Jitter Buffer */
+		if (flush)
+			jbuf_flush(rx->jbuf);
+
+		if (first && err == ENODATA)
+			goto out;
+
+		err = jbuf_put(rx->jbuf, hdr, mb);
+		if (err) {
+			info("stream: %s: dropping %u bytes from %J"
+			     " [seq=%u, ts=%u] (%m)\n",
+			     rx->name, mb->end,
+			     src, hdr->seq, hdr->ts, err);
+			metric_inc_err(rx->metric);
+		}
+
+		uint32_t n = jbuf_packets(rx->jbuf);
+		while (n--) {
+			if (decode_frame(rx) != EAGAIN)
+				break;
+		}
+	}
+	else {
+		(void)handle_rtp(rx, hdr, mb, 0, false);
+	}
+
+out:
+	return;
+
+unlock:
+	mtx_unlock(rx->mtx);
+}
+
+
+void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
+			  void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	(void)src;
+
+	MAGIC_CHECK(rx);
+
+	mtx_lock(rx->mtx);
+	rx->ts_last = tmr_jiffies();
+	mtx_unlock(rx->mtx);
+
+	pass_rtcp_work(rx, msg);
+}
+
+
+void rtprecv_mnat_connected_handler(const struct sa *raddr1,
+				     const struct sa *raddr2, void *arg)
+{
+	struct rtp_receiver *rx = arg;
+
+	MAGIC_CHECK(rx);
+
+	pass_mnat_work(rx, raddr1, raddr2);
+}
+
+
+/*
+ * functions that run in main thread
+ */
+
+void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc)
+{
+	mtx_lock(rx->mtx);
+	if (rx->ssrc_set) {
+		if (ssrc != rx->ssrc) {
+			debug("stream: receive: SSRC changed: %x -> %x\n",
+			     rx->ssrc, ssrc);
+			rx->ssrc = ssrc;
+		}
+	}
+	else {
+		debug("stream: receive: setting SSRC: %x\n", ssrc);
+		rx->ssrc = ssrc;
+		rx->ssrc_set = true;
+	}
+	mtx_unlock(rx->mtx);
+}
+
+
+uint64_t rtprecv_ts_last(struct rtp_receiver *rx)
+{
+	uint64_t ts_last;
+	mtx_lock(rx->mtx);
+	ts_last = rx->ts_last;
+	mtx_unlock(rx->mtx);
+
+	return ts_last;
+}
+
+
+void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last)
+{
+	mtx_lock(rx->mtx);
+	rx->ts_last = ts_last;
+	mtx_unlock(rx->mtx);
+}
+
+
+void rtprecv_flush(struct rtp_receiver *rx)
+{
+	if (!rx)
+		return;
+
+	jbuf_flush(rx->jbuf);
+}
+
+
+void rtprecv_set_enable(struct rtp_receiver *rx, bool enable)
+{
+	if (!rx)
+		return;
+
+	mtx_lock(rx->mtx);
+	rx->enabled = enable;
+	mtx_unlock(rx->mtx);
+}
+
+
+int rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc)
+{
+	int err;
+
+	if (!rx || !ssrc)
+		return EINVAL;
+
+	mtx_lock(rx->mtx);
+	if (rx->ssrc_set) {
+		*ssrc = rx->ssrc;
+		err = 0;
+	}
+	else
+		err = ENOENT;
+	mtx_unlock(rx->mtx);
+
+	return err;
+}
+
+
+void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable)
+{
+	mtx_lock(rx->mtx);
+	rtcp_enable_mux(rx->rtp, enable);
+	mtx_unlock(rx->mtx);
+}
+
+
+/**
+ * The debug function prints into the given mbuf in order to avoid long
+ * blocking print to stdout.
+ *
+ * @param rx The rtp_receiver
+ * @param mb Memory buffer
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx)
+{
+	int err;
+	bool enabled;
+
+	mtx_lock(rx->mtx);
+	enabled = rx->enabled;
+	mtx_unlock(rx->mtx);
+
+	err  = re_hprintf(pf, " rx.enabled: %s\n", enabled ? "yes" : "no");
+	err |= jbuf_debug(pf, rx->jbuf);
+
+	return err;
+}
+
+
+static void destructor(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	bool join = false;
+
+	mtx_lock(rx->mtx);
+	if (rx->run) {
+		join = true;
+		rx->run = false;
+	}
+	mtx_unlock(rx->mtx);
+	if (join)
+		thrd_join(rx->thr, NULL);
+
+	re_thread_async_main_cancel((intptr_t)rx);
+
+	mem_deref(rx->metric);
+	mem_deref(rx->name);
+	mem_deref(rx->mtx);
+	mem_deref(rx->jbuf);
+}
+
+
+int rtprecv_alloc(struct rtp_receiver **rxp,
+		   struct stream *strm,
+		   const char *name,
+		   const struct config_avt *cfg,
+		   stream_rtp_h *rtph,
+		   stream_pt_h *pth, void *arg)
+{
+	struct rtp_receiver *rx;
+	int err;
+
+	if (!rxp || !str_isset(name))
+		return EINVAL;
+
+	rx = mem_zalloc(sizeof(*rx), destructor);
+	if (!rx)
+		return ENOMEM;
+
+	MAGIC_INIT(rx);
+	rx->strm   = strm;
+	rx->rtph   = rtph;
+	rx->pth    = pth;
+	rx->arg    = arg;
+	rx->pseq   = -1;
+	rx->pt     = -1;
+	err  = str_dup(&rx->name, name);
+	err |= mutex_alloc(&rx->mtx);
+
+	/* Audio Jitter buffer */
+	if (stream_type(strm) == MEDIA_AUDIO &&
+	    cfg->audio.jbtype != JBUF_OFF && cfg->audio.jbuf_del.max) {
+
+		err = jbuf_alloc(&rx->jbuf, cfg->audio.jbuf_del.min,
+				 cfg->audio.jbuf_del.max);
+		err |= jbuf_set_type(rx->jbuf, cfg->audio.jbtype);
+	}
+
+	/* Video Jitter buffer */
+	if (stream_type(strm) == MEDIA_VIDEO &&
+	    cfg->video.jbtype != JBUF_OFF && cfg->video.jbuf_del.max) {
+
+		err = jbuf_alloc(&rx->jbuf, cfg->video.jbuf_del.min,
+				 cfg->video.jbuf_del.max);
+		err |= jbuf_set_type(rx->jbuf, cfg->video.jbtype);
+	}
+
+	rx->metric = metric_alloc();
+	if (!rx->metric)
+		err |= ENOMEM;
+	else
+		err |= metric_init(rx->metric);
+
+	if (err)
+		goto out;
+
+out:
+	if (err)
+		mem_deref(rx);
+	else
+		*rxp = rx;
+
+	return err;
+}
+
+
+int rtprecv_start_thread(struct rtp_receiver *rx, struct rtp_sock *rtp)
+{
+	int err;
+
+	if (!rx || !rtp)
+		return EINVAL;
+
+	if (rx->run)
+		return 0;
+
+	rx->rtp = rtp;
+	rx->run = true;
+	err = thread_create_name(&rx->thr,
+				 "RX thread",
+				 rtprecv_thread, rx);
+	if (err) {
+		rx->run = false;
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
+	}
+
+	return err;
+}
+
+
+bool rtprecv_running(const struct rtp_receiver *rx)
+{
+	if (!rx)
+		return false;
+
+	return rx->run;
+}
+
+
+void rtprecv_set_handlers(struct rtp_receiver *rx,
+			   stream_rtpestab_h *rtpestabh, void *arg)
+{
+	if (!rx)
+		return;
+
+	mtx_lock(rx->mtx);
+	rx->rtpestabh     = rtpestabh;
+	rx->sessarg       = arg;
+	mtx_unlock(rx->mtx);
+}
+
+
+struct metric *rtprecv_metric(struct rtp_receiver *rx)
+{
+	/* it is allowed to return metric because it is thread safe */
+	return rx->metric;
+}
+
+
+static void work_destructor(void *arg)
+{
+	struct work *w = arg;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			mem_deref(w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			mem_deref(w->u.pt.mb);
+			break;
+		default:
+			break;
+	}
+}
+
+
+static void async_work_main(int err, void *arg)
+{
+	struct work *w = arg;
+	struct rtp_receiver *rx = w->rx;
+	(void)err;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			stream_process_rtcp(rx->strm, w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			rx->pth(w->u.pt.pt, w->u.pt.mb, rx->arg);
+			break;
+		case WORK_RTPESTAB:
+			rx->rtpestabh(rx->strm, rx->sessarg);
+			break;
+		case WORK_MNATCONNH:
+			stream_mnat_connected(rx->strm,
+					      &w->u.mnat.raddr1,
+					      &w->u.mnat.raddr2);
+			break;
+		default:
+			break;
+	}
+
+	mem_deref(w);
+}

--- a/src/stream.c
+++ b/src/stream.c
@@ -227,7 +227,7 @@ int stream_enable_tx(struct stream *strm, bool enable)
 static void stream_start_receiver(void *arg)
 {
 	struct stream *s = arg;
-	rtprecv_start_thread(s->rx, s->rtp);
+	rtprecv_start_thread(s->rx);
 }
 
 
@@ -394,6 +394,7 @@ static int stream_sock_alloc(struct stream *s, int af)
 	else
 		udp_sockbuf_set(rtp_sock(s->rtp), 65536);
 
+	rtprecv_set_socket(s->rx, s->rtp);
 	return 0;
 }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -286,7 +286,6 @@ static void stream_close(struct stream *strm, int err)
 	strm->rx = mem_deref(strm->rx);
 	if (errorh)
 		errorh(strm, err, strm->sess_arg);
-
 }
 
 

--- a/src/video.c
+++ b/src/video.c
@@ -277,6 +277,8 @@ static void video_destructor(void *arg)
 	struct vtx *vtx = &v->vtx;
 	struct vrx *vrx = &v->vrx;
 
+	stream_enable(v->strm, false);
+
 	/* transmit */
 	if (re_atomic_rlx(&vtx->run)) {
 		re_atomic_rlx_set(&vtx->run, false);

--- a/test/call.c
+++ b/test/call.c
@@ -20,6 +20,7 @@ enum behaviour {
 	BEHAVIOUR_PROGRESS,
 	BEHAVIOUR_REJECT,
 	BEHAVIOUR_GET_HDRS,
+	BEHAVIOUR_NOTHING,
 };
 
 enum action {
@@ -1186,7 +1187,7 @@ int test_call_change_videodir(void)
 
 	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
 	cr->prm = "offer";
-	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 1);
+	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 1, 1);
 	cr->prm = "answer";
 
 	/* Set video inactive */
@@ -1264,7 +1265,7 @@ int test_call_100rel_video(void)
 	err = module_load(".", "fakevideo");
 	TEST_ERR(err);
 
-	f->behaviour = BEHAVIOUR_PROGRESS;
+	f->behaviour = BEHAVIOUR_NOTHING;
 	f->estab_action = ACTION_NOTHING;
 
 	/* Make a call from A to B */
@@ -1279,7 +1280,7 @@ int test_call_100rel_video(void)
 	/* switch off early video */
 	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 0);
 	cr->prm = "offer";
-	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 0);
+	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 1, 0);
 	cr->prm = "answer";
 
 	err = call_set_video_dir(ua_call(f->a.ua), SDP_INACTIVE);

--- a/test/call.c
+++ b/test/call.c
@@ -1116,7 +1116,7 @@ int test_call_change_videodir(void)
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
 	struct sdp_media *vm;
-	struct cancel_rule *cr, *cr_rtcp;
+	struct cancel_rule *cr, *cr_vida, *cr_vidb;
 	int err = 0;
 
 	conf_config()->video.fps = 100;
@@ -1124,8 +1124,14 @@ int test_call_change_videodir(void)
 
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
-	cr_rtcp = cancel_rule_new(UA_EVENT_CALL_RTCP, f->b.ua, 1, 0, 1);
-	cr_rtcp->prm = "video";
+
+	cr_vidb = cancel_rule_new(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 1);
+	cr_vidb->prm = "vidframe";
+	cr_vidb->n_vidframe = 3;
+	cr_vida = cancel_rule_and(UA_EVENT_CUSTOM, f->a.ua, 0, 0, 1);
+	cr_vida->prm = "vidframe";
+	cr_vida->n_vidframe = 3;
+
 	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
 	cr->n_offer_cnt = 1;
 
@@ -1154,7 +1160,7 @@ int test_call_change_videodir(void)
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
-	/* wait for CALL_RTCP at callee */
+	/* wait for video frames */
 	err = re_main_timeout(10000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
@@ -1162,6 +1168,8 @@ int test_call_change_videodir(void)
 	/* verify that video was enabled and bi-directional */
 	ASSERT_EQ(1, fix.a.n_established);
 	ASSERT_EQ(1, fix.b.n_established);
+	ASSERT_TRUE(fix.a.n_vidframe >= 3);
+	ASSERT_TRUE(fix.b.n_vidframe >= 3);
 
 	ASSERT_TRUE(call_has_video(ua_call(f->a.ua)));
 	ASSERT_TRUE(call_has_video(ua_call(f->b.ua)));
@@ -1194,7 +1202,9 @@ int test_call_change_videodir(void)
 	/* Set video sendrecv */
 	err = call_set_video_dir(ua_call(f->a.ua), SDP_SENDRECV);
 	TEST_ERR(err);
-	cr_rtcp->n_offer_cnt = 2;
+	cr_vidb->n_offer_cnt = 2;
+	cr_vidb->n_vidframe = 6;
+	cr_vida->n_vidframe = 6;
 	err = re_main_timeout(10000);
 	TEST_ERR(err);
 

--- a/test/call.c
+++ b/test/call.c
@@ -681,12 +681,13 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 }
 
 
-int test_call_answer(void)
+static int test_call_answer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 
@@ -709,18 +710,31 @@ int test_call_answer(void)
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	conf_config()->avt.rxmode  = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_reject(void)
+int test_call_answer(void)
+{
+	int err;
+
+	err  = test_call_answer_base(RECEIVE_MODE_MAIN);
+	err |= test_call_answer_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_reject_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_REJECT;
 
@@ -741,18 +755,31 @@ int test_call_reject(void)
 	ASSERT_EQ(0, fix.b.n_established);
 
  out:
+	conf_config()->avt.rxmode  = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_answer_hangup_a(void)
+int test_call_reject(void)
+{
+	int err;
+
+	err  = test_call_reject_base(RECEIVE_MODE_MAIN);
+	err |= test_call_reject_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_answer_hangup_a_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 	f->estab_action = ACTION_HANGUP_A;
@@ -775,19 +802,32 @@ int test_call_answer_hangup_a(void)
 	ASSERT_EQ(0, fix.b.close_scode);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_answer_hangup_b(void)
+int test_call_answer_hangup_a(void)
+{
+	int err;
+
+	err  = test_call_answer_hangup_a_base(RECEIVE_MODE_MAIN);
+	err |= test_call_answer_hangup_a_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_answer_hangup_b_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	char uri[256];
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 	f->estab_action = ACTION_HANGUP_B;
@@ -813,13 +853,25 @@ int test_call_answer_hangup_b(void)
 	ASSERT_EQ(0, fix.b.close_scode);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_rtp_timeout(void)
+int test_call_answer_hangup_b(void)
+{
+	int err;
+
+	err  = test_call_answer_hangup_b_base(RECEIVE_MODE_MAIN);
+	err |= test_call_answer_hangup_b_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_rtp_timeout_base(enum rtp_receive_mode rxmode)
 {
 #define RTP_TIMEOUT_MS 1
 	struct fixture fix, *f = &fix;
@@ -827,6 +879,7 @@ int test_call_rtp_timeout(void)
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 	f->estab_action = ACTION_NOTHING;
@@ -854,7 +907,19 @@ int test_call_rtp_timeout(void)
 	ASSERT_EQ(0, fix.b.close_scode);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
+
+	return err;
+}
+
+
+int test_call_rtp_timeout(void)
+{
+	int err;
+
+	err  = test_call_rtp_timeout_base(RECEIVE_MODE_MAIN);
+	err |= test_call_rtp_timeout_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -879,7 +944,7 @@ static bool linenum_are_sequential(const struct ua *ua)
 }
 
 
-int test_call_multiple(void)
+static int test_call_multiple_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct le *le;
@@ -887,6 +952,7 @@ int test_call_multiple(void)
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 	f->exp_estab = 4;
@@ -963,13 +1029,25 @@ int test_call_multiple(void)
 	ASSERT_EQ(4, list_count(ua_calls(f->b.ua)));
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_max(void)
+int test_call_multiple(void)
+{
+	int err;
+
+	err  = test_call_multiple_base(RECEIVE_MODE_MAIN);
+	err |= test_call_multiple_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_max_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	unsigned i;
@@ -981,6 +1059,7 @@ int test_call_max(void)
 	conf_config()->call.max_calls = 3;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 
@@ -1005,10 +1084,22 @@ int test_call_max(void)
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	/* Set the max-calls limit */
 	conf_config()->call.max_calls = 0;
+
+	return err;
+}
+
+
+int test_call_max(void)
+{
+	int err;
+
+	err  = test_call_max_base(RECEIVE_MODE_MAIN);
+	err |= test_call_max_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -1177,7 +1268,7 @@ int test_call_video(void)
 }
 
 
-int test_call_change_videodir(void)
+static int test_call_change_videodir_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1187,6 +1278,7 @@ int test_call_change_videodir(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
@@ -1289,6 +1381,7 @@ int test_call_change_videodir(void)
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(vm));
 
  out:
+	conf_config()->avt.rxmode  = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 	mem_deref(vidisp);
 	module_unload("fakevideo");
@@ -1298,7 +1391,18 @@ int test_call_change_videodir(void)
 }
 
 
-int test_call_100rel_video(void)
+int test_call_change_videodir(void)
+{
+	int err;
+
+	err  = test_call_change_videodir_base(RECEIVE_MODE_MAIN);
+	err |= test_call_change_videodir_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_100rel_video_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1307,6 +1411,7 @@ int test_call_100rel_video(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init_prm(f, ";100rel=yes;answermode=early");
 
@@ -1372,10 +1477,22 @@ int test_call_100rel_video(void)
 	ASSERT_TRUE(fix.a.n_vidframe >= 3);
 	ASSERT_TRUE(fix.b.n_vidframe >= 3);
  out:
+	conf_config()->avt.rxmode  = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 	mem_deref(vidisp);
 	module_unload("fakevideo");
 	mock_vidcodec_unregister();
+
+	return err;
+}
+
+
+int test_call_100rel_video(void)
+{
+	int err;
+
+	err  = test_call_100rel_video_base(RECEIVE_MODE_MAIN);
+	err |= test_call_100rel_video_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -1475,7 +1592,18 @@ static int test_call_aulevel_base(enum rtp_receive_mode rxmode)
 }
 
 
-static int test_100rel_audio_base(enum audio_mode txmode, enum rtp_receive_mode rxmode)
+int test_call_aulevel(void)
+{
+	int err;
+
+	err  = test_call_aulevel_base(RECEIVE_MODE_MAIN);
+	err |= test_call_aulevel_base(RECEIVE_MODE_THREAD);
+	return err;
+}
+
+
+static int test_100rel_audio_base(enum audio_mode txmode,
+				  enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -1593,22 +1721,13 @@ int test_call_100rel_audio(void)
 }
 
 
-int test_call_aulevel(void)
-{
-	int err;
-
-	err  = test_call_aulevel_base(RECEIVE_MODE_MAIN);
-	err |= test_call_aulevel_base(RECEIVE_MODE_THREAD);
-	return err;
-}
-
-
-int test_call_progress(void)
+static int test_call_progress_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
 
@@ -1635,7 +1754,19 @@ int test_call_progress(void)
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
+
+	return err;
+}
+
+
+int test_call_progress(void)
+{
+	int err;
+
+	err  = test_call_progress_base(RECEIVE_MODE_MAIN);
+	err |= test_call_progress_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -1867,7 +1998,7 @@ int test_call_medianat(void)
 }
 
 
-int test_call_custom_headers(void)
+static int test_call_custom_headers_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
@@ -1876,6 +2007,7 @@ int test_call_custom_headers(void)
 	bool headers_matched = true;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	ua_add_xhdr_filter(f->b.ua, "X-CALL_ID");
 	ua_add_xhdr_filter(f->b.ua, "X-HEADER_NAME");
@@ -1939,18 +2071,31 @@ int test_call_custom_headers(void)
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_tcp(void)
+int test_call_custom_headers(void)
+{
+	int err;
+
+	err  = test_call_custom_headers_base(RECEIVE_MODE_MAIN);
+	err |= test_call_custom_headers_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_tcp_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 
@@ -1967,19 +2112,32 @@ int test_call_tcp(void)
 	ASSERT_EQ(1, fix.b.n_established);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_deny_udp(void)
+int test_call_tcp(void)
+{
+	int err;
+
+	err  = test_call_tcp_base(RECEIVE_MODE_MAIN);
+	err |= test_call_tcp_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_deny_udp_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 	char curi[256];
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	mem_deref(f->a.ua);
 	mem_deref(f->b.ua);
@@ -2011,7 +2169,19 @@ int test_call_deny_udp(void)
 	ASSERT_EQ(0, fix.b.n_incoming);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
+
+	return err;
+}
+
+
+int test_call_deny_udp(void)
+{
+	int err;
+
+	err  = test_call_deny_udp_base(RECEIVE_MODE_MAIN);
+	err |= test_call_deny_udp_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -2025,12 +2195,13 @@ int test_call_deny_udp(void)
  *  Step 3. Call between B and C
  *          No call for A
  */
-int test_call_transfer(void)
+static int test_call_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Create a 3rd useragent needed for transfer */
 	err = ua_alloc(&f->c.ua, "C <sip:c@127.0.0.1>;regint=0");
@@ -2069,18 +2240,31 @@ int test_call_transfer(void)
 	ASSERT_EQ(1, list_count(ua_calls(f->c.ua)));
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_transfer_fail(void)
+int test_call_transfer(void)
+{
+	int err;
+
+	err  = test_call_transfer_base(RECEIVE_MODE_MAIN);
+	err |= test_call_transfer_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_transfer_fail_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Create a 3rd useragent needed for transfer */
 	err = ua_alloc(&f->c.ua, "C <sip:c@127.0.0.1>;regint=0");
@@ -2124,18 +2308,31 @@ int test_call_transfer_fail(void)
 	ASSERT_EQ(0, list_count(ua_calls(f->c.ua)));
 
 out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	return err;
 }
 
 
-int test_call_attended_transfer(void)
+int test_call_transfer_fail(void)
+{
+	int err;
+
+	err  = test_call_transfer_fail_base(RECEIVE_MODE_MAIN);
+	err |= test_call_transfer_fail_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_attended_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	err = ua_alloc(&f->c.ua, "C <sip:c@127.0.0.1>;regint=0");
 	TEST_ERR(err);
@@ -2175,7 +2372,19 @@ int test_call_attended_transfer(void)
 	ASSERT_EQ(1, list_count(ua_calls(f->c.ua)));
 
 out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
+
+	return err;
+}
+
+
+int test_call_attended_transfer(void)
+{
+	int err;
+
+	err  = test_call_attended_transfer_base(RECEIVE_MODE_MAIN);
+	err |= test_call_attended_transfer_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -2274,7 +2483,7 @@ int test_call_aufilt(void)
 /*
  * Simulate a complete WebRTC testcase
  */
-int test_call_webrtc(void)
+static int test_call_webrtc_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2282,6 +2491,7 @@ int test_call_webrtc(void)
 	int err;
 
 	conf_config()->avt.rtcp_mux = true;
+	conf_config()->avt.rxmode = rxmode;
 
 	mock_mnat_register(baresip_mnatl());
 
@@ -2348,6 +2558,7 @@ int test_call_webrtc(void)
 	ASSERT_EQ(20, atoi(sdp_media_rattr(sdp_b, "ptime")));
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	module_unload("fakevideo");
@@ -2365,7 +2576,19 @@ int test_call_webrtc(void)
 }
 
 
-static int test_call_bundle_base(bool use_mnat, bool use_menc)
+int test_call_webrtc(void)
+{
+	int err;
+
+	err  = test_call_webrtc_base(RECEIVE_MODE_MAIN);
+	err |= test_call_webrtc_base(RECEIVE_MODE_THREAD);
+
+	return err;
+}
+
+
+static int test_call_bundle_base(bool use_mnat, bool use_menc,
+				 enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2380,6 +2603,7 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
 	conf_config()->avt.bundle = true;
 	conf_config()->avt.rtcp_mux = true;  /* MUST enable RTP/RTCP mux */
 	conf_config()->video.fps = 100;
+	conf_config()->avt.rxmode = rxmode;
 
 	if (use_mnat) {
 		mock_mnat_register(baresip_mnatl());
@@ -2493,6 +2717,7 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
 	}
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 
 	mem_deref(sdp);
@@ -2525,10 +2750,14 @@ int test_call_bundle(void)
 {
 	int err = 0;
 
-	err |= test_call_bundle_base(false, false);
-	err |= test_call_bundle_base(true,  false);
-	err |= test_call_bundle_base(false, true);
-	err |= test_call_bundle_base(true,  true);
+	err |= test_call_bundle_base(false, false, RECEIVE_MODE_MAIN);
+	err |= test_call_bundle_base(true,  false, RECEIVE_MODE_MAIN);
+	err |= test_call_bundle_base(false, true,  RECEIVE_MODE_MAIN);
+	err |= test_call_bundle_base(true,  true,  RECEIVE_MODE_MAIN);
+	err |= test_call_bundle_base(false, false, RECEIVE_MODE_THREAD);
+	err |= test_call_bundle_base(true,  false, RECEIVE_MODE_THREAD);
+	err |= test_call_bundle_base(false, true,  RECEIVE_MODE_THREAD);
+	err |= test_call_bundle_base(true,  true,  RECEIVE_MODE_THREAD);
 
 	return err;
 }
@@ -2548,7 +2777,7 @@ static bool find_ipv6ll(const char *ifname, const struct sa *sa, void *arg)
 }
 
 
-int test_call_ipv6ll(void)
+static int test_call_ipv6ll_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2568,6 +2797,7 @@ int test_call_ipv6ll(void)
 	TEST_ERR(err);
 
 	fixture_init(f);
+	conf_config()->avt.rxmode = rxmode;
 
 	f->behaviour = BEHAVIOUR_ANSWER;
 	f->estab_action = ACTION_NOTHING;
@@ -2613,8 +2843,20 @@ int test_call_ipv6ll(void)
 	ASSERT_TRUE(sa_is_linklocal(&ipv6ll) && sa_af(&ipv6ll) == AF_INET6);
 
  out:
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	fixture_close(f);
 	module_unload("ausine");
+
+	return err;
+}
+
+
+int test_call_ipv6ll(void)
+{
+	int err;
+
+	err  = test_call_ipv6ll_base(RECEIVE_MODE_MAIN);
+	err |= test_call_ipv6ll_base(RECEIVE_MODE_THREAD);
 
 	return err;
 }

--- a/test/call.c
+++ b/test/call.c
@@ -49,6 +49,7 @@ struct cancel_rule {
 	unsigned n_answer_cnt;
 	unsigned n_vidframe;
 	unsigned n_auframe;
+	double aulvl;
 
 	struct cancel_rule *cr_and;
 	bool met;
@@ -78,6 +79,7 @@ struct agent {
 	unsigned n_answer_cnt;
 	unsigned n_vidframe;
 	unsigned n_auframe;
+	double aulvl;
 };
 
 
@@ -205,6 +207,7 @@ static struct cancel_rule *cancel_rule_alloc(enum ua_event ev,
 	r->n_answer_cnt  = (unsigned) -1;
 	r->n_vidframe    = (unsigned) -1;
 	r->n_auframe     = (unsigned) -1;
+	r->aulvl         = 0.0f;
 	return r;
 }
 
@@ -372,6 +375,14 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 
 	if (UINTSET(rule->n_vidframe) &&
 	    ag->n_vidframe < rule->n_vidframe)
+		return false;
+
+	if (UINTSET(rule->n_auframe) &&
+	    ag->n_auframe < rule->n_auframe)
+		return false;
+
+	if (rule->aulvl != 0.0f &&
+	    (ag->aulvl < rule->aulvl || ag->aulvl >= 0.0f))
 		return false;
 
 	rule->met = true;
@@ -1342,37 +1353,73 @@ int test_call_100rel_video(void)
 }
 
 
-static void mock_sample_handler(struct auframe *af, void *arg)
+static void auframe_handler(struct auframe *af, void *arg)
 {
 	struct fixture *fix = arg;
-	bool got_aulevel;
-	(void)af;
+	uint32_t ptime;
+	struct agent *ag = NULL;
+	struct ua *ua;
+	int err = 0;
 
-	got_aulevel =
-		0 == audio_level_get(call_audio(ua_call(fix->a.ua)), NULL) &&
-		0 == audio_level_get(call_audio(ua_call(fix->b.ua)), NULL);
+	ASSERT_EQ(MAGIC, fix->magic);
 
-	if (got_aulevel)
-		re_cancel();
+	ptime = af->sampc * 1000 / af->srate;
+	if (ptime == 1) {
+		ag = &fix->a;
+	}
+	else if (ptime == 2) {
+		ag = &fix->b;
+	}
+	else {
+		warning("test: received audio frame - agent unclear\n");
+		return;
+	}
+
+	ua = ag->ua;
+	/* Does auframe come from the decoder ? */
+	if (!audio_rxaubuf_started(call_audio(ua_call(ua)))) {
+		info("test: received audio frame not from decoder yet\n");
+		return;
+	}
+
+	++ag->n_auframe;
+	(void)audio_level_get(call_audio(ua_call(ua)), &ag->aulvl);
+
+	ua_event(ua, UA_EVENT_CUSTOM, ua_call(ua), "auframe %u",
+		 ag->n_auframe);
+
+ out:
+	if (err)
+		fixture_abort(fix, err);
 }
 
 
 int test_call_aulevel(void)
 {
 	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
 	struct auplay *auplay = NULL;
-	double lvl;
 	int err = 0;
 
 	/* Use a low packet time, so the test completes quickly */
 	fixture_init_prm(f, ";ptime=1");
+	mem_deref(f->b.ua);
+	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>;regint=0;ptime=2");
+	TEST_ERR(err);
+
+	cancel_rule_new(UA_EVENT_CUSTOM, f->a.ua, 0, 0, 1);
+	cr->prm = "auframe";
+	cr->aulvl = -96.0f;
+	cancel_rule_and(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 1);
+	cr->prm = "auframe";
+	cr->aulvl = -96.0f;
 
 	conf_config()->audio.level = true;
 
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
 	err = mock_auplay_register(&auplay, baresip_auplayl(),
-				   mock_sample_handler, f);
+				   auframe_handler, f);
 	TEST_ERR(err);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -1386,14 +1433,6 @@ int test_call_aulevel(void)
 	err = re_main_timeout(5000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
-
-	/* verify audio silence */
-	err = audio_level_get(call_audio(ua_call(f->a.ua)), &lvl);
-	TEST_ERR(err);
-	ASSERT_TRUE(lvl > -96.0f && lvl < 0.0f);
-	err = audio_level_get(call_audio(ua_call(f->b.ua)), &lvl);
-	TEST_ERR(err);
-	ASSERT_TRUE(lvl > -96.0f && lvl < 0.0f);
 
  out:
 	conf_config()->audio.level = false;
@@ -1444,45 +1483,6 @@ int test_call_progress(void)
 }
 
 
-static void audio_sample_handler(struct auframe *af, void *arg)
-{
-	struct fixture *fix = arg;
-	uint32_t   ptime;
-	struct agent *ag = NULL;
-	struct ua *ua;
-	int err = 0;
-
-	ASSERT_EQ(MAGIC, fix->magic);
-
-	ptime = af->sampc * 1000 / af->srate;
-	if (ptime == 1) {
-		ag = &fix->a;
-	}
-	else if (ptime == 2) {
-		ag = &fix->b;
-	}
-	else {
-		warning("test: received audio frame - agent unclear\n");
-		return;
-	}
-
-	ua = ag->ua;
-	/* Does auframe come from the decoder ? */
-	if (!audio_rxaubuf_started(call_audio(ua_call(ua)))) {
-		info("test: received audio frame not from decoder yet\n");
-		return;
-	}
-
-	++ag->n_auframe;
-	ua_event(ua, UA_EVENT_CUSTOM, ua_call(ua), "auframe %u",
-		 ag->n_auframe);
-
- out:
-	if (err)
-		fixture_abort(fix, err);
-}
-
-
 static int test_media_base(enum audio_mode txmode)
 {
 	struct fixture fix, *f = &fix;
@@ -1509,7 +1509,7 @@ static int test_media_base(enum audio_mode txmode)
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
 	err = mock_auplay_register(&auplay, baresip_auplayl(),
-				   audio_sample_handler, f);
+				   auframe_handler, f);
 	TEST_ERR(err);
 
 	f->estab_action = ACTION_NOTHING;

--- a/test/call.c
+++ b/test/call.c
@@ -48,6 +48,7 @@ struct cancel_rule {
 	unsigned n_offer_cnt;
 	unsigned n_answer_cnt;
 	unsigned n_vidframe;
+	unsigned n_auframe;
 
 	struct cancel_rule *cr_and;
 	bool met;
@@ -76,6 +77,7 @@ struct agent {
 	unsigned n_offer_cnt;
 	unsigned n_answer_cnt;
 	unsigned n_vidframe;
+	unsigned n_auframe;
 };
 
 
@@ -202,6 +204,7 @@ static struct cancel_rule *cancel_rule_alloc(enum ua_event ev,
 	r->n_offer_cnt   = (unsigned) -1;
 	r->n_answer_cnt  = (unsigned) -1;
 	r->n_vidframe    = (unsigned) -1;
+	r->n_auframe     = (unsigned) -1;
 	return r;
 }
 
@@ -1339,12 +1342,11 @@ int test_call_100rel_video(void)
 }
 
 
-static void mock_sample_handler(const void *sampv, size_t sampc, void *arg)
+static void mock_sample_handler(struct auframe *af, void *arg)
 {
 	struct fixture *fix = arg;
 	bool got_aulevel;
-	(void)sampv;
-	(void)sampc;
+	(void)af;
 
 	got_aulevel =
 		0 == audio_level_get(call_audio(ua_call(fix->a.ua)), NULL) &&
@@ -1442,24 +1444,38 @@ int test_call_progress(void)
 }
 
 
-static void audio_sample_handler(const void *sampv, size_t sampc, void *arg)
+static void audio_sample_handler(struct auframe *af, void *arg)
 {
 	struct fixture *fix = arg;
+	uint32_t   ptime;
+	struct agent *ag = NULL;
+	struct ua *ua;
 	int err = 0;
-	(void)sampv;
-	(void)sampc;
 
 	ASSERT_EQ(MAGIC, fix->magic);
 
-	/* Wait until the call is established and the incoming
-	 * audio samples are successfully decoded.
-	 */
-	if (sampc && fix->a.n_established && fix->b.n_established &&
-	    audio_rxaubuf_started(call_audio(ua_call(fix->a.ua))) &&
-	    audio_rxaubuf_started(call_audio(ua_call(fix->b.ua)))
-	    ) {
-		re_cancel();
+	ptime = af->sampc * 1000 / af->srate;
+	if (ptime == 1) {
+		ag = &fix->a;
 	}
+	else if (ptime == 2) {
+		ag = &fix->b;
+	}
+	else {
+		warning("test: received audio frame - agent unclear\n");
+		return;
+	}
+
+	ua = ag->ua;
+	/* Does auframe come from the decoder ? */
+	if (!audio_rxaubuf_started(call_audio(ua_call(ua)))) {
+		info("test: received audio frame not from decoder yet\n");
+		return;
+	}
+
+	++ag->n_auframe;
+	ua_event(ua, UA_EVENT_CUSTOM, ua_call(ua), "auframe %u",
+		 ag->n_auframe);
 
  out:
 	if (err)
@@ -1470,15 +1486,25 @@ static void audio_sample_handler(const void *sampv, size_t sampc, void *arg)
 static int test_media_base(enum audio_mode txmode)
 {
 	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
 	struct auplay *auplay = NULL;
 	int err = 0;
 
 	fixture_init_prm(f, ";ptime=1");
+	mem_deref(f->b.ua);
+	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>;regint=0;ptime=2");
+	TEST_ERR(err);
 
 	conf_config()->audio.txmode = txmode;
-
 	conf_config()->audio.src_fmt = AUFMT_S16LE;
 	conf_config()->audio.play_fmt = AUFMT_S16LE;
+
+	cancel_rule_new(UA_EVENT_CUSTOM, f->a.ua, 0, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = 3;
+	cancel_rule_and(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = 3;
 
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
@@ -1495,7 +1521,7 @@ static int test_media_base(enum audio_mode txmode)
 	TEST_ERR(err);
 
 	/* run main-loop with timeout, wait for events */
-	err = re_main_timeout(15000);
+	err = re_main_timeout(5000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
@@ -1528,6 +1554,9 @@ int test_call_format_float(void)
 	int err;
 
 	err = test_media_base(AUDIO_MODE_POLL);
+	ASSERT_EQ(0, err);
+
+	err = test_media_base(AUDIO_MODE_THREAD);
 	ASSERT_EQ(0, err);
 
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;

--- a/test/call.c
+++ b/test/call.c
@@ -1137,9 +1137,6 @@ int test_call_change_videodir(void)
 	cr_vida->prm = "vidframe";
 	cr_vida->n_vidframe = 3;
 
-	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
-	cr->n_offer_cnt = 1;
-
 	/* to enable video, we need one vidsrc and vidcodec */
 	mock_vidcodec_register();
 
@@ -1187,18 +1184,25 @@ int test_call_change_videodir(void)
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(vm));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(vm));
 
+	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
+	cr->prm = "offer";
+	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 1);
+	cr->prm = "answer";
+
 	/* Set video inactive */
 	err = call_set_video_dir(ua_call(f->a.ua), SDP_INACTIVE);
 	TEST_ERR(err);
 	err = re_main_timeout(10000);
 	TEST_ERR(err);
+	TEST_ERR(fix.err);
+	cancel_rule_pop();
 
-	ASSERT_TRUE(call_has_video(ua_call(f->a.ua)));
+	ASSERT_TRUE(!call_has_video(ua_call(f->a.ua)));
 	ASSERT_TRUE(call_has_video(ua_call(f->b.ua)));
 
 	vm = stream_sdpmedia(video_strm(call_video(ua_call(f->a.ua))));
 	ASSERT_EQ(SDP_INACTIVE, sdp_media_ldir(vm));
-	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(vm));
+	ASSERT_EQ(SDP_INACTIVE, sdp_media_rdir(vm));
 
 	vm = stream_sdpmedia(video_strm(call_video(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(vm));
@@ -1207,9 +1211,8 @@ int test_call_change_videodir(void)
 	/* Set video sendrecv */
 	err = call_set_video_dir(ua_call(f->a.ua), SDP_SENDRECV);
 	TEST_ERR(err);
-	cr_vidb->n_offer_cnt = 2;
-	cr_vidb->n_vidframe = 6;
-	cr_vida->n_vidframe = 6;
+	f->a.n_vidframe = 0;
+	f->b.n_vidframe = 0;
 	err = re_main_timeout(10000);
 	TEST_ERR(err);
 

--- a/test/call.c
+++ b/test/call.c
@@ -175,6 +175,7 @@ static void cancel_rule_destructor(void *arg)
 {
 	struct cancel_rule *r = arg;
 
+	list_unlink(&r->le);
 	mem_deref(r->cr_and);
 }
 
@@ -247,6 +248,10 @@ static void cancel_rule_reset(struct cancel_rule *cr)
 		err = ENOMEM;						  \
 		goto out;						  \
 	}
+
+
+#define cancel_rule_pop()						  \
+	mem_deref(list_tail(&f->rules)->data);
 
 
 static const struct list *hdrs;
@@ -1219,6 +1224,89 @@ int test_call_change_videodir(void)
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(vm));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(vm));
 
+ out:
+	fixture_close(f);
+	mem_deref(vidisp);
+	module_unload("fakevideo");
+	mock_vidcodec_unregister();
+
+	return err;
+}
+
+
+int test_call_100rel_video(void)
+{
+	struct fixture fix, *f = &fix;
+	struct vidisp *vidisp = NULL;
+	struct cancel_rule *cr;
+	int err = 0;
+
+	conf_config()->video.fps = 100;
+	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+
+	fixture_init_prm(f, ";100rel=yes;answermode=early");
+
+	cancel_rule_new(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 0);
+	cr->prm = "vidframe";
+	cr->n_vidframe = 3;
+	cancel_rule_and(UA_EVENT_CUSTOM, f->a.ua, 0, 0, 0);
+	cr->prm = "vidframe";
+	cr->n_vidframe = 3;
+	/* to enable video, we need one vidsrc and vidcodec */
+	mock_vidcodec_register();
+
+	err = mock_vidisp_register(&vidisp, mock_vidisp_handler, f);
+	TEST_ERR(err);
+
+	err = module_load(".", "fakevideo");
+	TEST_ERR(err);
+
+	f->behaviour = BEHAVIOUR_PROGRESS;
+	f->estab_action = ACTION_NOTHING;
+
+	/* Make a call from A to B */
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_ON);
+	TEST_ERR(err);
+
+	/* wait for video frames */
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	/* switch off early video */
+	cancel_rule_new(UA_EVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 0);
+	cr->prm = "offer";
+	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 0);
+	cr->prm = "answer";
+
+	err = call_set_video_dir(ua_call(f->a.ua), SDP_INACTIVE);
+	TEST_ERR(err);
+	/* wait for remote SDP at both UAs */
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+	cancel_rule_pop();
+
+	struct sdp_media *vm;
+	vm = stream_sdpmedia(video_strm(call_video(ua_call(f->a.ua))));
+	ASSERT_EQ(SDP_INACTIVE, sdp_media_ldir(vm));
+	ASSERT_EQ(SDP_INACTIVE, sdp_media_rdir(vm));
+
+	vm = stream_sdpmedia(video_strm(call_video(ua_call(f->b.ua))));
+	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(vm));
+	ASSERT_EQ(SDP_INACTIVE, sdp_media_rdir(vm));
+	ASSERT_TRUE(call_refresh_allowed(ua_call(f->a.ua)));
+
+	f->a.n_vidframe=0;
+	f->b.n_vidframe=0;
+	err = call_set_video_dir(ua_call(f->a.ua), SDP_SENDRECV);
+	TEST_ERR(err);
+	/* wait for video frames */
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+	ASSERT_TRUE(fix.a.n_vidframe >= 3);
+	ASSERT_TRUE(fix.b.n_vidframe >= 3);
  out:
 	fixture_close(f);
 	mem_deref(vidisp);

--- a/test/main.c
+++ b/test/main.c
@@ -49,6 +49,7 @@ static const struct test tests[] = {
 	TEST(test_call_webrtc),
 	TEST(test_call_bundle),
 	TEST(test_call_ipv6ll),
+	TEST(test_call_100rel_audio),
 	TEST(test_call_100rel_video),
 	TEST(test_cmd),
 	TEST(test_cmd_long),

--- a/test/main.c
+++ b/test/main.c
@@ -49,6 +49,7 @@ static const struct test tests[] = {
 	TEST(test_call_webrtc),
 	TEST(test_call_bundle),
 	TEST(test_call_ipv6ll),
+	TEST(test_call_100rel_video),
 	TEST(test_cmd),
 	TEST(test_cmd_long),
 	TEST(test_contact),

--- a/test/main.c
+++ b/test/main.c
@@ -255,7 +255,6 @@ int main(int argc, char *argv[])
 
 	str_ncpy(config->sip.local, "0.0.0.0:0", sizeof(config->sip.local));
 	config->sip.verify_server = false;
-	config->avt.rxmode = RX_MODE_THREAD;
 
 	uag_set_exit_handler(ua_exit_handler, NULL);
 

--- a/test/main.c
+++ b/test/main.c
@@ -10,6 +10,7 @@
 #include <baresip.h>
 #include "test.h"
 
+enum { ASYNC_WORKERS = 4 };
 
 typedef int (test_exec_h)(void);
 
@@ -245,6 +246,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
+	re_thread_async_init(ASYNC_WORKERS);
 	err = baresip_init(config);
 	err = sa_set_str(&sa, "127.0.0.1", 0);
 	err |= net_add_address(baresip_network(), &sa);
@@ -253,6 +255,7 @@ int main(int argc, char *argv[])
 
 	str_ncpy(config->sip.local, "0.0.0.0:0", sizeof(config->sip.local));
 	config->sip.verify_server = false;
+	config->avt.rxmode = RX_MODE_THREAD;
 
 	uag_set_exit_handler(ua_exit_handler, NULL);
 

--- a/test/mock/cert.c
+++ b/test/mock/cert.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Alfred E. Heggestad
  */
 #include <re.h>
+#include <rem.h>
 #include "../test.h"
 
 

--- a/test/mock/dnssrv.c
+++ b/test/mock/dnssrv.c
@@ -5,6 +5,7 @@
  */
 #include <string.h>
 #include <re.h>
+#include <rem.h>
 #include "../test.h"
 
 

--- a/test/mock/mock_auplay.c
+++ b/test/mock/mock_auplay.c
@@ -49,7 +49,7 @@ static void tmr_handler(void *arg)
 
 	/* feed the audio-samples back to the test */
 	if (mock.sampleh)
-		mock.sampleh(st->sampv, st->sampc, mock.arg);
+		mock.sampleh(&af, mock.arg);
 }
 
 

--- a/test/mock/mock_vidisp.c
+++ b/test/mock/mock_vidisp.c
@@ -58,7 +58,6 @@ static int mock_display(struct vidisp_st *st, const char *title,
 			const struct vidframe *frame, uint64_t timestamp)
 {
 	unsigned width, height;
-	(void)title;
 	(void)timestamp;
 
 	if (!st || !frame)
@@ -88,7 +87,7 @@ static int mock_display(struct vidisp_st *st, const char *title,
 		info("mock_vidisp: got %u frames\n", st->n_frame);
 
 		if (mock.disph)
-			mock.disph(frame, timestamp, mock.arg);
+			mock.disph(frame, timestamp, title, mock.arg);
 	}
 
 	return 0;

--- a/test/play.c
+++ b/test/play.c
@@ -5,6 +5,7 @@
  */
 #include <string.h>
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "test.h"
 
@@ -39,10 +40,10 @@ static struct mbuf *generate_tone(void)
 }
 
 
-static void sample_handler(const void *sampv, size_t sampc, void *arg)
+static void auframe_handler(struct auframe *af, void *arg)
 {
 	struct test *test = arg;
-	size_t bytec = sampc * 2;
+	size_t bytec = af->sampc * 2;
 	int err = 0;
 
 	if (!test->mb_samp) {
@@ -51,7 +52,7 @@ static void sample_handler(const void *sampv, size_t sampc, void *arg)
 	}
 
 	/* save the samples that was played */
-	err = mbuf_write_mem(test->mb_samp, (void *)sampv, bytec);
+	err = mbuf_write_mem(test->mb_samp, (void *)af->sampv, bytec);
 
  out:
 	/* stop the test? */
@@ -73,7 +74,7 @@ int test_play(void)
 
 	/* use a mock audio-driver to save the audio-samples */
 	err = mock_auplay_register(&auplay, baresip_auplayl(),
-				   sample_handler, &test);
+				   auframe_handler, &test);
 	ASSERT_EQ(0, err);
 
 	err = play_init(&player);

--- a/test/test.h
+++ b/test/test.h
@@ -151,7 +151,7 @@ int dns_server_add_srv(struct dns_server *srv, const char *name,
 
 struct auplay;
 
-typedef void (mock_sample_h)(const void *sampv, size_t sampc, void *arg);
+typedef void (mock_sample_h)(struct auframe *af, void *arg);
 
 int mock_auplay_register(struct auplay **auplayp, struct list *auplayl,
 			 mock_sample_h *sampleh, void *arg);

--- a/test/test.h
+++ b/test/test.h
@@ -218,6 +218,7 @@ int test_call_change_videodir(void);
 int test_call_webrtc(void);
 int test_call_bundle(void);
 int test_call_ipv6ll(void);
+int test_call_100rel_audio(void);
 int test_call_100rel_video(void);
 int test_cmd(void);
 int test_cmd_long(void);

--- a/test/test.h
+++ b/test/test.h
@@ -181,7 +181,7 @@ struct vidisp;
 struct vidframe;
 
 typedef void (mock_vidisp_h)(const struct vidframe *frame, uint64_t timestamp,
-			     void *arg);
+			     const char *title, void *arg);
 
 int mock_vidisp_register(struct vidisp **vidispp,
 			 mock_vidisp_h *disph, void *arg);

--- a/test/test.h
+++ b/test/test.h
@@ -218,6 +218,7 @@ int test_call_change_videodir(void);
 int test_call_webrtc(void);
 int test_call_bundle(void);
 int test_call_ipv6ll(void);
+int test_call_100rel_video(void);
 int test_cmd(void);
 int test_cmd_long(void);
 int test_contact(void);


### PR DESCRIPTION
I opened this draft only to see if github actions pass. Both RTP RX modes are tested in the unit tests.

We need more of the new tests:
- https://github.com/baresip/baresip/pull/2687
- more cancel rule improvements
- 100rel tests
- reliable check if audio frames are processed


Commits:

- stream: extract thread safe RTP receiver
- rtprecv: remove some gotos
- rtprecv: make rx->run atomic
- rtprecv: simplify destructor
- stream: remove empty line
- rtprecv: set rtp socket fixes rtcp mux
- [TMP] config: add a warning for rtp_rxmode thread
- audio: separate aureceiver
- test: initialize async worker
- test: test both rx modes
- aureceiver: simplify logging of over/underruns
- aup: concurrency safe check if aubuf exists
- aup: use atomic instead mtx lock for latency
- audio: fix sanitizer warning in auplay_write_handler
- aucodec: move aucodec_print to internal API
- api,test: rename enum rx_mode to receive_mode
- audio/video: disable stream in destructor
- aup: correctly read/write atomic
- aup: check atomic ready flag instead of aubuf pointer
- aup: replace atomic by mtx avoids thread sanitizer warnings
- test: run all call tests with RX_MODE_THREAD
- aur: rename aurpipe to audio_recv
- aur: rename audio_recv pointer from rp to ar
- aur: rename functin prefix aup_ to aur_
- audio,aur: measure SW decoding jitter
- aur: print times in ms float numbers
- stream,receiver: rename rx to receive
- audio: rename pointer aup to aur
- Revert "[TMP] config: add a warning for rtp_rxmode thread"
