### PR TITLE
webrtc/js: add rtcpMuxPolicy require policy

### DIFF
--- a/webrtc/www/js/main.js
+++ b/webrtc/www/js/main.js
@@ -35,6 +35,9 @@ const pc_configuration = {
 
 	iceTransportPolicy: 'all',
 
+	/* default on Firefox/Chrome but needed by Safari */
+	rtcpMuxPolicy: 'require' 
+
 	/* peerIdentity */
 };
 


### PR DESCRIPTION
Default on Firefox/Chrome but needed by Safari, otherwise RTCP candidates are gathered