### PR TITLE
Implement play_file_ext with offset parameter in ms

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -775,6 +775,10 @@ typedef void (play_finish_h)(struct play *play, void *arg);
 int  play_file(struct play **playp, struct player *player,
 	       const char *filename, int repeat,
 	       const char *play_mod, const char *play_dev);
+int play_file_ext(struct play **playp, struct player *player,
+	      const char *filename, int repeat,
+	      const char *play_mod, const char *play_dev,
+		  size_t offset_ms);
 int  play_tone(struct play **playp, struct player *player,
 	       struct mbuf *tone,
 	       uint32_t srate, uint8_t ch, int repeat,
@@ -783,6 +787,8 @@ void play_set_finish_handler(struct play *play, play_finish_h *fh, void *arg);
 int  play_init(struct player **playerp);
 void play_set_path(struct player *player, const char *path);
 
+
+int enqueue(const char* molecule, void* arg);
 
 /*
  * User Agent

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -788,7 +788,6 @@ int  play_init(struct player **playerp);
 void play_set_path(struct player *player, const char *path);
 
 
-int enqueue(const char* molecule, void* arg);
 
 /*
  * User Agent

--- a/src/play.c
+++ b/src/play.c
@@ -218,44 +218,12 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 		err = aufile_read(af, buf, &n);
 		if (err || !n)
 			break;
-
-		switch (prm.fmt) {
-
-		case AUFMT_S16LE:
-			/* convert from Little-Endian to Native-Endian */
-			for (i=0; i<n/2; i++) {
-				int16_t s = sys_ltohs(*p++);
-				err |= mbuf_write_u16(mb, s);
-			}
-			fsize = 2;
-			break;
-
-		case AUFMT_PCMA:
-			for (i=0; i<n; i++) {
-				err |= mbuf_write_u16(mb,
-						      g711_alaw2pcm(buf[i]));
-			}
-			fsize = 1;
-			break;
-
-		case AUFMT_PCMU:
-			for (i=0; i<n; i++) {
-				err |= mbuf_write_u16(mb,
-						      g711_ulaw2pcm(buf[i]));
-			}
-			fsize = 1;
-			break;
-
-		default:
-			err = ENOSYS;
-			break;
-		}
 	}
 
 	mem_deref(af);
 
 	if (!err) {
-		mb->pos = (prm.srate * fsize * prm.channels / 1000) / file_size;
+		mb->pos = (prm.srate * aufmt_sample_size(prm.fmt) * prm.channels / 1000) / file_size;
 
 		*srate    = prm.srate;
 		*channels = prm.channels;

--- a/src/play.c
+++ b/src/play.c
@@ -24,6 +24,7 @@ struct play {
 	char *dev;
 	struct tmr tmr;
 	int repeat;
+	size_t offset_ms;
 	uint64_t delay;
 	uint64_t trep;
 	bool eof;
@@ -191,7 +192,17 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 {
 	struct aufile_prm prm;
 	struct aufile *af;
+	size_t file_size = 0;
+	int fsize = 2;
 	int err;
+
+	FILE* aufile = fopen(filename, "r");
+	if (aufile) {
+		fseek(aufile, 0, SEEK_END);
+		file_size = ftell(aufile);
+		fseek(aufile, 0, SEEK_SET);
+		fclose(aufile);
+	}
 
 	err = aufile_open(&af, &prm, filename, AUFILE_READ);
 	if (err)
@@ -216,7 +227,7 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 				int16_t s = sys_ltohs(*p++);
 				err |= mbuf_write_u16(mb, s);
 			}
-
+			fsize = 2;
 			break;
 
 		case AUFMT_PCMA:
@@ -224,6 +235,7 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 				err |= mbuf_write_u16(mb,
 						      g711_alaw2pcm(buf[i]));
 			}
+			fsize = 1;
 			break;
 
 		case AUFMT_PCMU:
@@ -231,6 +243,7 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 				err |= mbuf_write_u16(mb,
 						      g711_ulaw2pcm(buf[i]));
 			}
+			fsize = 1;
 			break;
 
 		default:
@@ -242,7 +255,7 @@ static int aufile_load(struct mbuf *mb, const char *filename,
 	mem_deref(af);
 
 	if (!err) {
-		mb->pos = 0;
+		mb->pos = (prm.srate * fsize * prm.channels / 1000) / file_size;
 
 		*srate    = prm.srate;
 		*channels = prm.channels;
@@ -401,7 +414,7 @@ static int start_auplay(struct play *play)
 static int play_file_ausrc(struct play **playp,
 		    const struct ausrc *ausrc,
 		    const char *filename, int repeat,
-		    const char *play_mod, const char *play_dev)
+		    const char *play_mod, const char *play_dev, size_t offset_ms)
 {
 	int err = 0;
 	size_t sampsz;
@@ -441,6 +454,7 @@ static int play_file_ausrc(struct play **playp,
 
 	play->sprm = sprm;
 	play->repeat = repeat ? repeat : 1;
+	play->offset_ms = offset_ms;
 	str_dup(&play->filename, filename);
 
 	sampsz = aufmt_sample_size(sprm.fmt);
@@ -517,6 +531,26 @@ int play_file(struct play **playp, struct player *player,
 	      const char *filename, int repeat,
 	      const char *play_mod, const char *play_dev)
 {
+	return play_file_ext(playp, player, filename, repeat, play_mod, play_dev, 0);
+}
+
+/**
+ * Play an audio file in WAV format
+ *
+ * @param playp    Pointer to allocated player object
+ * @param player   Audio-file player
+ * @param filename Name of WAV file to play
+ * @param repeat   Number of times to repeat
+ * @param play_mod Audio player module
+ * @param play_dev Audio player device
+ * @param offset_ms Offset in milliseconds
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int play_file_ext(struct play **playp, struct player *player,
+	      const char *filename, int repeat,
+	      const char *play_mod, const char *play_dev, size_t offset_ms)
+{
 	char file[FS_PATH_MAX];
 	char path[FS_PATH_MAX];
 	const struct ausrc *ausrc;
@@ -556,7 +590,7 @@ int play_file(struct play **playp, struct player *player,
 		if (ausrc) {
 			err = play_file_ausrc(&play, ausrc,
 					      path, repeat,
-					      play_mod, play_dev);
+					      play_mod, play_dev, 0);
 
 			goto out;
 		}


### PR DESCRIPTION
This PR allows to start playing a file with an offset, which is useful for resuming audio where it was interrupted