### PR TITLE
cmake: replace old add_definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ list(APPEND RE_DEFINITIONS
   -DVER_PATCH=${PROJECT_VERSION_PATCH}
 )
 
-add_definitions(${RE_DEFINITIONS})
+add_compile_definitions(${RE_DEFINITIONS})
 
 include_directories(
   include


### PR DESCRIPTION
`add_definitions` does not support cmake generator expressions and is replaced by `add_compile_definitions`