### PR TITLE
avcodec/decode: refactor hw_frame handling

### DIFF
--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -212,6 +212,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 		if (!hw_frame)
 			return ENOMEM;
 
+		/* av_hwframe_transfer_data needs clean dst frame */
 		sw_frame = av_frame_alloc();
 		if (!sw_frame) {
 			av_frame_free(&hw_frame);

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -295,7 +295,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
  out:
 	if (hw_frame) {
 		av_frame_free(&hw_frame);
-		av_frame_free(&sw_frame);
+		av_free(sw_frame);
 	}
 	av_packet_free(&avpkt);
 	return err;


### PR DESCRIPTION
With hardware decoding I had crashes after `av_hwframe_transfer_data`. It looks like a clean `dst` frame is needed and can not be reused with some hardware codecs.