### PR TITLE
tools: add jitter buffer plots generation

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -66,9 +66,10 @@ rtp_video_tos		136
 #rtp_ports		10000-20000
 #rtp_bandwidth		512-1024 # [kbit/s]
 audio_jitter_buffer_type	fixed	# off, fixed, adaptive
-audio_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
+audio_jitter_buffer_delay	5-10	# (min. frames)-(max. frames)
 video_jitter_buffer_type	fixed	# off, fixed, adaptive
-video_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
+video_jitter_buffer_delay	5-10	# (min. frames)-(max. frames)
+video_jitter_buffer_size	500	# max. packets
 rtp_stats		no
 #rtp_timeout		60
 #avt_bundle		no

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -392,6 +392,7 @@ struct config_avt {
 	struct {
 		enum jbuf_type jbtype;  /**< Jitter buffer type     */
 		struct range jbuf_del;  /**< Delay, number of frames*/
+		uint32_t jbuf_size;     /**< Size of packet pool    */
 	} video;
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */

--- a/src/conf.c
+++ b/src/conf.c
@@ -337,7 +337,6 @@ enum jbuf_type conf_get_jbuf_type(const struct pl *pl)
 {
 	if (0 == pl_strcasecmp(pl, "off"))      return JBUF_OFF;
 	if (0 == pl_strcasecmp(pl, "fixed"))    return JBUF_FIXED;
-	if (0 == pl_strcasecmp(pl, "adaptive")) return JBUF_ADAPTIVE;
 
 	warning("unsupported jitter buffer type (%r)\n", pl);
 	return JBUF_FIXED;

--- a/src/config.c
+++ b/src/config.c
@@ -242,8 +242,6 @@ static const char *jbuf_type_str(enum jbuf_type jbtype)
 		return "off";
 	case JBUF_FIXED:
 		return "fixed";
-	case JBUF_ADAPTIVE:
-		return "adaptive";
 	}
 
 	return "?";

--- a/src/config.c
+++ b/src/config.c
@@ -95,6 +95,7 @@ static struct config core_config = {
 		{
 			JBUF_FIXED,
 			{5, 50},
+			500,
 		},
 		false,
 		0,
@@ -464,6 +465,9 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_range(conf, "video_jitter_buffer_delay",
 			     &cfg->avt.video.jbuf_del);
 
+	(void)conf_get_u32(conf, "video_jitter_buffer_size",
+			   &cfg->avt.video.jbuf_size);
+
 	(void)conf_get_bool(conf, "rtp_stats", &cfg->avt.rtp_stats);
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
@@ -566,6 +570,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "audio_jitter_buffer_delay\t%H\n"
 			 "video_jitter_buffer_type\t%s\n"
 			 "video_jitter_buffer_delay\t%H\n"
+			 "video_jitter_buffer_size\t%u\n"
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "avt_bundle\t\t%s\n"
@@ -620,6 +625,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 range_print, &cfg->avt.audio.jbuf_del,
 			 jbuf_type_str(cfg->avt.video.jbtype),
 			 range_print, &cfg->avt.video.jbuf_del,
+			 cfg->avt.video.jbuf_size,
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 			 cfg->avt.bundle ? "yes" : "no",
@@ -825,11 +831,13 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "audio_jitter_buffer_type\tfixed\t\t# off, fixed,"
 				" adaptive\n"
 			  "audio_jitter_buffer_delay\t%u-%u\t\t"
-					"# (min. frames)-(max. packets)\n"
+					"# (min. frames)-(max. frames)\n"
 			  "video_jitter_buffer_type\tfixed\t\t# off, fixed,"
 				" adaptive\n"
 			  "video_jitter_buffer_delay\t%u-%u\t\t"
-					"# (min. frames)-(max. packets)\n"
+					"# (min. frames)-(max. frames)\n"
+			  "video_jitter_buffer_size\t%u\t\t"
+					"# max. packets\n"
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "#avt_bundle\t\tno\n"
@@ -848,6 +856,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  cfg->avt.audio.jbuf_del.max,
 			  cfg->avt.video.jbuf_del.min,
 			  cfg->avt.video.jbuf_del.max,
+			  cfg->avt.video.jbuf_size,
 			  default_interface_print, NULL);
 
 	return err;

--- a/src/stream.c
+++ b/src/stream.c
@@ -807,6 +807,7 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		err = jbuf_alloc(&s->rx.jbuf, cfg->video.jbuf_del.min,
 				 cfg->video.jbuf_del.max);
 		err |= jbuf_set_type(s->rx.jbuf, cfg->video.jbtype);
+		err |= jbuf_resize(s->rx.jbuf, cfg->video.jbuf_size);
 		if (err)
 			goto out;
 	}

--- a/tools/jbuf/.gitignore
+++ b/tools/jbuf/.gitignore
@@ -1,0 +1,8 @@
+.env
+contacts
+current_contact
+*.dat
+*.eps
+plots
+uuid
+*.json

--- a/tools/jbuf/README.md
+++ b/tools/jbuf/README.md
@@ -2,6 +2,9 @@ How to use
 ----------
 - Increase the `DEBUG_LEVEL` to `6` and re-build `re`
 
+- At the call target automatic answer mode should be configured.
+  E.g. if baresip then the account parameter `;answermode=auto`
+
 - Generate the plots
 ```
 cd tools/jbuf

--- a/tools/jbuf/README.md
+++ b/tools/jbuf/README.md
@@ -1,0 +1,13 @@
+How to use
+----------
+- Increase the `DEBUG_LEVEL` to `6` and re-build `re`
+
+- Generate the plots
+```
+cd tools/jbuf
+cp env-template .env
+# edit .env
+./generate_plot.sh
+```
+
+- The plots are collected in sub-directory plots.

--- a/tools/jbuf/README.md
+++ b/tools/jbuf/README.md
@@ -11,3 +11,11 @@ cp env-template .env
 ```
 
 - The plots are collected in sub-directory plots.
+
+Units in the Plots
+------------------
+
+The variables `rdiff`, `wish` and `n` are given in number of packets.
+The events "underflow", "overrun", "too late", "duplicate", "out of sequence"
+and "lost" are printed only as dimensionless dots with a `y` value somewhere
+in the middle of the diagram.

--- a/tools/jbuf/audio/accounts
+++ b/tools/jbuf/audio/accounts
@@ -1,0 +1,1 @@
+<sip:alice@office>;regint=0;ptime=20

--- a/tools/jbuf/audio/config
+++ b/tools/jbuf/audio/config
@@ -7,27 +7,13 @@ audio_buffer   10-50
 audio_buffer_mode	adaptive
 audio_silence		0.0
 
-audio_jitter_buffer_type	off
-video_jitter_buffer_type	adaptive
-video_jitter_buffer_delay   0-500
+audio_jitter_buffer_type	adaptive
+audio_jitter_buffer_delay   0-500
 
 statmode_default	off
 rtp_stats		no
 
 module_path		/usr/local/lib/baresip/modules
-
-# Video
-video_source		v4l2,/dev/video0
-video_display		x11,nil
-# video_source		comvideo,
-video_size		640x480
-video_bitrate		500000
-video_fps		15.0
-
-# module			comvideo.so
-module			x11.so
-module			avcodec.so
-module			v4l2.so
 
 # UI Modules
 module			stdio.so

--- a/tools/jbuf/env-template
+++ b/tools/jbuf/env-template
@@ -1,0 +1,4 @@
+target=1.2.3.4
+netif=eno1
+once=true
+

--- a/tools/jbuf/generate_plot.sh
+++ b/tools/jbuf/generate_plot.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+if [ ! -f .env ]; then
+    echo ".env is missing. Copy and edit env-template!"
+    exit 1
+fi
+
+export `cat .env`
+
+echo "target: $target"
+echo "netif:  $netif"
+echo "once:   $once"
+
+if ! which jq; then
+    echo "Install jq"
+    exit 1
+fi
+
+trap "./jitter-off.sh; killall -q baresip" EXIT
+
+function gen_datfile() {
+    ph=$1
+    filename=$2
+
+    jqc='.traceEvents[] | select (.ph == "'"${ph}"'") | .args.line'
+    cat jbuf.json | jq -r "${jqc}" > $filename
+}
+
+source ./jitter.sh
+init_jitter $netif
+
+i=1
+for jmin in 0 10 20; do
+    echo "########### jitter buffer $jmin ###############"
+
+    sed -e "s/video_jitter_buffer_delay\s*[0-9]*\-.*/video_jitter_buffer_delay   $jmin-500/" -i video/config
+    baresip -v -f video > /tmp/b.log 2>&1 &
+    sleep 1
+    echo "/dial $target" | nc -N localhost 5555
+
+    sleep 3
+
+    enable_jitter
+
+    sleep 5
+
+    disable_jitter
+
+    sleep 25
+
+    echo "/quit" | nc -N localhost 5555
+
+    sleep 1
+
+    gen_datfile "P" jbuf.dat
+    gen_datfile "O" overrun.dat
+    gen_datfile "U" underflow.dat
+    gen_datfile "L" toolate.dat
+    gen_datfile "D" duplicate.dat
+    gen_datfile "S" oosequence.dat
+    gen_datfile "T" lost.dat
+#    cat jbuf.json | jq -r '.traceEvents[] | select (.ph == "P") | .args.line' > jbuf.dat
+
+    ./jbuf.plot
+    if [ ! -d plots ]; then
+        mkdir plots
+    fi
+    cp jbuf.eps plots/jbuf_${jmin}.eps
+    i=$(( i+1 ))
+
+    if [ $once == "true" ]; then
+        exit 0
+    fi
+done

--- a/tools/jbuf/generate_plot.sh
+++ b/tools/jbuf/generate_plot.sh
@@ -71,7 +71,12 @@ for jmin in 0 10 20; do
         if [ ! -d plots ]; then
             mkdir plots
         fi
-        cp jbuf.eps plots/jbuf_${strm}_${jmin}.eps
+        if [ -f jbuf.eps ]; then
+            mv jbuf.eps plots/jbuf_${strm}_${jmin}.eps
+        fi
+        if [ -f jbuf.png ]; then
+            mv jbuf.png plots/jbuf_${strm}_${jmin}.png
+        fi
     done
 
     if [ $once == "true" ]; then

--- a/tools/jbuf/generate_plot.sh
+++ b/tools/jbuf/generate_plot.sh
@@ -29,44 +29,50 @@ function gen_datfile() {
 source ./jitter.sh
 init_jitter $netif
 
-i=1
+strm="audio"
 for jmin in 0 10 20; do
-    echo "########### jitter buffer $jmin ###############"
+    for i in 0 1; do
+        if [ "$i" == "0" ]; then
+            strm="audio"
+        else
+            strm="video"
+        fi
 
-    sed -e "s/video_jitter_buffer_delay\s*[0-9]*\-.*/video_jitter_buffer_delay   $jmin-500/" -i video/config
-    baresip -v -f video > /tmp/b.log 2>&1 &
-    sleep 1
-    echo "/dial $target" | nc -N localhost 5555
+        echo "########### jitter buffer $strm $jmin ###############"
 
-    sleep 3
+        sed -e "s/${strm}_jitter_buffer_delay\s*[0-9]*\-.*/${strm}_jitter_buffer_delay   ${jmin}-500/" -i ${strm}/config
+        baresip -v -f ${strm} > /tmp/${strm}.log 2>&1 &
+        sleep 1
+        echo "/dial $target" | nc -N localhost 5555
 
-    enable_jitter
+        sleep 3
 
-    sleep 5
+        enable_jitter
 
-    disable_jitter
+        sleep 5
 
-    sleep 25
+        disable_jitter
 
-    echo "/quit" | nc -N localhost 5555
+        sleep 25
 
-    sleep 1
+        echo "/quit" | nc -N localhost 5555
 
-    gen_datfile "P" jbuf.dat
-    gen_datfile "O" overrun.dat
-    gen_datfile "U" underflow.dat
-    gen_datfile "L" toolate.dat
-    gen_datfile "D" duplicate.dat
-    gen_datfile "S" oosequence.dat
-    gen_datfile "T" lost.dat
-#    cat jbuf.json | jq -r '.traceEvents[] | select (.ph == "P") | .args.line' > jbuf.dat
+        sleep 1
 
-    ./jbuf.plot
-    if [ ! -d plots ]; then
-        mkdir plots
-    fi
-    cp jbuf.eps plots/jbuf_${jmin}.eps
-    i=$(( i+1 ))
+        gen_datfile "P" jbuf.dat
+        gen_datfile "O" overrun.dat
+        gen_datfile "U" underflow.dat
+        gen_datfile "L" toolate.dat
+        gen_datfile "D" duplicate.dat
+        gen_datfile "S" oosequence.dat
+        gen_datfile "T" lost.dat
+
+        ./jbuf.plot
+        if [ ! -d plots ]; then
+            mkdir plots
+        fi
+        cp jbuf.eps plots/jbuf_${strm}_${jmin}.eps
+    done
 
     if [ $once == "true" ]; then
         exit 0

--- a/tools/jbuf/jbuf.plot
+++ b/tools/jbuf/jbuf.plot
@@ -48,5 +48,5 @@ plot \
 'underflow.dat' using 3:(event_h(2)) title 'underflow' pt 7 ps 1.5 lc "#FF4444", \
 'toolate.dat' using 3:(event_h(3)) title  'toolate' pt 7 ps 1.5 lc "#BB5454", \
 'duplicate.dat' using 3:(event_h(4)) title 'duplicate' pt 7 ps 1.5 lc "#E919C6", \
-'oosequence.dat' using 3:(event_h(5)) title 'out off seq' pt 7 ps 1.5 lc "#A5A5A5", \
+'oosequence.dat' using 3:(event_h(5)) title 'out of seq' pt 7 ps 1.5 lc "#A5A5A5", \
 'lost.dat' using 3:(event_h(6)) title 'lost' pt 7 ps 1.5 lc "#C08DBC"

--- a/tools/jbuf/jbuf.plot
+++ b/tools/jbuf/jbuf.plot
@@ -1,0 +1,52 @@
+#!/usr/bin/gnuplot
+#
+# How to generate a plot
+# ======================
+# This gnuplot script plots DEBUG_LEVEL 6 output of jbuf.c. You have to
+# increment the DEBUG_LEVEL in ajb.c if you want to get the table for
+# jbuf.dat. Then call baresip like this:
+#
+# ./baresip 2>&1 | grep -Eo "jbuf.*" > jbuf.dat
+#
+# Call this script. Then compare the plot legend with the variables in jbuf.c!
+#
+#
+# Description of the plot
+# =======================
+# The plot is a time based diagram.
+#
+# Events:
+# - overflow
+# - underflow
+# - packet too late
+# - out of sequence
+# - lost packet
+# Copyright (C) 2023 commend.com - Christian Spielberger
+
+
+# Choose your preferred gnuplot terminal or use e.g. evince to view the
+# jbuf.eps!
+
+#set terminal qt persist
+set terminal postscript eps size 15,10 enhanced color
+set output 'jbuf.eps'
+#set terminal png size 1280,480
+#set output 'jbuf.png'
+set datafile separator ","
+set key outside
+set xlabel "time/[ms]"
+set ylabel "#packets"
+
+stats "jbuf.dat" using ($6) name "N"
+event_h(i) = (0.5*N_max) + 0.3*N_max*(i/6.0)
+
+plot \
+'jbuf.dat' using 3:4 title 'rdiff' with linespoints lc "orange", \
+'jbuf.dat' using 3:5 title 'wish' with linespoints lc "sea-green", \
+'jbuf.dat' using 3:6 title 'n' with linespoints lc "skyblue", \
+'overrun.dat' using 3:(event_h(1)) title 'overrun' pt 7 ps 1.5 lc "#FF0000", \
+'underflow.dat' using 3:(event_h(2)) title 'underflow' pt 7 ps 1.5 lc "#FF4444", \
+'toolate.dat' using 3:(event_h(3)) title  'toolate' pt 7 ps 1.5 lc "#BB5454", \
+'duplicate.dat' using 3:(event_h(4)) title 'duplicate' pt 7 ps 1.5 lc "#E919C6", \
+'oosequence.dat' using 3:(event_h(5)) title 'out off seq' pt 7 ps 1.5 lc "#A5A5A5", \
+'lost.dat' using 3:(event_h(6)) title 'lost' pt 7 ps 1.5 lc "#C08DBC"

--- a/tools/jbuf/jitter-off.sh
+++ b/tools/jbuf/jitter-off.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -f .env ]; then
+    echo ".env is missing. Copy and edit env-template!"
+    exit 1
+fi
+
+export `cat .env`
+
+echo "netif:  $netif"
+
+source ./jitter.sh
+
+
+disable_jitter
+
+cleanup_jitter $netif
+

--- a/tools/jbuf/jitter-on.sh
+++ b/tools/jbuf/jitter-on.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -f .env ]; then
+    echo ".env is missing. Copy and edit env-template!"
+    exit 1
+fi
+
+export `cat .env`
+
+echo "netif:  $netif"
+
+source ./jitter.sh
+
+
+init_jitter $netif
+
+enable_jitter
+

--- a/tools/jbuf/jitter.sh
+++ b/tools/jbuf/jitter.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function init_jitter () {
+    netif=$1
+    sudo ip link add ifb1 type ifb || :
+    sudo ip link set ifb1 up
+    sudo tc qdisc add dev $netif handle ffff: ingress
+    sudo tc filter add dev $netif parent ffff: u32 match u32 0 0 action mirred egress redirect dev ifb1
+}
+
+
+function enable_jitter() {
+    echo "ENABLE JITTER ..."
+    sudo tc qdisc add dev ifb1 root netem delay 0ms 50ms
+}
+
+
+function disable_jitter() {
+    echo "DISABLE JITTER ..."
+    sudo tc qdisc del dev ifb1 root
+}
+
+
+function cleanup_jitter() {
+    netif=$1
+    echo "CLEANUP jitter"
+    sudo tc filter delete dev $netif parent ffff:
+    sudo tc qdisc delete dev $netif ingress
+    sudo ip link set ifb1 down
+    sudo ip link delete ifb1
+}

--- a/tools/jbuf/video/accounts
+++ b/tools/jbuf/video/accounts
@@ -1,0 +1,1 @@
+<sip:alice@office>;regint=0;ptime=20

--- a/tools/jbuf/video/config
+++ b/tools/jbuf/video/config
@@ -1,0 +1,68 @@
+#audio_path		/usr/local/share/baresip
+audio_player		pulse,
+audio_source		pulse,
+audio_alert		pulse,
+audio_level		no
+audio_buffer   30-250
+audio_buffer_mode	adaptive
+audio_silence		0.0
+
+audio_jitter_buffer_type	off
+video_jitter_buffer_type	adaptive
+video_jitter_buffer_delay   0-500
+
+statmode_default	off
+rtp_stats		no
+
+module_path		/usr/local/lib/baresip/modules
+
+# Video
+video_source		v4l2,/dev/video0
+video_display		x11,nil
+# video_source		comvideo,
+video_size		640x480
+video_bitrate		500000
+video_fps		15.0
+
+# module			comvideo.so
+module			x11.so
+module			avcodec.so
+module			v4l2.so
+
+# UI Modules
+module			stdio.so
+module			cons.so
+
+module			opus.so
+
+module			auconv.so
+module			auresamp.so
+
+module			pulse.so
+
+
+module_app		account.so
+module_app		menu.so
+module_app		netroam.so
+
+
+cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets
+
+# Opus codec parameters
+opus_bitrate		28000 # 6000-510000
+#opus_stereo		yes
+#opus_sprop_stereo	yes
+#opus_cbr		no
+#opus_inbandfec		no
+#opus_dtx		no
+#opus_mirror		no
+#opus_complexity	10
+#opus_application	audio	# {voip,audio}
+#opus_samplerate	48000
+#opus_packet_loss	10	# 0-100 percent (expected packet loss)
+
+# Opus Multistream codec parameters
+#opus_ms_channels	2	#total channels (2 or 4)
+#opus_ms_streams	2	#number of streams
+#opus_ms_c_streams	2	#number of coupled streams
+


### PR DESCRIPTION
- tools: add jbuf plot tools
- tools: add jbuf audio call plots
- tools: jbuf support png plots


The following plots are done including already the fixes for the adaptive jitter buffer mode: https://github.com/baresip/re/pull/960

### Adaptive Jitter Buffer for Audio stream
![jbuf_audio_0](https://github.com/baresip/baresip/assets/14180877/2a467480-ebf2-44c8-9c60-3161e0a3b1ff)

### Adaptive Jitter Buffer for Video stream
![jbuf_video_0](https://github.com/baresip/baresip/assets/14180877/7ae77521-49cb-4db3-a5b1-e380ba05921a)

### Jitter Buffer `fixed` mode for Audio stream
![jbuf_audio_fixed](https://github.com/baresip/baresip/assets/14180877/18d65c77-aad4-44cc-bbfe-63f240db31de)

### Jitter Buffer `fixed` mode for Video stream
![jbuf_video_fixed](https://github.com/baresip/baresip/assets/14180877/8685f778-7b64-4927-a028-8bb6a357b5f0)

### Conclusion
- In adaptive mode the wish size is adjusted such that out-of-order packets can be re-ordered.
- In fixed mode the wish size is set during allocation and does not change.
- The adaptive mode minimizes the latency.

### How to use
- Increase the `DEBUG_LEVEL` to `6` and re-build `re`!
```
cd tools/jbuf
cp env-template .env
# edit .env
./generate_plot.sh
```
- Then view `eps` in sub-directory `plots`!