### PR TITLE
Add a list of error handlers for audio errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ Win32/*
 # Visual studio config
 mk/win32/baresip.vcxproj.user
 
+# VSCode config
+.vscode/*
+
 # clangd
 .cache
 compile_commands.json

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1354,6 +1354,8 @@ int  audio_decoder_set(struct audio *a, const struct aucodec *ac,
 const struct aucodec *audio_codec(const struct audio *au, bool tx);
 struct config_audio *audio_config(struct audio *au);
 bool audio_txtelev_empty(const struct audio *au);
+int  audio_add_error_handler(struct audio *au, audio_err_h handler, void *arg);
+int  audio_remove_error_handler(struct audio *au, audio_err_h handler);
 
 
 /*

--- a/src/audio.c
+++ b/src/audio.c
@@ -188,7 +188,7 @@ struct audio {
 	uint8_t extmap_aulevel;       /**< ID Range 1-14 inclusive         */
 	audio_event_h *eventh;        /**< Event handler                   */
 	audio_level_h *levelh;        /**< Audio level handler             */
-	struct list errhl;            /**< List of error handlers		   */
+	struct list errhl;            /**< List of error handlers          */
 	void *arg;                    /**< Handler argument                */
 };
 
@@ -2375,7 +2375,8 @@ int  audio_add_error_handler(struct audio *au, audio_err_h handler, void *arg)
 			return EALREADY;
 	}
 
-	struct audio_err_st *err_st = mem_zalloc(sizeof(struct audio_err_st), audio_err_st_destructor);
+	struct audio_err_st *err_st = mem_zalloc(sizeof(struct audio_err_st),
+		audio_err_st_destructor);
 
 	err_st->errh = handler;
 	err_st->arg = arg;

--- a/src/call.c
+++ b/src/call.c
@@ -465,7 +465,8 @@ static void audio_error_handler(int err, const char *str, void *arg)
 	if (err) {
 		warning("call: audio device error: %m (%s)\n", err, str);
 
-		ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s", err, str);
+		ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s",
+			err, str);
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_CLOSED, "%s", str);
 	}

--- a/src/call.c
+++ b/src/call.c
@@ -464,11 +464,11 @@ static void audio_error_handler(int err, const char *str, void *arg)
 
 	if (err) {
 		warning("call: audio device error: %m (%s)\n", err, str);
-	}
 
-	ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s", err, str);
-	call_stream_stop(call);
-	call_event_handler(call, CALL_EVENT_CLOSED, "%s", str);
+		ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s", err, str);
+		call_stream_stop(call);
+		call_event_handler(call, CALL_EVENT_CLOSED, "%s", str);
+	}
 }
 
 


### PR DESCRIPTION
This is useful when using `audio_set_source` with the `aufile` module and a filename: when the file has played to the end, the error handler is called with a 0 error code and the message `end of file`. This is sometimes needed by an application/module.