### PR TITLE
avcodec/decode: revert hw_frame handling and fix unref frame

### DIFF
--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -252,6 +252,7 @@ static int ffdecode(struct viddec_state *st, struct vidframe *frame,
 	if (got_picture) {
 
 		if (hw_frame) {
+			av_frame_unref(st->pict); /* cleanup old frame */
 			/* retrieve data from GPU to CPU */
 			ret = av_hwframe_transfer_data(st->pict, hw_frame, 0);
 			if (ret < 0) {


### PR DESCRIPTION
`av_frame_unref` is called by `avcodec_receive_frame` but since `hw_frame` is used instead, it has to be called before
`av_hwframe_transfer_data` for `st->pict`