### PR TITLE
Add UA_EVENT_END_OF_FILE 

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -825,6 +825,7 @@ enum ua_event {
 	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
 	UA_EVENT_REFER,
 	UA_EVENT_MODULE,
+	UA_EVENT_END_OF_FILE,
 	UA_EVENT_CUSTOM,
 
 	UA_EVENT_MAX,

--- a/src/audio.c
+++ b/src/audio.c
@@ -705,10 +705,8 @@ static void ausrc_error_handler(int err, const char *str, void *arg)
 	if (!err) {
 		info("audio: ausrc - %s\n", str);
 	}
-	else {
-		if (a->errh)
-			a->errh(err, str, a->arg);
-	}
+	if (a->errh)
+		a->errh(err, str, a->arg);
 }
 
 

--- a/src/call.c
+++ b/src/call.c
@@ -464,11 +464,15 @@ static void audio_error_handler(int err, const char *str, void *arg)
 
 	if (err) {
 		warning("call: audio device error: %m (%s)\n", err, str);
-	}
 
-	ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s", err, str);
-	call_stream_stop(call);
-	call_event_handler(call, CALL_EVENT_CLOSED, "%s", str);
+		ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s",
+			err, str);
+		call_stream_stop(call);
+		call_event_handler(call, CALL_EVENT_CLOSED,
+			"%s", str);
+	}
+	else
+		ua_event(call->ua, UA_EVENT_END_OF_FILE, call, "");
 }
 
 

--- a/src/event.c
+++ b/src/event.c
@@ -451,6 +451,7 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
 	case UA_EVENT_REFER:                return "REFER";
 	case UA_EVENT_MODULE:               return "MODULE";
+	case UA_EVENT_END_OF_FILE:          return "END_OF_FILE";
 	case UA_EVENT_CUSTOM:               return "CUSTOM";
 	default: return "?";
 	}


### PR DESCRIPTION
This will have the side effect of calling `ausrc_error_h` handlers with a 0 error code. I looked at the code (also in baresip-apps) and I didn't see any usages where this would break existing code.

I like the extra UA event `UA_END_OF_FILE`, which makes this more explicit.