### PR TITLE
call,event: add CALL_HOLD and CALL_RESUME events and fix call resume requests

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -831,6 +831,8 @@ enum ua_event {
 	UA_EVENT_AUDIO_ERROR,
 	UA_EVENT_CALL_LOCAL_SDP,      /**< param: offer or answer */
 	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
+	UA_EVENT_CALL_HOLD,           /**< Call put on-hold by peer          */
+	UA_EVENT_CALL_RESUME,         /**< Call resumed by peer              */
 	UA_EVENT_REFER,
 	UA_EVENT_MODULE,
 	UA_EVENT_END_OF_FILE,

--- a/src/event.c
+++ b/src/event.c
@@ -69,6 +69,8 @@ static const char *event_class_name(enum ua_event ev)
 	case UA_EVENT_CALL_MENC:
 	case UA_EVENT_CALL_LOCAL_SDP:
 	case UA_EVENT_CALL_REMOTE_SDP:
+	case UA_EVENT_CALL_HOLD:
+	case UA_EVENT_CALL_RESUME:
 		return "call";
 	case UA_EVENT_VU_RX:
 	case UA_EVENT_VU_TX:
@@ -449,6 +451,8 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_AUDIO_ERROR:          return "AUDIO_ERROR";
 	case UA_EVENT_CALL_LOCAL_SDP:       return "CALL_LOCAL_SDP";
 	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
+	case UA_EVENT_CALL_HOLD:            return "CALL_HOLD";
+	case UA_EVENT_CALL_RESUME:          return "CALL_RESUME";
 	case UA_EVENT_REFER:                return "REFER";
 	case UA_EVENT_MODULE:               return "MODULE";
 	case UA_EVENT_END_OF_FILE:          return "END_OF_FILE";


### PR DESCRIPTION
This reduces complexity in the application code

- A few simple lines in baresip can reduce the complexity in the application if a call-on-hold information should be displayed.
- Fixes also multiple re-INVITES for resumes in a row if there is only one call.
