### PR TITLE
test: call - add call on-hold/resume test

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -221,6 +221,7 @@ bool call_has_audio(const struct call *call);
 bool call_has_video(const struct call *call);
 bool call_early_video_available(const struct call *call);
 bool call_refresh_allowed(const struct call *call);
+bool call_ack_pending(const struct call *call);
 int  call_transfer(struct call *call, const char *uri);
 int  call_replace_transfer(struct call *target_call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);

--- a/src/call.c
+++ b/src/call.c
@@ -1557,6 +1557,12 @@ bool call_refresh_allowed(const struct call *call)
 }
 
 
+bool call_ack_pending(const struct call *call)
+{
+	return call ? sipsess_ack_pending(call->sess) : false;
+}
+
+
 /**
  * Get the session call-id for the call
  *

--- a/src/call.c
+++ b/src/call.c
@@ -1557,6 +1557,14 @@ bool call_refresh_allowed(const struct call *call)
 }
 
 
+/**
+ * Check if the local SIP Session expects an ACK as answer to a SIP Session
+ * Reply
+ *
+ * @param call  Call object
+ *
+ * @return True if an ACK is pending, false if not
+ */
 bool call_ack_pending(const struct call *call)
 {
 	return call ? sipsess_ack_pending(call->sess) : false;

--- a/test/call.c
+++ b/test/call.c
@@ -2593,7 +2593,12 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_RECVONLY, sdp_media_rdir(m));
-	ASSERT_TRUE(!call_ack_pending(ua_call(f->b.ua)));
+	int tries = 100;
+	while (call_ack_pending(ua_call(f->b.ua)) && --tries) {
+		(void)re_main_timeout(1);
+	}
+
+	ASSERT_TRUE(tries > 0);
 
 	/* set call to resume */
 	err = call_hold(ua_call(f->a.ua), false);
@@ -2608,7 +2613,12 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(m));
-	ASSERT_TRUE(!call_ack_pending(ua_call(f->b.ua)));
+	tries = 100;
+	while (call_ack_pending(ua_call(f->b.ua)) && --tries) {
+		(void)re_main_timeout(1);
+	}
+
+	ASSERT_TRUE(tries > 0);
 
  out:
 	if (err)

--- a/test/call.c
+++ b/test/call.c
@@ -2557,7 +2557,7 @@ int test_call_hold_resume(void)
 	TEST_ERR(err);
 
 	/* wait for RTP audio */
-	err = re_main_timeout(2000);
+	err = re_main_timeout(10000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
@@ -2582,7 +2582,7 @@ int test_call_hold_resume(void)
 	/* set call on-hold */
 	err = call_hold(ua_call(f->a.ua), true);
 	TEST_ERR(err);
-	err = re_main_timeout(2000);
+	err = re_main_timeout(10000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
@@ -2598,7 +2598,7 @@ int test_call_hold_resume(void)
 	/* set call to resume */
 	err = call_hold(ua_call(f->a.ua), false);
 	TEST_ERR(err);
-	err = re_main_timeout(2000);
+	err = re_main_timeout(10000);
 	TEST_ERR(err);
 
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->a.ua))));

--- a/test/call.c
+++ b/test/call.c
@@ -424,7 +424,7 @@ static int agent_wait_for_ack(struct agent *ag)
 	if (!call_ack_pending(ua_call(ag->ua)))
 		return 0;
 
-	cancel_rule_new(UA_EVENT_CUSTOM, ag->ua, 1, 0, 1);
+	cancel_rule_new(UA_EVENT_CUSTOM, ag->ua, -1, -1, 1);
 	cr->prm = "gotack";
 	cr->checkack = true;
 

--- a/test/call.c
+++ b/test/call.c
@@ -2560,7 +2560,7 @@ int test_call_ipv6ll(void)
 }
 
 
-int test_call_hold_resume(void)
+static int test_call_hold_resume_base(bool tcp)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -2582,7 +2582,8 @@ int test_call_hold_resume(void)
 	f->estab_action = ACTION_NOTHING;
 
 	/* Make a call from A to B */
-	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_ON);
+	err = ua_connect(f->a.ua, 0, NULL, tcp ? f->buri_tcp : f->buri,
+			 VIDMODE_ON);
 	TEST_ERR(err);
 
 	/* wait for RTP audio */
@@ -2653,5 +2654,20 @@ int test_call_hold_resume(void)
 	module_unload("aufile");
 	module_unload("ausine");
 
+	return err;
+}
+
+
+int test_call_hold_resume(void)
+{
+	int err;
+
+	err = test_call_hold_resume_base(false);
+	TEST_ERR(err);
+
+	err = test_call_hold_resume_base(true);
+	TEST_ERR(err);
+
+out:
 	return err;
 }

--- a/test/call.c
+++ b/test/call.c
@@ -2608,6 +2608,7 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(m));
+	ASSERT_TRUE(!call_ack_pending(ua_call(f->a.ua)));
 
  out:
 	if (err)

--- a/test/call.c
+++ b/test/call.c
@@ -2593,7 +2593,7 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_RECVONLY, sdp_media_rdir(m));
-	ASSERT_TRUE(!call_ack_pending(ua_call(f->a.ua)));
+	ASSERT_TRUE(!call_ack_pending(ua_call(f->b.ua)));
 
 	/* set call to resume */
 	err = call_hold(ua_call(f->a.ua), false);
@@ -2608,7 +2608,7 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_rdir(m));
-	ASSERT_TRUE(!call_ack_pending(ua_call(f->a.ua)));
+	ASSERT_TRUE(!call_ack_pending(ua_call(f->b.ua)));
 
  out:
 	if (err)

--- a/test/call.c
+++ b/test/call.c
@@ -2593,6 +2593,7 @@ int test_call_hold_resume(void)
 	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
 	ASSERT_EQ(SDP_SENDRECV, sdp_media_ldir(m));
 	ASSERT_EQ(SDP_RECVONLY, sdp_media_rdir(m));
+	ASSERT_TRUE(!call_ack_pending(ua_call(f->a.ua)));
 
 	/* set call to resume */
 	err = call_hold(ua_call(f->a.ua), false);

--- a/test/main.c
+++ b/test/main.c
@@ -50,6 +50,7 @@ static const struct test tests[] = {
 	TEST(test_call_bundle),
 	TEST(test_call_ipv6ll),
 	TEST(test_call_100rel_video),
+	TEST(test_call_hold_resume),
 	TEST(test_cmd),
 	TEST(test_cmd_long),
 	TEST(test_contact),

--- a/test/test.h
+++ b/test/test.h
@@ -219,6 +219,7 @@ int test_call_webrtc(void);
 int test_call_bundle(void);
 int test_call_ipv6ll(void);
 int test_call_100rel_video(void);
+int test_call_hold_resume(void);
 int test_cmd(void);
 int test_cmd_long(void);
 int test_contact(void);


### PR DESCRIPTION
relates to: https://github.com/baresip/re/pull/990
try to reproduce: https://github.com/baresip/baresip/issues/2772

- adds call on hold and resume test
- adds function to wait for SIP ACK