### PR TITLE
test: call - count audio frames

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -1470,7 +1470,7 @@ static void auframe_handler(struct auframe *af, void *arg)
 
 	ASSERT_EQ(MAGIC, fix->magic);
 
-	ptime = af->sampc * 1000 / af->srate;
+	ptime = (uint32_t) af->sampc * 1000 / af->srate;
 	if (ptime == 1) {
 		ag = &fix->a;
 	}

--- a/test/mock/cert.c
+++ b/test/mock/cert.c
@@ -4,6 +4,7 @@
  * Copyright (C) 2010 Alfred E. Heggestad
  */
 #include <re.h>
+#include <rem.h>
 #include "../test.h"
 
 

--- a/test/mock/dnssrv.c
+++ b/test/mock/dnssrv.c
@@ -5,6 +5,7 @@
  */
 #include <string.h>
 #include <re.h>
+#include <rem.h>
 #include "../test.h"
 
 

--- a/test/mock/mock_auplay.c
+++ b/test/mock/mock_auplay.c
@@ -49,7 +49,7 @@ static void tmr_handler(void *arg)
 
 	/* feed the audio-samples back to the test */
 	if (mock.sampleh)
-		mock.sampleh(st->sampv, st->sampc, mock.arg);
+		mock.sampleh(&af, mock.arg);
 }
 
 

--- a/test/play.c
+++ b/test/play.c
@@ -5,6 +5,7 @@
  */
 #include <string.h>
 #include <re.h>
+#include <rem.h>
 #include <baresip.h>
 #include "test.h"
 
@@ -39,10 +40,10 @@ static struct mbuf *generate_tone(void)
 }
 
 
-static void sample_handler(const void *sampv, size_t sampc, void *arg)
+static void auframe_handler(struct auframe *af, void *arg)
 {
 	struct test *test = arg;
-	size_t bytec = sampc * 2;
+	size_t bytec = af->sampc * 2;
 	int err = 0;
 
 	if (!test->mb_samp) {
@@ -51,7 +52,7 @@ static void sample_handler(const void *sampv, size_t sampc, void *arg)
 	}
 
 	/* save the samples that was played */
-	err = mbuf_write_mem(test->mb_samp, (void *)sampv, bytec);
+	err = mbuf_write_mem(test->mb_samp, (void *)af->sampv, bytec);
 
  out:
 	/* stop the test? */
@@ -73,7 +74,7 @@ int test_play(void)
 
 	/* use a mock audio-driver to save the audio-samples */
 	err = mock_auplay_register(&auplay, baresip_auplayl(),
-				   sample_handler, &test);
+				   auframe_handler, &test);
 	ASSERT_EQ(0, err);
 
 	err = play_init(&player);

--- a/test/test.h
+++ b/test/test.h
@@ -151,7 +151,7 @@ int dns_server_add_srv(struct dns_server *srv, const char *name,
 
 struct auplay;
 
-typedef void (mock_sample_h)(const void *sampv, size_t sampc, void *arg);
+typedef void (mock_sample_h)(struct auframe *af, void *arg);
 
 int mock_auplay_register(struct auplay **auplayp, struct list *auplayl,
 			 mock_sample_h *sampleh, void *arg);


### PR DESCRIPTION
Here are some improvements for audio tests that will make it possible to add a 100rel test for audio, finally. All these will be useful to test against concurrency failures with the RX thread.

- test: call - replace re_cancel in audio_sample_handler() by cancel rule
- test: call - for test_call_aulevel() move new auframe_handler()
- test: play - update to auframe in auframe_handler
