### PR TITLE
RTP audio: activate RX thread via config

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -72,6 +72,7 @@ video_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
 rtp_stats		no
 #rtp_timeout		60
 #avt_bundle		no
+#rtp_rxmode		main            # main,thread
 
 # Network
 #dns_server		1.1.1.1:53

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -325,6 +325,12 @@ enum audio_mode {
 	AUDIO_MODE_THREAD,           /**< Use dedicated thread          */
 };
 
+/** RTP receive mode */
+enum rtp_receive_mode {
+	RECEIVE_MODE_MAIN = 0,  /**< RTP RX is processed in main thread      */
+	RECEIVE_MODE_THREAD,    /**< RTP RX is processed in separate thread  */
+};
+
 /** SIP User-Agent */
 struct config_sip {
 	char uuid[64];          /**< Universally Unique Identifier  */
@@ -403,6 +409,7 @@ struct config_avt {
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 	bool bundle;            /**< Media Multiplexing (BUNDLE)    */
+	enum rtp_receive_mode rxmode;   /**< RTP RX processing mode */
 };
 
 /** Network Configuration */

--- a/src/audio.c
+++ b/src/audio.c
@@ -296,6 +296,7 @@ static void audio_destructor(void *arg)
 
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
+	stream_stop(a->strm);
 
 	mem_deref(a->tx.enc);
 	mem_deref(a->rx.dec);
@@ -1731,6 +1732,7 @@ void audio_stop(struct audio *a)
 
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
+	stream_stop(a->strm);
 	a->started = false;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -98,7 +98,8 @@ static struct config core_config = {
 		},
 		false,
 		0,
-		false
+		false,
+		RECEIVE_MODE_MAIN,
 	},
 
 	/* Network */
@@ -313,6 +314,7 @@ static const char *net_af_str(int af)
 int config_parse_conf(struct config *cfg, const struct conf *conf)
 {
 	struct vidsz size = {0, 0};
+	struct pl rxmode;
 	struct pl txmode;
 	struct pl jbtype;
 	struct pl tr;
@@ -470,6 +472,14 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
+	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
+
+		if (0 == pl_strcasecmp(&rxmode, "thread")) {
+			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
+			warning("rtp_rxmode thread is currently "
+				"experimental\n");
+		}
+	}
 
 	if (err) {
 		warning("config: configure parse error (%m)\n", err);
@@ -571,6 +581,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "avt_bundle\t\t%s\n"
+			 "rtp_rxmode\t\t\t%s\n"
 			 "\n"
 			 "# Network\n"
 			 "net_interface\t\t%s\n"
@@ -625,6 +636,8 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 			 cfg->avt.bundle ? "yes" : "no",
+			 cfg->avt.rxmode == RECEIVE_MODE_THREAD ? "thread" :
+								  "main",
 
 			 cfg->net.ifname,
 			 net_af_str(cfg->net.af)
@@ -835,6 +848,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "#avt_bundle\t\tno\n"
+			  "#rtp_rxmode\t\tmain\n"
 			  "\n# Network\n"
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"

--- a/src/core.h
+++ b/src/core.h
@@ -481,5 +481,7 @@ void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
+int  rtprecv_start_thread(struct rtp_receiver *rx);
 void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 				    const struct sa *raddr2, void *arg);
+bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/core.h
+++ b/src/core.h
@@ -319,6 +319,7 @@ void stream_stop_natpinhole(struct stream *strm);
 void stream_process_rtcp(struct stream *strm, struct rtcp_msg *msg);
 void stream_mnat_connected(struct stream *strm, const struct sa *raddr1,
 			   const struct sa *raddr2);
+void stream_stop(struct stream *s);
 
 
 /*

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -159,10 +159,14 @@ static void rtprecv_check_stop(void *arg)
 {
 	struct rtp_receiver *rx = arg;
 
-	if (re_atomic_rlx(&rx->run))
+	if (re_atomic_rlx(&rx->run)) {
 		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
-	else
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
 		re_cancel();
+	}
 }
 
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -30,6 +30,7 @@ struct rtp_receiver {
 	uint32_t pseq;                 /**< Sequence number for incoming RTP */
 	bool pseq_set;                 /**< True if sequence number is set   */
 	bool rtp_estab;                /**< True if RTP stream established   */
+	RE_ATOMIC bool run;            /**< True if RX thread is running     */
 	mtx_t *mtx;                    /**< Mutex protects above fields      */
 
 	/* Unprotected data */
@@ -40,8 +41,153 @@ struct rtp_receiver {
 	stream_rtpestab_h *rtpestabh;  /**< RTP established handler          */
 	void *arg;                     /**< Stream argument                  */
 	void *sessarg;                 /**< Session argument                 */
+	thrd_t thr;                    /**< RX thread                        */
+	struct tmr tmr;                /**< Timer for stopping RX thread     */
 	int pt;                        /**< Previous payload type            */
 };
+
+
+enum work_type {
+	WORK_RTCP,
+	WORK_RTPESTAB,
+	WORK_PTCHANGED,
+	WORK_MNATCONNH,
+};
+
+
+struct work {
+	enum work_type type;
+	struct rtp_receiver *rx;
+	union {
+		struct rtcp_msg *rtcp;
+		struct {
+			uint8_t pt;
+			struct mbuf *mb;
+		} pt;
+		struct {
+			struct sa raddr1;
+			struct sa raddr2;
+		} mnat;
+	} u;
+};
+
+
+static void async_work_main(int err, void *arg);
+static void work_destructor(void *arg);
+
+
+/*
+ * functions that run in RX thread (if "rxmode thread" is configured)
+ */
+
+
+static void pass_rtcp_work(struct rtp_receiver *rx, struct rtcp_msg *msg)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		stream_process_rtcp(rx->strm, msg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	if (!w)
+		return;
+
+	w->type    = WORK_RTCP;
+	w->rx      = rx;
+	w->u.rtcp  = mem_ref(msg);
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static int pass_pt_work(struct rtp_receiver *rx, uint8_t pt, struct mbuf *mb)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run))
+		return rx->pth(pt, mb, rx->arg);
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type    = WORK_PTCHANGED;
+	w->rx      = rx;
+	w->u.pt.pt = pt;
+	w->u.pt.mb = mbuf_dup(mb);
+
+	return re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_rtpestab_work(struct rtp_receiver *rx)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		rx->rtpestabh(rx->strm, rx->sessarg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_RTPESTAB;
+	w->rx   = rx;
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_mnat_work(struct rtp_receiver *rx, const struct sa *raddr1,
+			   const struct sa *raddr2)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		stream_mnat_connected(rx->strm, raddr1, raddr2);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_MNATCONNH;
+	w->rx   = rx;
+	sa_cpy(&w->u.mnat.raddr1, raddr1);
+	sa_cpy(&w->u.mnat.raddr2, raddr2);
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void rtprecv_check_stop(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+
+	if (re_atomic_rlx(&rx->run))
+		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+	else
+		re_cancel();
+}
+
+
+static int rtprecv_thread(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	int err;
+
+	re_thread_init();
+	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+
+	err = udp_thread_attach(rtp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = udp_thread_attach(rtcp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = re_main(NULL);
+
+	tmr_cancel(&rx->tmr);
+	re_thread_close();
+	return err;
+}
 
 
 static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
@@ -198,7 +344,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 			debug("stream: incoming rtp for '%s' established, "
 			      "receiving from %J\n", rx->name, src);
 			rx->rtp_estab = true;
-			rx->rtpestabh(rx->strm, rx->sessarg);
+			pass_rtpestab_work(rx);
 		}
 	}
 
@@ -227,7 +373,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 	if (hdr->pt != rx->pt) {
 		rx->pt = hdr->pt;
 
-		err = rx->pth(hdr->pt, mb, rx->arg);
+		err = pass_pt_work(rx, hdr->pt, mb);
 		if (err && err != ENODATA)
 			return;
 	}
@@ -274,7 +420,7 @@ void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
 	rx->ts_last = tmr_jiffies();
 	mtx_unlock(rx->mtx);
 
-	stream_process_rtcp(rx->strm, msg);
+	pass_rtcp_work(rx, msg);
 }
 
 
@@ -285,9 +431,13 @@ void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 
 	MAGIC_CHECK(rx);
 
-	stream_mnat_connected(rx->strm, raddr1, raddr2);
+	pass_mnat_work(rx, raddr1, raddr2);
 }
 
+
+/*
+ * functions that run in main thread
+ */
 
 void rtprecv_set_socket(struct rtp_receiver *rx, struct rtp_sock *rtp)
 {
@@ -412,6 +562,13 @@ static void destructor(void *arg)
 {
 	struct rtp_receiver *rx = arg;
 
+	if (re_atomic_rlx(&rx->run)) {
+		re_atomic_rlx_set(&rx->run, false);
+		thrd_join(rx->thr, NULL);
+	}
+
+	re_thread_async_main_cancel((intptr_t)rx);
+
 	mem_deref(rx->metric);
 	mem_deref(rx->name);
 	mem_deref(rx->mtx);
@@ -483,6 +640,41 @@ out:
 }
 
 
+int rtprecv_start_thread(struct rtp_receiver *rx)
+{
+	int err;
+
+	if (!rx)
+		return EINVAL;
+
+	if (re_atomic_rlx(&rx->run))
+		return 0;
+
+	re_atomic_rlx_set(&rx->run, true);
+	err = thread_create_name(&rx->thr,
+				 "RX thread",
+				 rtprecv_thread, rx);
+	if (err) {
+		re_atomic_rlx_set(&rx->run, false);
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
+	}
+
+	return err;
+}
+
+
+bool rtprecv_running(const struct rtp_receiver *rx)
+{
+	if (!rx)
+		return false;
+
+	return re_atomic_rlx(&rx->run);
+}
+
+
 void rtprecv_set_handlers(struct rtp_receiver *rx,
 			   stream_rtpestab_h *rtpestabh, void *arg)
 {
@@ -500,4 +692,50 @@ struct metric *rtprecv_metric(struct rtp_receiver *rx)
 {
 	/* it is allowed to return metric because it is thread safe */
 	return rx->metric;
+}
+
+
+static void work_destructor(void *arg)
+{
+	struct work *w = arg;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			mem_deref(w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			mem_deref(w->u.pt.mb);
+			break;
+		default:
+			break;
+	}
+}
+
+
+static void async_work_main(int err, void *arg)
+{
+	struct work *w = arg;
+	struct rtp_receiver *rx = w->rx;
+	(void)err;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			stream_process_rtcp(rx->strm, w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			rx->pth(w->u.pt.pt, w->u.pt.mb, rx->arg);
+			break;
+		case WORK_RTPESTAB:
+			rx->rtpestabh(rx->strm, rx->sessarg);
+			break;
+		case WORK_MNATCONNH:
+			stream_mnat_connected(rx->strm,
+					      &w->u.mnat.raddr1,
+					      &w->u.mnat.raddr2);
+			break;
+		default:
+			break;
+	}
+
+	mem_deref(w);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -152,6 +152,12 @@ static void stream_destructor(void *arg)
 }
 
 
+void stream_stop(struct stream *s)
+{
+	s->rx = mem_deref(s->rx);
+}
+
+
 static const char *media_name(enum media_type type)
 {
 	switch (type) {

--- a/test/call.c
+++ b/test/call.c
@@ -1646,7 +1646,8 @@ static void auframe_handler(struct auframe *af, void *arg)
 	ua = ag->ua;
 	/* Does auframe come from the decoder ? */
 	if (!audio_rxaubuf_started(call_audio(ua_call(ua)))) {
-		info("test: received audio frame not from decoder yet\n");
+		info("test: [%s] no audio received from decoder yet\n",
+		     account_aor(ua_account(ua)));
 		return;
 	}
 
@@ -1824,7 +1825,7 @@ static int test_media_base(enum rtp_receive_mode rxmode,
 	TEST_ERR(err);
 
 	/* run main-loop with timeout, wait for events */
-	err = re_main_timeout(15000);
+	err = re_main_timeout(10000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
@@ -2503,6 +2504,12 @@ int test_call_aufilt(void)
 	TEST_ERR(err);
 
 	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	TEST_ERR(err);
+
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_THREAD);
+	TEST_ERR(err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	TEST_ERR(err);
 
  out:

--- a/test/call.c
+++ b/test/call.c
@@ -781,11 +781,12 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 }
 
 
-int test_call_answer(void)
+static int test_call_answer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -811,6 +812,21 @@ int test_call_answer(void)
  out:
 	fixture_close(f);
 
+	return err;
+}
+
+
+int test_call_answer(void)
+{
+	int err;
+
+	err = test_call_answer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -847,11 +863,12 @@ int test_call_reject(void)
 }
 
 
-int test_call_answer_hangup_a(void)
+static int test_call_answer_hangup_a_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -881,12 +898,28 @@ int test_call_answer_hangup_a(void)
 }
 
 
-int test_call_answer_hangup_b(void)
+int test_call_answer_hangup_a(void)
+{
+	int err;
+
+	err = test_call_answer_hangup_a_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_hangup_a_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_answer_hangup_b_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	char uri[256];
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -919,13 +952,29 @@ int test_call_answer_hangup_b(void)
 }
 
 
-int test_call_rtp_timeout(void)
+int test_call_answer_hangup_b(void)
+{
+	int err;
+
+	err = test_call_answer_hangup_b_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_hangup_b_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_rtp_timeout_base(enum rtp_receive_mode rxmode)
 {
 #define RTP_TIMEOUT_MS 1
 	struct fixture fix, *f = &fix;
 	struct call *call;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -960,6 +1009,21 @@ int test_call_rtp_timeout(void)
 }
 
 
+int test_call_rtp_timeout(void)
+{
+	int err;
+
+	err = test_call_rtp_timeout_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_rtp_timeout_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 /* veriy that line-numbers are in sequence */
 static bool linenum_are_sequential(const struct ua *ua)
 {
@@ -979,13 +1043,14 @@ static bool linenum_are_sequential(const struct ua *ua)
 }
 
 
-int test_call_multiple(void)
+static int test_call_multiple_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct le *le;
 	unsigned i;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -1069,7 +1134,22 @@ int test_call_multiple(void)
 }
 
 
-int test_call_max(void)
+int test_call_multiple(void)
+{
+	int err;
+
+	err = test_call_multiple_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_multiple_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_max_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	unsigned i;
@@ -1079,6 +1159,7 @@ int test_call_max(void)
 	/* We start 2 calls from a.ua to b.ua. */
 	/* This are 2 outgoing calls and 1 incoming. */
 	conf_config()->call.max_calls = 3;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init(f);
 
@@ -1114,11 +1195,28 @@ int test_call_max(void)
 }
 
 
-int test_call_dtmf(void)
+int test_call_max(void)
+{
+	int err;
+
+	err = test_call_max_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_max_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_dtmf_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	size_t i, n = str_len(dtmf_digits);
 	int err = 0;
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	fixture_init_prm(f, ";ptime=1");
@@ -1160,6 +1258,21 @@ int test_call_dtmf(void)
 }
 
 
+int test_call_dtmf(void)
+{
+	int err;
+
+	err = test_call_dtmf_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_dtmf_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 static void mock_vidisp_handler(const struct vidframe *frame,
 				uint64_t timestamp, const char *title,
 				void *arg)
@@ -1193,7 +1306,7 @@ static void mock_vidisp_handler(const struct vidframe *frame,
 }
 
 
-int test_call_video(void)
+static int test_call_video_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1202,6 +1315,7 @@ int test_call_video(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 1);
@@ -1249,7 +1363,22 @@ int test_call_video(void)
 }
 
 
-int test_call_change_videodir(void)
+int test_call_video(void)
+{
+	int err;
+
+	err = test_call_video_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_video_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_change_videodir_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1259,6 +1388,7 @@ int test_call_change_videodir(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init_prm(f, ";answermode=early");
 	cr_prog = cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
@@ -1374,7 +1504,22 @@ int test_call_change_videodir(void)
 }
 
 
-int test_call_100rel_video(void)
+int test_call_change_videodir(void)
+{
+	int err;
+
+	err = test_call_change_videodir_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_change_videodir_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_100rel_video_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1383,6 +1528,7 @@ int test_call_100rel_video(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init_prm(f, ";100rel=yes;answermode=early");
 
@@ -1460,6 +1606,21 @@ int test_call_100rel_video(void)
 }
 
 
+int test_call_100rel_video(void)
+{
+	int err;
+
+	err = test_call_100rel_video_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_100rel_video_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 static void auframe_handler(struct auframe *af, void *arg)
 {
 	struct fixture *fix = arg;
@@ -1501,12 +1662,14 @@ static void auframe_handler(struct auframe *af, void *arg)
 }
 
 
-int test_call_aulevel(void)
+static int test_call_aulevel_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	struct auplay *auplay = NULL;
 	int err = 0;
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	fixture_init_prm(f, ";ptime=1");
@@ -1552,12 +1715,28 @@ int test_call_aulevel(void)
 }
 
 
-int test_call_progress(void)
+int test_call_aulevel(void)
+{
+	int err;
+
+	err = test_call_aulevel_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_aulevel_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_progress_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init_prm(f, ";answermode=early");
 	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
 
@@ -1590,13 +1769,30 @@ int test_call_progress(void)
 }
 
 
-static int test_media_base(enum audio_mode txmode)
+int test_call_progress(void)
+{
+	int err;
+
+	err = test_call_progress_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_progress_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_media_base(enum rtp_receive_mode rxmode,
+			   enum audio_mode txmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	struct auplay *auplay = NULL;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init_prm(f, ";ptime=1");
 	mem_deref(f->b.ua);
 	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>;regint=0;ptime=2");
@@ -1660,10 +1856,16 @@ int test_call_format_float(void)
 {
 	int err;
 
-	err = test_media_base(AUDIO_MODE_POLL);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_POLL);
 	ASSERT_EQ(0, err);
 
-	err = test_media_base(AUDIO_MODE_THREAD);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_THREAD);
+	ASSERT_EQ(0, err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	ASSERT_EQ(0, err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	ASSERT_EQ(0, err);
 
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;
@@ -1673,7 +1875,7 @@ int test_call_format_float(void)
 }
 
 
-int test_call_mediaenc(void)
+static int test_call_mediaenc_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -1681,6 +1883,8 @@ int test_call_mediaenc(void)
 
 	err = module_load(".", "srtp");
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Enable a dummy media encryption protocol */
 	fixture_init_prm(f, ";mediaenc=srtp;ptime=1");
@@ -1734,13 +1938,29 @@ int test_call_mediaenc(void)
 }
 
 
-int test_call_medianat(void)
+int test_call_mediaenc(void)
+{
+	int err;
+
+	err = test_call_mediaenc_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_mediaenc_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_medianat_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err;
 
 	mock_mnat_register(baresip_mnatl());
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Enable a dummy media NAT-traversal protocol */
 	fixture_init_prm(f, ";medianat=XNAT;ptime=1");
@@ -1784,7 +2004,22 @@ int test_call_medianat(void)
 }
 
 
-int test_call_custom_headers(void)
+int test_call_medianat(void)
+{
+	int err;
+
+	err = test_call_medianat_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_medianat_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_custom_headers_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
@@ -1792,6 +2027,7 @@ int test_call_custom_headers(void)
 	struct list custom_hdrs;
 	bool headers_matched = true;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	ua_add_xhdr_filter(f->b.ua, "X-CALL_ID");
@@ -1862,11 +2098,27 @@ int test_call_custom_headers(void)
 }
 
 
-int test_call_tcp(void)
+int test_call_custom_headers(void)
+{
+	int err;
+
+	err = test_call_custom_headers_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_custom_headers_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_tcp_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -1886,6 +2138,21 @@ int test_call_tcp(void)
  out:
 	fixture_close(f);
 
+	return err;
+}
+
+
+int test_call_tcp(void)
+{
+	int err;
+
+	err = test_call_tcp_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_tcp_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -1942,11 +2209,12 @@ int test_call_deny_udp(void)
  *  Step 3. Call between B and C
  *          No call for A
  */
-int test_call_transfer(void)
+static int test_call_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	/* Create a 3rd useragent needed for transfer */
@@ -1992,11 +2260,27 @@ int test_call_transfer(void)
 }
 
 
-int test_call_transfer_fail(void)
+int test_call_transfer(void)
+{
+	int err;
+
+	err = test_call_transfer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_transfer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_transfer_fail_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	/* Create a 3rd useragent needed for transfer */
@@ -2047,11 +2331,27 @@ out:
 }
 
 
-int test_call_attended_transfer(void)
+int test_call_transfer_fail(void)
+{
+	int err;
+
+	err = test_call_transfer_fail_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_transfer_fail_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_attended_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	err = ua_alloc(&f->c.ua, "C <sip:c@127.0.0.1>;regint=0");
@@ -2098,7 +2398,22 @@ out:
 }
 
 
-static int test_call_rtcp_base(bool rtcp_mux)
+int test_call_attended_transfer(void)
+{
+	int err;
+
+	err = test_call_attended_transfer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_attended_transfer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_rtcp_base(enum rtp_receive_mode rxmode, bool rtcp_mux)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -2106,6 +2421,8 @@ static int test_call_rtcp_base(bool rtcp_mux)
 
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	if (rtcp_mux) {
@@ -2156,11 +2473,21 @@ static int test_call_rtcp_base(bool rtcp_mux)
 
 int test_call_rtcp(void)
 {
-	int err = 0;
+	int err;
 
-	err |= test_call_rtcp_base(false);
-	err |= test_call_rtcp_base(true);
+	err = test_call_rtcp_base(RECEIVE_MODE_MAIN, false);
+	TEST_ERR(err);
 
+	err = test_call_rtcp_base(RECEIVE_MODE_MAIN, true);
+	TEST_ERR(err);
+
+	err = test_call_rtcp_base(RECEIVE_MODE_THREAD, false);
+	TEST_ERR(err);
+
+	err = test_call_rtcp_base(RECEIVE_MODE_THREAD, true);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -2172,8 +2499,11 @@ int test_call_aufilt(void)
 	err = module_load(".", "auconv");
 	TEST_ERR(err);
 
-	err = test_media_base(AUDIO_MODE_POLL);
-	ASSERT_EQ(0, err);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_POLL);
+	TEST_ERR(err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	TEST_ERR(err);
 
  out:
 	module_unload("auconv");
@@ -2185,7 +2515,7 @@ int test_call_aufilt(void)
 /*
  * Simulate a complete WebRTC testcase
  */
-int test_call_webrtc(void)
+static int test_call_webrtc_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2193,6 +2523,7 @@ int test_call_webrtc(void)
 	int err;
 
 	conf_config()->avt.rtcp_mux = true;
+	conf_config()->avt.rxmode = rxmode;
 
 	mock_mnat_register(baresip_mnatl());
 
@@ -2276,7 +2607,23 @@ int test_call_webrtc(void)
 }
 
 
-static int test_call_bundle_base(bool use_mnat, bool use_menc)
+int test_call_webrtc(void)
+{
+	int err;
+
+	err = test_call_webrtc_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_webrtc_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_bundle_base(bool use_mnat, bool use_menc,
+				 enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2291,6 +2638,7 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
 	conf_config()->avt.bundle = true;
 	conf_config()->avt.rtcp_mux = true;  /* MUST enable RTP/RTCP mux */
 	conf_config()->video.fps = 100;
+	conf_config()->avt.rxmode = rxmode;
 
 	if (use_mnat) {
 		mock_mnat_register(baresip_mnatl());
@@ -2434,13 +2782,26 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
  */
 int test_call_bundle(void)
 {
-	int err = 0;
+	int err;
 
-	err |= test_call_bundle_base(false, false);
-	err |= test_call_bundle_base(true,  false);
-	err |= test_call_bundle_base(false, true);
-	err |= test_call_bundle_base(true,  true);
+	err = test_call_bundle_base(false, false, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  false, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, true, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  true, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, false, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  false, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, true, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  true, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
 
+out:
 	return err;
 }
 
@@ -2459,7 +2820,7 @@ static bool find_ipv6ll(const char *ifname, const struct sa *sa, void *arg)
 }
 
 
-int test_call_ipv6ll(void)
+static int test_call_ipv6ll_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2478,6 +2839,7 @@ int test_call_ipv6ll(void)
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -2527,5 +2889,20 @@ int test_call_ipv6ll(void)
 	fixture_close(f);
 	module_unload("ausine");
 
+	return err;
+}
+
+
+int test_call_ipv6ll(void)
+{
+	int err;
+
+	err = test_call_ipv6ll_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_ipv6ll_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
 	return err;
 }

--- a/test/call.c
+++ b/test/call.c
@@ -1648,8 +1648,8 @@ static void auframe_handler(struct auframe *af, void *arg)
 	ua = ag->ua;
 	/* Does auframe come from the decoder ? */
 	if (!audio_rxaubuf_started(call_audio(ua_call(ua)))) {
-		info("test: [%s] no audio received from decoder yet\n",
-		     account_aor(ua_account(ua)));
+		debug("test: [%s] no audio received from decoder yet\n",
+		      account_aor(ua_account(ua)));
 		return;
 	}
 

--- a/test/call.c
+++ b/test/call.c
@@ -270,6 +270,7 @@ static int cancel_rule_debug(struct re_printf *pf,
 	err |= cr_debug_nbr(n_video_estab);
 	err |= cr_debug_nbr(n_offer_cnt);
 	err |= cr_debug_nbr(n_answer_cnt);
+	err |= cr_debug_nbr(n_auframe);
 	err |= cr_debug_nbr(n_vidframe);
 	err |= re_hprintf(pf, "    met:  %s\n", cr->met ? "yes": "no");
 	if (err)
@@ -313,6 +314,7 @@ static int agent_debug(struct re_printf *pf, const struct agent *ag)
 	err |= ag_debug_nbr(n_video_estab);
 	err |= ag_debug_nbr(n_offer_cnt);
 	err |= ag_debug_nbr(n_answer_cnt);
+	err |= ag_debug_nbr(n_auframe);
 	err |= ag_debug_nbr(n_vidframe);
 	if (err)
 		return err;

--- a/test/main.c
+++ b/test/main.c
@@ -10,6 +10,7 @@
 #include <baresip.h>
 #include "test.h"
 
+enum { ASYNC_WORKERS = 4 };
 
 typedef int (test_exec_h)(void);
 
@@ -190,6 +191,7 @@ int main(int argc, char *argv[])
 		return err;
 
 	log_enable_info(false);
+	re_thread_async_init(ASYNC_WORKERS);
 
 #ifdef HAVE_GETOPT
 	for (;;) {


### PR DESCRIPTION
Has to be rebased after
- https://github.com/baresip/baresip/pull/2776
- https://github.com/baresip/baresip/pull/2775
- An one more test PR.

commits:
- test: call - replace re_cancel in audio_sample_handler() by cancel rule
- test: call - for test_call_aulevel() move new auframe_handler()
- test: play - update to auframe in auframe_handler
- test: call - fix integer precision warning
- stream,rtprecv: activate RX thread via config
- test: run call tests with RX_MODE_THREAD
- test: main - init async workers
- rtprecv: detach from rtp/rtcp sockets on stop
