### PR TITLE
rtprecv: fix possible rtprecv_metric null pointer deref

### DIFF
--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -499,7 +499,7 @@ void rtprecv_set_handlers(struct rtp_receiver *rx,
 struct metric *rtprecv_metric(struct rtp_receiver *rx)
 {
 	if (!rx)
-		return;
+		return NULL;
 
 	/* it is allowed to return metric because it is thread safe */
 	return rx->metric;

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -498,6 +498,9 @@ void rtprecv_set_handlers(struct rtp_receiver *rx,
 
 struct metric *rtprecv_metric(struct rtp_receiver *rx)
 {
+	if (!rx)
+		return;
+
 	/* it is allowed to return metric because it is thread safe */
 	return rx->metric;
 }


### PR DESCRIPTION
Fixes https://github.com/baresip/baresip/issues/2785. Please commit or provide better fix.