### PR TITLE
RTP audio: activate RX thread

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,4 +43,4 @@ jobs:
       run: cmake -B build -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: valgrind test
-      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest
+      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest -v

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -72,6 +72,7 @@ video_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
 rtp_stats		no
 #rtp_timeout		60
 #avt_bundle		no
+#rtp_rxmode		main            # main,thread
 
 # Network
 #dns_server		1.1.1.1:53

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -326,6 +326,12 @@ enum audio_mode {
 	AUDIO_MODE_THREAD,           /**< Use dedicated thread          */
 };
 
+/** RTP receive mode */
+enum rtp_receive_mode {
+	RECEIVE_MODE_MAIN = 0,  /**< RTP RX is processed in main thread      */
+	RECEIVE_MODE_THREAD,    /**< RTP RX is processed in separate thread  */
+};
+
 /** SIP User-Agent */
 struct config_sip {
 	char uuid[64];          /**< Universally Unique Identifier  */
@@ -404,6 +410,7 @@ struct config_avt {
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 	bool bundle;            /**< Media Multiplexing (BUNDLE)    */
+	enum rtp_receive_mode rxmode;   /**< RTP RX processing mode */
 };
 
 /** Network Configuration */

--- a/src/audio.c
+++ b/src/audio.c
@@ -2348,14 +2348,16 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
  */
 bool audio_rxaubuf_started(const struct audio *au)
 {
-	const struct aurx *rx;
+	bool started;
 
 	if (!au)
 		return false;
 
-	rx = &au->rx;
+	mtx_lock(au->rx.mtx);
+	started = au->rx.aubuf_started;
+	mtx_unlock(au->rx.mtx);
 
-	return rx->aubuf_started;
+	return started;
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -296,6 +296,7 @@ static void audio_destructor(void *arg)
 
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
+	stream_enable(a->strm, false);
 
 	mem_deref(a->tx.enc);
 	mem_deref(a->rx.dec);
@@ -1731,6 +1732,7 @@ void audio_stop(struct audio *a)
 
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
+	stream_enable(a->strm, false);
 	a->started = false;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -98,7 +98,8 @@ static struct config core_config = {
 		},
 		false,
 		0,
-		false
+		false,
+		RECEIVE_MODE_MAIN,
 	},
 
 	/* Network */
@@ -313,6 +314,7 @@ static const char *net_af_str(int af)
 int config_parse_conf(struct config *cfg, const struct conf *conf)
 {
 	struct vidsz size = {0, 0};
+	struct pl rxmode;
 	struct pl txmode;
 	struct pl jbtype;
 	struct pl tr;
@@ -470,6 +472,14 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
+	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
+
+		if (0 == pl_strcasecmp(&rxmode, "thread")) {
+			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
+			warning("rtp_rxmode thread is currently "
+				"experimental\n");
+		}
+	}
 
 	if (err) {
 		warning("config: configure parse error (%m)\n", err);
@@ -571,6 +581,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "avt_bundle\t\t%s\n"
+			 "rtp_rxmode\t\t\t%s\n"
 			 "\n"
 			 "# Network\n"
 			 "net_interface\t\t%s\n"
@@ -625,6 +636,8 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 			 cfg->avt.bundle ? "yes" : "no",
+			 cfg->avt.rxmode == RECEIVE_MODE_THREAD ? "thread" :
+								  "main",
 
 			 cfg->net.ifname,
 			 net_af_str(cfg->net.af)
@@ -835,6 +848,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "#avt_bundle\t\tno\n"
+			  "#rtp_rxmode\t\tmain\n"
 			  "\n# Network\n"
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"

--- a/src/core.h
+++ b/src/core.h
@@ -481,5 +481,7 @@ void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
+int  rtprecv_start_thread(struct rtp_receiver *rx);
 void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 				    const struct sa *raddr2, void *arg);
+bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/core.h
+++ b/src/core.h
@@ -477,7 +477,7 @@ void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc);
 uint64_t rtprecv_ts_last(struct rtp_receiver *rx);
 void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last);
 void rtprecv_flush(struct rtp_receiver *rx);
-void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
+void rtprecv_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -179,12 +179,18 @@ static int rtprecv_thread(void *arg)
 	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
 
 	err = udp_thread_attach(rtp_sock(rx->rtp));
-	if (err)
+	if (err) {
+		warning("rtp_receiver: could not attach to RTP socket (%m)\n",
+			err);
 		return err;
+	}
 
 	err = udp_thread_attach(rtcp_sock(rx->rtp));
-	if (err)
+	if (err) {
+		warning("rtp_receiver: could not attach to RTCP socket (%m)\n",
+			err);
 		return err;
+	}
 
 	err = re_main(NULL);
 
@@ -239,7 +245,7 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 
 		size_t ext_len = hdr->x.len*sizeof(uint32_t);
 		if (mb->pos < ext_len) {
-			warning("stream: corrupt rtp packet,"
+			warning("rtp_receiver: corrupt rtp packet,"
 				" not enough space for rtpext of %zu bytes\n",
 				ext_len);
 			return 0;
@@ -252,8 +258,8 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 
 			err = rtpext_decode(&extv[i], mb);
 			if (err) {
-				warning("stream: rtpext_decode failed (%m)\n",
-					err);
+				warning("rtp_receiver: rtpext_decode failed "
+					"(%m)\n", err);
 				return 0;
 			}
 		}

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -159,10 +159,14 @@ static void rtprecv_check_stop(void *arg)
 {
 	struct rtp_receiver *rx = arg;
 
-	if (re_atomic_rlx(&rx->run))
+	if (re_atomic_rlx(&rx->run)) {
 		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
-	else
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
 		re_cancel();
+	}
 }
 
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -419,8 +419,12 @@ void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
 	(void)src;
 
 	MAGIC_CHECK(rx);
-
 	mtx_lock(rx->mtx);
+	if (!rx->enabled) {
+		mtx_unlock(rx->mtx);
+		return;
+	}
+
 	rx->ts_last = tmr_jiffies();
 	mtx_unlock(rx->mtx);
 
@@ -586,6 +590,7 @@ static void destructor(void *arg)
 	struct rtp_receiver *rx = arg;
 
 	if (re_atomic_rlx(&rx->run)) {
+		rtprecv_enable(rx, false);
 		re_atomic_rlx_set(&rx->run, false);
 		thrd_join(rx->thr, NULL);
 		re_thread_async_main_cancel((intptr_t)rx);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -681,16 +681,16 @@ int rtprecv_start_thread(struct rtp_receiver *rx)
 	if (re_atomic_rlx(&rx->run))
 		return 0;
 
+	udp_thread_detach(rtp_sock(rx->rtp));
+	udp_thread_detach(rtcp_sock(rx->rtp));
 	re_atomic_rlx_set(&rx->run, true);
 	err = thread_create_name(&rx->thr,
 				 "RX thread",
 				 rtprecv_thread, rx);
 	if (err) {
 		re_atomic_rlx_set(&rx->run, false);
-	}
-	else {
-		udp_thread_detach(rtp_sock(rx->rtp));
-		udp_thread_detach(rtcp_sock(rx->rtp));
+		udp_thread_attach(rtp_sock(rx->rtp));
+		udp_thread_attach(rtcp_sock(rx->rtp));
 	}
 
 	return err;

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -30,6 +30,7 @@ struct rtp_receiver {
 	uint32_t pseq;                 /**< Sequence number for incoming RTP */
 	bool pseq_set;                 /**< True if sequence number is set   */
 	bool rtp_estab;                /**< True if RTP stream established   */
+	RE_ATOMIC bool run;            /**< True if RX thread is running     */
 	mtx_t *mtx;                    /**< Mutex protects above fields      */
 
 	/* Unprotected data */
@@ -40,8 +41,153 @@ struct rtp_receiver {
 	stream_rtpestab_h *rtpestabh;  /**< RTP established handler          */
 	void *arg;                     /**< Stream argument                  */
 	void *sessarg;                 /**< Session argument                 */
+	thrd_t thr;                    /**< RX thread                        */
+	struct tmr tmr;                /**< Timer for stopping RX thread     */
 	int pt;                        /**< Previous payload type            */
 };
+
+
+enum work_type {
+	WORK_RTCP,
+	WORK_RTPESTAB,
+	WORK_PTCHANGED,
+	WORK_MNATCONNH,
+};
+
+
+struct work {
+	enum work_type type;
+	struct rtp_receiver *rx;
+	union {
+		struct rtcp_msg *rtcp;
+		struct {
+			uint8_t pt;
+			struct mbuf *mb;
+		} pt;
+		struct {
+			struct sa raddr1;
+			struct sa raddr2;
+		} mnat;
+	} u;
+};
+
+
+static void async_work_main(int err, void *arg);
+static void work_destructor(void *arg);
+
+
+/*
+ * functions that run in RX thread (if "rxmode thread" is configured)
+ */
+
+
+static void pass_rtcp_work(struct rtp_receiver *rx, struct rtcp_msg *msg)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		stream_process_rtcp(rx->strm, msg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	if (!w)
+		return;
+
+	w->type    = WORK_RTCP;
+	w->rx      = rx;
+	w->u.rtcp  = mem_ref(msg);
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static int pass_pt_work(struct rtp_receiver *rx, uint8_t pt, struct mbuf *mb)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run))
+		return rx->pth(pt, mb, rx->arg);
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type    = WORK_PTCHANGED;
+	w->rx      = rx;
+	w->u.pt.pt = pt;
+	w->u.pt.mb = mbuf_dup(mb);
+
+	return re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_rtpestab_work(struct rtp_receiver *rx)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		rx->rtpestabh(rx->strm, rx->sessarg);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_RTPESTAB;
+	w->rx   = rx;
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void pass_mnat_work(struct rtp_receiver *rx, const struct sa *raddr1,
+			   const struct sa *raddr2)
+{
+	struct work *w;
+
+	if (!re_atomic_rlx(&rx->run)) {
+		stream_mnat_connected(rx->strm, raddr1, raddr2);
+		return;
+	}
+
+	w = mem_zalloc(sizeof(*w), work_destructor);
+	w->type = WORK_MNATCONNH;
+	w->rx   = rx;
+	sa_cpy(&w->u.mnat.raddr1, raddr1);
+	sa_cpy(&w->u.mnat.raddr2, raddr2);
+
+	re_thread_async_main_id((intptr_t)rx, NULL, async_work_main, w);
+}
+
+
+static void rtprecv_check_stop(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+
+	if (re_atomic_rlx(&rx->run))
+		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+	else
+		re_cancel();
+}
+
+
+static int rtprecv_thread(void *arg)
+{
+	struct rtp_receiver *rx = arg;
+	int err;
+
+	re_thread_init();
+	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
+
+	err = udp_thread_attach(rtp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = udp_thread_attach(rtcp_sock(rx->rtp));
+	if (err)
+		return err;
+
+	err = re_main(NULL);
+
+	tmr_cancel(&rx->tmr);
+	re_thread_close();
+	return err;
+}
 
 
 static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
@@ -198,7 +344,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 			debug("stream: incoming rtp for '%s' established, "
 			      "receiving from %J\n", rx->name, src);
 			rx->rtp_estab = true;
-			rx->rtpestabh(rx->strm, rx->sessarg);
+			pass_rtpestab_work(rx);
 		}
 	}
 
@@ -227,7 +373,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 	if (hdr->pt != rx->pt) {
 		rx->pt = hdr->pt;
 
-		err = rx->pth(hdr->pt, mb, rx->arg);
+		err = pass_pt_work(rx, hdr->pt, mb);
 		if (err && err != ENODATA)
 			return;
 	}
@@ -274,7 +420,7 @@ void rtprecv_handle_rtcp(const struct sa *src, struct rtcp_msg *msg,
 	rx->ts_last = tmr_jiffies();
 	mtx_unlock(rx->mtx);
 
-	stream_process_rtcp(rx->strm, msg);
+	pass_rtcp_work(rx, msg);
 }
 
 
@@ -285,9 +431,13 @@ void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 
 	MAGIC_CHECK(rx);
 
-	stream_mnat_connected(rx->strm, raddr1, raddr2);
+	pass_mnat_work(rx, raddr1, raddr2);
 }
 
+
+/*
+ * functions that run in main thread
+ */
 
 void rtprecv_set_socket(struct rtp_receiver *rx, struct rtp_sock *rtp)
 {
@@ -427,6 +577,13 @@ static void destructor(void *arg)
 {
 	struct rtp_receiver *rx = arg;
 
+	if (re_atomic_rlx(&rx->run)) {
+		re_atomic_rlx_set(&rx->run, false);
+		thrd_join(rx->thr, NULL);
+	}
+
+	re_thread_async_main_cancel((intptr_t)rx);
+
 	mem_deref(rx->metric);
 	mem_deref(rx->name);
 	mem_deref(rx->mtx);
@@ -498,6 +655,41 @@ out:
 }
 
 
+int rtprecv_start_thread(struct rtp_receiver *rx)
+{
+	int err;
+
+	if (!rx)
+		return EINVAL;
+
+	if (re_atomic_rlx(&rx->run))
+		return 0;
+
+	re_atomic_rlx_set(&rx->run, true);
+	err = thread_create_name(&rx->thr,
+				 "RX thread",
+				 rtprecv_thread, rx);
+	if (err) {
+		re_atomic_rlx_set(&rx->run, false);
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
+	}
+
+	return err;
+}
+
+
+bool rtprecv_running(const struct rtp_receiver *rx)
+{
+	if (!rx)
+		return false;
+
+	return re_atomic_rlx(&rx->run);
+}
+
+
 void rtprecv_set_handlers(struct rtp_receiver *rx,
 			   stream_rtpestab_h *rtpestabh, void *arg)
 {
@@ -518,4 +710,50 @@ struct metric *rtprecv_metric(struct rtp_receiver *rx)
 
 	/* it is allowed to return metric because it is thread safe */
 	return rx->metric;
+}
+
+
+static void work_destructor(void *arg)
+{
+	struct work *w = arg;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			mem_deref(w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			mem_deref(w->u.pt.mb);
+			break;
+		default:
+			break;
+	}
+}
+
+
+static void async_work_main(int err, void *arg)
+{
+	struct work *w = arg;
+	struct rtp_receiver *rx = w->rx;
+	(void)err;
+
+	switch (w->type) {
+		case WORK_RTCP:
+			stream_process_rtcp(rx->strm, w->u.rtcp);
+			break;
+		case WORK_PTCHANGED:
+			rx->pth(w->u.pt.pt, w->u.pt.mb, rx->arg);
+			break;
+		case WORK_RTPESTAB:
+			rx->rtpestabh(rx->strm, rx->sessarg);
+			break;
+		case WORK_MNATCONNH:
+			stream_mnat_connected(rx->strm,
+					      &w->u.mnat.raddr1,
+					      &w->u.mnat.raddr2);
+			break;
+		default:
+			break;
+	}
+
+	mem_deref(w);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -248,7 +248,7 @@ int stream_enable_rx(struct stream *strm, bool enable)
 		debug("stream: disable %s RTP receiver\n",
 		      media_name(strm->type));
 
-		rtprecv_set_enable(strm->rx, false);
+		rtprecv_enable(strm->rx, false);
 		return 0;
 	}
 
@@ -256,7 +256,7 @@ int stream_enable_rx(struct stream *strm, bool enable)
 		return ENOTSUP;
 
 	debug("stream: enable %s RTP receiver\n", media_name(strm->type));
-	rtprecv_set_enable(strm->rx, true);
+	rtprecv_enable(strm->rx, true);
 
 	if (strm->rtp && strm->cfg.rxmode == RECEIVE_MODE_THREAD &&
 	    strm->type == MEDIA_AUDIO && !rtprecv_running(strm->rx)) {

--- a/test/call.c
+++ b/test/call.c
@@ -839,11 +839,12 @@ static void event_handler(struct ua *ua, enum ua_event ev,
 }
 
 
-int test_call_answer(void)
+static int test_call_answer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -869,6 +870,21 @@ int test_call_answer(void)
  out:
 	fixture_close(f);
 
+	return err;
+}
+
+
+int test_call_answer(void)
+{
+	int err;
+
+	err = test_call_answer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -905,11 +921,12 @@ int test_call_reject(void)
 }
 
 
-int test_call_answer_hangup_a(void)
+static int test_call_answer_hangup_a_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -939,12 +956,28 @@ int test_call_answer_hangup_a(void)
 }
 
 
-int test_call_answer_hangup_b(void)
+int test_call_answer_hangup_a(void)
+{
+	int err;
+
+	err = test_call_answer_hangup_a_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_hangup_a_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_answer_hangup_b_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	char uri[256];
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -977,13 +1010,29 @@ int test_call_answer_hangup_b(void)
 }
 
 
-int test_call_rtp_timeout(void)
+int test_call_answer_hangup_b(void)
+{
+	int err;
+
+	err = test_call_answer_hangup_b_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_answer_hangup_b_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_rtp_timeout_base(enum rtp_receive_mode rxmode)
 {
 #define RTP_TIMEOUT_MS 1
 	struct fixture fix, *f = &fix;
 	struct call *call;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -1018,6 +1067,21 @@ int test_call_rtp_timeout(void)
 }
 
 
+int test_call_rtp_timeout(void)
+{
+	int err;
+
+	err = test_call_rtp_timeout_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_rtp_timeout_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 /* veriy that line-numbers are in sequence */
 static bool linenum_are_sequential(const struct ua *ua)
 {
@@ -1037,13 +1101,14 @@ static bool linenum_are_sequential(const struct ua *ua)
 }
 
 
-int test_call_multiple(void)
+static int test_call_multiple_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct le *le;
 	unsigned i;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -1127,7 +1192,22 @@ int test_call_multiple(void)
 }
 
 
-int test_call_max(void)
+int test_call_multiple(void)
+{
+	int err;
+
+	err = test_call_multiple_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_multiple_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_max_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	unsigned i;
@@ -1137,6 +1217,7 @@ int test_call_max(void)
 	/* We start 2 calls from a.ua to b.ua. */
 	/* This are 2 outgoing calls and 1 incoming. */
 	conf_config()->call.max_calls = 3;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init(f);
 
@@ -1172,11 +1253,28 @@ int test_call_max(void)
 }
 
 
-int test_call_dtmf(void)
+int test_call_max(void)
+{
+	int err;
+
+	err = test_call_max_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_max_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_dtmf_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	size_t i, n = str_len(dtmf_digits);
 	int err = 0;
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	fixture_init_prm(f, ";ptime=1");
@@ -1218,6 +1316,21 @@ int test_call_dtmf(void)
 }
 
 
+int test_call_dtmf(void)
+{
+	int err;
+
+	err = test_call_dtmf_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_dtmf_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 static void mock_vidisp_handler(const struct vidframe *frame,
 				uint64_t timestamp, const char *title,
 				void *arg)
@@ -1251,7 +1364,7 @@ static void mock_vidisp_handler(const struct vidframe *frame,
 }
 
 
-int test_call_video(void)
+static int test_call_video_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1260,6 +1373,7 @@ int test_call_video(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CUSTOM, f->b.ua, 1, 0, 1);
@@ -1307,7 +1421,22 @@ int test_call_video(void)
 }
 
 
-int test_call_change_videodir(void)
+int test_call_video(void)
+{
+	int err;
+
+	err = test_call_video_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_video_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_change_videodir_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1317,6 +1446,7 @@ int test_call_change_videodir(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init_prm(f, ";answermode=early");
 	cr_prog = cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
@@ -1438,7 +1568,22 @@ int test_call_change_videodir(void)
 }
 
 
-int test_call_100rel_video(void)
+int test_call_change_videodir(void)
+{
+	int err;
+
+	err = test_call_change_videodir_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_change_videodir_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_100rel_video_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct vidisp *vidisp = NULL;
@@ -1447,6 +1592,7 @@ int test_call_100rel_video(void)
 
 	conf_config()->video.fps = 100;
 	conf_config()->video.enc_fmt = VID_FMT_YUV420P;
+	conf_config()->avt.rxmode = rxmode;
 
 	fixture_init_prm(f, ";100rel=yes;answermode=early");
 
@@ -1526,6 +1672,21 @@ int test_call_100rel_video(void)
 }
 
 
+int test_call_100rel_video(void)
+{
+	int err;
+
+	err = test_call_100rel_video_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_100rel_video_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
 static void auframe_handler(struct auframe *af, const char *dev, void *arg)
 {
 	struct fixture *fix = arg;
@@ -1567,12 +1728,14 @@ static void auframe_handler(struct auframe *af, const char *dev, void *arg)
 }
 
 
-int test_call_aulevel(void)
+static int test_call_aulevel_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	struct auplay *auplay = NULL;
 	int err = 0;
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	fixture_init_prm(f, ";ptime=1;audio_player=mock-auplay,a");
@@ -1619,7 +1782,8 @@ int test_call_aulevel(void)
 }
 
 
-static int test_100rel_audio_base(enum audio_mode txmode)
+static int test_100rel_audio_base(enum rtp_receive_mode rxmode,
+				  enum audio_mode txmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -1633,6 +1797,7 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 		       ";regint=0;ptime=1;audio_player=mock-auplay,b"
 		       ";answermode=early;100rel=yes");
 	TEST_ERR(err);
+	conf_config()->avt.rxmode = rxmode;
 	conf_config()->audio.txmode = txmode;
 
 	cancel_rule_new(UA_EVENT_CUSTOM, f->b.ua, 1, -1, 0);
@@ -1720,11 +1885,14 @@ int test_call_100rel_audio(void)
 {
 	int err;
 
-	err = test_100rel_audio_base(AUDIO_MODE_POLL);
-	ASSERT_EQ(0, err);
-
-	err = test_100rel_audio_base(AUDIO_MODE_THREAD);
-	ASSERT_EQ(0, err);
+	err = test_100rel_audio_base(RECEIVE_MODE_MAIN, AUDIO_MODE_POLL);
+	TEST_ERR(err);
+	err = test_100rel_audio_base(RECEIVE_MODE_MAIN, AUDIO_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_100rel_audio_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	TEST_ERR(err);
+	err = test_100rel_audio_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
+	TEST_ERR(err);
 
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;
 
@@ -1733,12 +1901,28 @@ int test_call_100rel_audio(void)
 }
 
 
-int test_call_progress(void)
+int test_call_aulevel(void)
+{
+	int err;
+
+	err = test_call_aulevel_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_aulevel_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_progress_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init_prm(f, ";answermode=early");
 	cancel_rule_new(UA_EVENT_CALL_PROGRESS, f->a.ua, 0, 1, 0);
 
@@ -1771,7 +1955,23 @@ int test_call_progress(void)
 }
 
 
-static int test_media_base(enum audio_mode txmode)
+int test_call_progress(void)
+{
+	int err;
+
+	err = test_call_progress_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_progress_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_media_base(enum rtp_receive_mode rxmode,
+			   enum audio_mode txmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -1779,6 +1979,7 @@ static int test_media_base(enum audio_mode txmode)
 	int err = 0;
 
 	fixture_init_prm(f, ";ptime=1;audio_player=mock-auplay,a");
+	conf_config()->avt.rxmode = rxmode;
 	mem_deref(f->b.ua);
 	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>"
 		       ";regint=0;ptime=1;audio_player=mock-auplay,b");
@@ -1843,10 +2044,16 @@ int test_call_format_float(void)
 {
 	int err;
 
-	err = test_media_base(AUDIO_MODE_POLL);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_POLL);
 	ASSERT_EQ(0, err);
 
-	err = test_media_base(AUDIO_MODE_THREAD);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_THREAD);
+	ASSERT_EQ(0, err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	ASSERT_EQ(0, err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	ASSERT_EQ(0, err);
 
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;
@@ -1856,7 +2063,7 @@ int test_call_format_float(void)
 }
 
 
-int test_call_mediaenc(void)
+static int test_call_mediaenc_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -1864,6 +2071,8 @@ int test_call_mediaenc(void)
 
 	err = module_load(".", "srtp");
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Enable a dummy media encryption protocol */
 	fixture_init_prm(f, ";mediaenc=srtp;ptime=1");
@@ -1917,13 +2126,29 @@ int test_call_mediaenc(void)
 }
 
 
-int test_call_medianat(void)
+int test_call_mediaenc(void)
+{
+	int err;
+
+	err = test_call_mediaenc_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_mediaenc_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_medianat_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err;
 
 	mock_mnat_register(baresip_mnatl());
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Enable a dummy media NAT-traversal protocol */
 	fixture_init_prm(f, ";medianat=XNAT;ptime=1");
@@ -1967,7 +2192,22 @@ int test_call_medianat(void)
 }
 
 
-int test_call_custom_headers(void)
+int test_call_medianat(void)
+{
+	int err;
+
+	err = test_call_medianat_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_medianat_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_custom_headers_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
@@ -1975,6 +2215,7 @@ int test_call_custom_headers(void)
 	struct list custom_hdrs;
 	bool headers_matched = true;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	ua_add_xhdr_filter(f->b.ua, "X-CALL_ID");
@@ -2045,11 +2286,27 @@ int test_call_custom_headers(void)
 }
 
 
-int test_call_tcp(void)
+int test_call_custom_headers(void)
+{
+	int err;
+
+	err = test_call_custom_headers_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_custom_headers_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_tcp_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -2069,6 +2326,21 @@ int test_call_tcp(void)
  out:
 	fixture_close(f);
 
+	return err;
+}
+
+
+int test_call_tcp(void)
+{
+	int err;
+
+	err = test_call_tcp_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_tcp_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -2125,11 +2397,12 @@ int test_call_deny_udp(void)
  *  Step 3. Call between B and C
  *          No call for A
  */
-int test_call_transfer(void)
+static int test_call_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	/* Create a 3rd useragent needed for transfer */
@@ -2175,11 +2448,27 @@ int test_call_transfer(void)
 }
 
 
-int test_call_transfer_fail(void)
+int test_call_transfer(void)
+{
+	int err;
+
+	err = test_call_transfer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_transfer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_transfer_fail_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	/* Create a 3rd useragent needed for transfer */
@@ -2230,11 +2519,27 @@ out:
 }
 
 
-int test_call_attended_transfer(void)
+int test_call_transfer_fail(void)
+{
+	int err;
+
+	err = test_call_transfer_fail_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_transfer_fail_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_attended_transfer_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	err = ua_alloc(&f->c.ua, "C <sip:c@127.0.0.1>;regint=0");
@@ -2281,7 +2586,22 @@ out:
 }
 
 
-static int test_call_rtcp_base(bool rtcp_mux)
+int test_call_attended_transfer(void)
+{
+	int err;
+
+	err = test_call_attended_transfer_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_attended_transfer_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_rtcp_base(enum rtp_receive_mode rxmode, bool rtcp_mux)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
@@ -2289,6 +2609,8 @@ static int test_call_rtcp_base(bool rtcp_mux)
 
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = rxmode;
 
 	/* Use a low packet time, so the test completes quickly */
 	if (rtcp_mux) {
@@ -2339,11 +2661,21 @@ static int test_call_rtcp_base(bool rtcp_mux)
 
 int test_call_rtcp(void)
 {
-	int err = 0;
+	int err;
 
-	err |= test_call_rtcp_base(false);
-	err |= test_call_rtcp_base(true);
+	err = test_call_rtcp_base(RECEIVE_MODE_MAIN, false);
+	TEST_ERR(err);
 
+	err = test_call_rtcp_base(RECEIVE_MODE_MAIN, true);
+	TEST_ERR(err);
+
+	err = test_call_rtcp_base(RECEIVE_MODE_THREAD, false);
+	TEST_ERR(err);
+
+	err = test_call_rtcp_base(RECEIVE_MODE_THREAD, true);
+	TEST_ERR(err);
+
+out:
 	return err;
 }
 
@@ -2355,8 +2687,11 @@ int test_call_aufilt(void)
 	err = module_load(".", "auconv");
 	TEST_ERR(err);
 
-	err = test_media_base(AUDIO_MODE_POLL);
-	ASSERT_EQ(0, err);
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_POLL);
+	TEST_ERR(err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
+	TEST_ERR(err);
 
  out:
 	module_unload("auconv");
@@ -2368,7 +2703,7 @@ int test_call_aufilt(void)
 /*
  * Simulate a complete WebRTC testcase
  */
-int test_call_webrtc(void)
+static int test_call_webrtc_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2376,6 +2711,7 @@ int test_call_webrtc(void)
 	int err;
 
 	conf_config()->avt.rtcp_mux = true;
+	conf_config()->avt.rxmode = rxmode;
 
 	mock_mnat_register(baresip_mnatl());
 
@@ -2459,7 +2795,23 @@ int test_call_webrtc(void)
 }
 
 
-static int test_call_bundle_base(bool use_mnat, bool use_menc)
+int test_call_webrtc(void)
+{
+	int err;
+
+	err = test_call_webrtc_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_webrtc_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_bundle_base(bool use_mnat, bool use_menc,
+				 enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2474,6 +2826,7 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
 	conf_config()->avt.bundle = true;
 	conf_config()->avt.rtcp_mux = true;  /* MUST enable RTP/RTCP mux */
 	conf_config()->video.fps = 100;
+	conf_config()->avt.rxmode = rxmode;
 
 	if (use_mnat) {
 		mock_mnat_register(baresip_mnatl());
@@ -2617,13 +2970,26 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc)
  */
 int test_call_bundle(void)
 {
-	int err = 0;
+	int err;
 
-	err |= test_call_bundle_base(false, false);
-	err |= test_call_bundle_base(true,  false);
-	err |= test_call_bundle_base(false, true);
-	err |= test_call_bundle_base(true,  true);
+	err = test_call_bundle_base(false, false, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  false, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, true, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  true, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, false, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  false, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(false, true, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+	err = test_call_bundle_base(true,  true, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
 
+out:
 	return err;
 }
 
@@ -2642,7 +3008,7 @@ static bool find_ipv6ll(const char *ifname, const struct sa *sa, void *arg)
 }
 
 
-int test_call_ipv6ll(void)
+static int test_call_ipv6ll_base(enum rtp_receive_mode rxmode)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2661,6 +3027,7 @@ int test_call_ipv6ll(void)
 	err = module_load(".", "ausine");
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 
 	f->behaviour = BEHAVIOUR_ANSWER;
@@ -2714,13 +3081,28 @@ int test_call_ipv6ll(void)
 }
 
 
-static int test_call_hold_resume_base(bool tcp)
+int test_call_ipv6ll(void)
+{
+	int err;
+
+	err = test_call_ipv6ll_base(RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_ipv6ll_base(RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+out:
+	return err;
+}
+
+
+static int test_call_hold_resume_base(bool tcp, enum rtp_receive_mode rxmode)
 {
 	struct fixture fix, *f = &fix;
 	struct cancel_rule *cr;
 	int err = 0;
 
-
+	conf_config()->avt.rxmode = rxmode;
 	fixture_init(f);
 	cancel_rule_new(UA_EVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
 	cr->n_audio_estab = 1;
@@ -2817,10 +3199,16 @@ int test_call_hold_resume(void)
 {
 	int err;
 
-	err = test_call_hold_resume_base(false);
+	err = test_call_hold_resume_base(false, RECEIVE_MODE_MAIN);
 	TEST_ERR(err);
 
-	err = test_call_hold_resume_base(true);
+	err = test_call_hold_resume_base(true, RECEIVE_MODE_MAIN);
+	TEST_ERR(err);
+
+	err = test_call_hold_resume_base(false, RECEIVE_MODE_THREAD);
+	TEST_ERR(err);
+
+	err = test_call_hold_resume_base(true, RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
 out:

--- a/test/call.c
+++ b/test/call.c
@@ -2051,6 +2051,9 @@ static int test_media_base(enum rtp_receive_mode rxmode,
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	if (err)
+		failure_debug(f, false);
+
 	conf_config()->audio.src_fmt = AUFMT_S16LE;
 	conf_config()->audio.play_fmt = AUFMT_S16LE;
 

--- a/test/call.c
+++ b/test/call.c
@@ -2863,8 +2863,7 @@ out:
 }
 
 
-static int test_call_bundle_base(bool use_mnat, bool use_menc,
-				 enum rtp_receive_mode rxmode)
+static int test_call_bundle_base(bool use_mnat, bool use_menc)
 {
 	struct fixture fix = {0}, *f = &fix;
 	struct cancel_rule *cr;
@@ -2879,7 +2878,6 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc,
 	conf_config()->avt.bundle = true;
 	conf_config()->avt.rtcp_mux = true;  /* MUST enable RTP/RTCP mux */
 	conf_config()->video.fps = 100;
-	conf_config()->avt.rxmode = rxmode;
 
 	if (use_mnat) {
 		mock_mnat_register(baresip_mnatl());
@@ -3023,28 +3021,13 @@ static int test_call_bundle_base(bool use_mnat, bool use_menc,
  */
 int test_call_bundle(void)
 {
-	int err;
+	int err = 0;
 
-	err = test_call_bundle_base(false, false, RECEIVE_MODE_MAIN);
-	TEST_ERR(err);
-	err = test_call_bundle_base(true,  false, RECEIVE_MODE_MAIN);
-	TEST_ERR(err);
-	err = test_call_bundle_base(false, true, RECEIVE_MODE_MAIN);
-	TEST_ERR(err);
-	err = test_call_bundle_base(true,  true, RECEIVE_MODE_MAIN);
-	TEST_ERR(err);
-	err = test_call_bundle_base(false, false, RECEIVE_MODE_THREAD);
-	TEST_ERR(err);
-	err = test_call_bundle_base(true,  false, RECEIVE_MODE_THREAD);
-	TEST_ERR(err);
-	err = test_call_bundle_base(false, true, RECEIVE_MODE_THREAD);
-	TEST_ERR(err);
-	err = test_call_bundle_base(true,  true, RECEIVE_MODE_THREAD);
-	TEST_ERR(err);
+	err |= test_call_bundle_base(false, false);
+	err |= test_call_bundle_base(true,  false);
+	err |= test_call_bundle_base(false, true);
+	err |= test_call_bundle_base(true,  true);
 
-	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
-
-out:
 	return err;
 }
 

--- a/test/call.c
+++ b/test/call.c
@@ -2693,6 +2693,12 @@ int test_call_aufilt(void)
 	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_POLL);
 	TEST_ERR(err);
 
+	err = test_media_base(RECEIVE_MODE_MAIN, AUDIO_MODE_THREAD);
+	TEST_ERR(err);
+
+	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
+	TEST_ERR(err);
+
  out:
 	module_unload("auconv");
 

--- a/test/call.c
+++ b/test/call.c
@@ -884,6 +884,8 @@ int test_call_answer(void)
 	err = test_call_answer_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -966,6 +968,8 @@ int test_call_answer_hangup_a(void)
 	err = test_call_answer_hangup_a_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -1019,6 +1023,8 @@ int test_call_answer_hangup_b(void)
 
 	err = test_call_answer_hangup_b_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1076,6 +1082,8 @@ int test_call_rtp_timeout(void)
 
 	err = test_call_rtp_timeout_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1202,6 +1210,8 @@ int test_call_multiple(void)
 	err = test_call_multiple_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -1262,6 +1272,8 @@ int test_call_max(void)
 
 	err = test_call_max_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1325,6 +1337,8 @@ int test_call_dtmf(void)
 
 	err = test_call_dtmf_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1430,6 +1444,8 @@ int test_call_video(void)
 
 	err = test_call_video_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1578,6 +1594,8 @@ int test_call_change_videodir(void)
 	err = test_call_change_videodir_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -1681,6 +1699,8 @@ int test_call_100rel_video(void)
 
 	err = test_call_100rel_video_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1894,6 +1914,7 @@ int test_call_100rel_audio(void)
 	err = test_100rel_audio_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;
 
  out:
@@ -1910,6 +1931,8 @@ int test_call_aulevel(void)
 
 	err = test_call_aulevel_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -1964,6 +1987,8 @@ int test_call_progress(void)
 
 	err = test_call_progress_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -2056,6 +2081,7 @@ int test_call_format_float(void)
 	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	ASSERT_EQ(0, err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;
 
  out:
@@ -2136,6 +2162,8 @@ int test_call_mediaenc(void)
 	err = test_call_mediaenc_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -2201,6 +2229,8 @@ int test_call_medianat(void)
 
 	err = test_call_medianat_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -2296,6 +2326,8 @@ int test_call_custom_headers(void)
 	err = test_call_custom_headers_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -2339,6 +2371,8 @@ int test_call_tcp(void)
 
 	err = test_call_tcp_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -2458,6 +2492,8 @@ int test_call_transfer(void)
 	err = test_call_transfer_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -2529,6 +2565,8 @@ int test_call_transfer_fail(void)
 	err = test_call_transfer_fail_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -2595,6 +2633,8 @@ int test_call_attended_transfer(void)
 
 	err = test_call_attended_transfer_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -2675,6 +2715,8 @@ int test_call_rtcp(void)
 	err = test_call_rtcp_base(RECEIVE_MODE_THREAD, true);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -2698,6 +2740,9 @@ int test_call_aufilt(void)
 
 	err = test_media_base(RECEIVE_MODE_THREAD, AUDIO_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+	conf_config()->audio.txmode = AUDIO_MODE_POLL;
 
  out:
 	module_unload("auconv");
@@ -2810,6 +2855,8 @@ int test_call_webrtc(void)
 
 	err = test_call_webrtc_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;
@@ -2995,6 +3042,8 @@ int test_call_bundle(void)
 	err = test_call_bundle_base(true,  true, RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
 
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
+
 out:
 	return err;
 }
@@ -3096,6 +3145,8 @@ int test_call_ipv6ll(void)
 
 	err = test_call_ipv6ll_base(RECEIVE_MODE_THREAD);
 	TEST_ERR(err);
+
+	conf_config()->avt.rxmode = RECEIVE_MODE_MAIN;
 
 out:
 	return err;

--- a/test/main.c
+++ b/test/main.c
@@ -10,6 +10,7 @@
 #include <baresip.h>
 #include "test.h"
 
+enum { ASYNC_WORKERS = 4 };
 
 typedef int (test_exec_h)(void);
 
@@ -192,6 +193,7 @@ int main(int argc, char *argv[])
 		return err;
 
 	log_enable_info(false);
+	re_thread_async_init(ASYNC_WORKERS);
 
 #ifdef HAVE_GETOPT
 	for (;;) {


### PR DESCRIPTION
- stream,rtprecv: activate RX thread via config
- test: run call tests with RX_MODE_THREAD
- test: main - init async workers
- rtprecv: detach from RTP/RTCP sockets before re_cancel
- stream,rtprecv: detach from RTP/RTCP also in RECEIVE_MODE_MAIN
- test: call - add AUDIO_MODE_THREAD for test_call_aufilt
- test: call - reset to RECEIVE_MODE_MAIN
- rtprecv: use enable flag to prevent data race on stream termination
- test: call - do not test unsupported combination

replaces: https://github.com/baresip/baresip/pull/2777
