### PR TITLE
rx thread: refactoring part 2 - separate audio receiver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(SRCS
   src/audio.c
   src/aufilt.c
   src/auplay.c
+  src/aureceiver.c
   src/ausrc.c
   src/baresip.c
   src/bundle.c

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1190,7 +1190,6 @@ void aucodec_unregister(struct aucodec *ac);
 const struct aucodec *aucodec_find(const struct list *aucodecl,
 				   const char *name, uint32_t srate,
 				   uint8_t ch);
-int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1190,6 +1190,7 @@ void aucodec_unregister(struct aucodec *ac);
 const struct aucodec *aucodec_find(const struct list *aucodecl,
 				   const char *name, uint32_t srate,
 				   uint8_t ch);
+int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*

--- a/src/audio.c
+++ b/src/audio.c
@@ -224,6 +224,7 @@ static void audio_destructor(void *arg)
 
 	debug("audio: destroyed (started=%d)\n", a->started);
 
+	stream_enable(a->strm, false);
 	stop_tx(&a->tx, a);
 	stop_rx(&a->rx);
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -127,12 +127,12 @@ struct aurx {
 	int pt;                       /**< Payload type for incoming RTP   */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
 
-	struct aurpipe *aup;          /**< Audio receive pipeline          */
+	struct audio_recv *aup;       /**< Audio receive pipeline          */
 	bool first_write;             /**< First write to auplay           */
 };
 
 
-struct aurpipe;
+struct audio_recv;
 
 
 /** Generic Audio stream */
@@ -536,14 +536,14 @@ static void check_plframe(struct auframe *af1, struct auframe *af2)
 {
 	if ((af1->srate && af1->srate != af2->srate) ||
 	    (af1->ch    && af1->ch    != af2->ch   )) {
-		warning("aurpipe: srate/ch of frame %u/%u vs "
+		warning("audio_recv: srate/ch of frame %u/%u vs "
 			"player %u/%u. Use module auresamp!\n",
 			af1->srate, af1->ch,
 			af2->srate, af2->ch);
 	}
 
 	if (af1->fmt != af2->fmt) {
-		warning("aurpipe: invalid sample formats (%s -> %s). "
+		warning("audio_recv: invalid sample formats (%s -> %s). "
 			"%s\n",
 			aufmt_name(af1->fmt), aufmt_name(af2->fmt),
 			af1->fmt == AUFMT_S16LE ?
@@ -1762,7 +1762,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	const struct aurpipe *aup;
+	const struct audio_recv *aup;
 	size_t sztx;
 	int err;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -569,9 +569,6 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	struct auframe afr;
 	struct aurx *rx = &a->rx;
 
-	if (!rx->auplay)
-		return;
-
 	if (!rx->first_write)
 		afr = *af;
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -127,7 +127,7 @@ struct aurx {
 	int pt;                       /**< Payload type for incoming RTP   */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
 
-	struct audio_recv *aup;       /**< Audio receive pipeline          */
+	struct audio_recv *aur;       /**< Audio receive pipeline          */
 	bool first_write;             /**< First write to auplay           */
 };
 
@@ -171,7 +171,7 @@ uint64_t audio_jb_current_value(const struct audio *au)
 	if (!au)
 		return 0;
 
-	return aur_latency(au->rx.aup);
+	return aur_latency(au->rx.aur);
 }
 
 
@@ -214,7 +214,7 @@ static void stop_rx(struct aurx *rx)
 
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
-	aur_stop(rx->aup);
+	aur_stop(rx->aur);
 }
 
 
@@ -241,7 +241,7 @@ static void audio_destructor(void *arg)
 
 	mem_deref(a->strm);
 	mem_deref(a->telev);
-	mem_deref(a->rx.aup);
+	mem_deref(a->rx.aur);
 
 	mem_deref(a->tx.mtx);
 }
@@ -573,7 +573,7 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	if (!rx->first_write)
 		afr = *af;
 
-	aur_read(rx->aup, af);
+	aur_read(rx->aur, af);
 
 	if (!rx->first_write) {
 		(void)check_plframe(&afr, af);
@@ -707,10 +707,10 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 
 	MAGIC_CHECK(a);
 
-	if (!a->rx.aup)
+	if (!a->rx.aur)
 		return;
 
-	aur_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
+	aur_receive(a->rx.aur, hdr, extv, extc, mb, lostc, ignore);
 }
 
 
@@ -734,7 +734,7 @@ static int add_telev_codec(struct audio *a)
 		return err;
 
 	if (add)
-		aur_set_telev_pt(a->rx.aup, pt);
+		aur_set_telev_pt(a->rx.aur, pt);
 
 	return 0;
 }
@@ -812,7 +812,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ, ptime);
+	err = aur_alloc(&a->rx.aur, &a->cfg, AUDIO_SAMPSZ, ptime);
 	if (err)
 		goto out;
 
@@ -845,7 +845,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (cfg->audio.level && offerer) {
 
 		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
-		aur_set_extmap(a->rx.aup, a->extmap_aulevel);
+		aur_set_extmap(a->rx.aur, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 					  "extmap",
@@ -1059,14 +1059,14 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 	int err = 0;
 
 	/* wait until we have both Encoder and Decoder */
-	if (!tx->ac || !aur_codec(rx->aup))
+	if (!tx->ac || !aur_codec(rx->aur))
 		return 0;
 
-	update_dec = aur_filt_empty(rx->aup);
+	update_dec = aur_filt_empty(rx->aur);
 	update_enc = list_isempty(&tx->filtl);
 
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&plprm, aur_codec(rx->aup), a->cfg.play_fmt);
+	aufilt_param_set(&plprm, aur_codec(rx->aur), a->cfg.play_fmt);
 	if (a->cfg.srate_play && a->cfg.srate_play != plprm.srate) {
 		plprm.srate = a->cfg.srate_play;
 	}
@@ -1102,7 +1102,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			}
 			else {
 				decst->af = af;
-				aur_filt_append(rx->aup, decst);
+				aur_filt_append(rx->aur, decst);
 			}
 		}
 
@@ -1120,7 +1120,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
-	const struct aucodec *ac = aur_codec(rx->aup);
+	const struct aucodec *ac = aur_codec(rx->aur);
 	uint32_t srate_dsp;
 	uint32_t channels_dsp;
 	int err = 0;
@@ -1286,7 +1286,7 @@ static void audio_flush_filters(struct audio *a)
 	struct aurx *rx = &a->rx;
 	struct autx *tx = &a->tx;
 
-	aur_flush(rx->aup);
+	aur_flush(rx->aur);
 
 	mtx_lock(a->tx.mtx);
 	list_flush(&tx->filtl);
@@ -1333,13 +1333,13 @@ int audio_start(struct audio *a)
 		return err;
 	}
 
-	if (a->tx.ac && aur_codec(a->rx.aup)) {
+	if (a->tx.ac && aur_codec(a->rx.aur)) {
 
 		if (!a->started) {
 			info("%H\n%H%H",
 			     autx_print_pipeline, &a->tx,
 			     aurx_print_pipeline, &a->rx,
-			     aur_print_pipeline, a->rx.aup);
+			     aur_print_pipeline, a->rx.aur);
 		}
 
 		a->started = true;
@@ -1512,12 +1512,12 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 	rx = &a->rx;
 	rx->pt = pt_rx;
 
-	if (ac != aur_codec(rx->aup)) {
+	if (ac != aur_codec(rx->aur)) {
 		struct sdp_media *m;
 		bool reset;
 
 		m = stream_sdpmedia(audio_strm(a));
-		reset  = !aucodec_equal(ac, aur_codec(rx->aup));
+		reset  = !aucodec_equal(ac, aur_codec(rx->aur));
 		reset |= !(sdp_media_dir(m) & SDP_RECVONLY);
 		if (reset) {
 			rx->auplay = mem_deref(rx->auplay);
@@ -1526,7 +1526,7 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		}
 	}
 
-	err = aur_decoder_set(rx->aup, ac, params);
+	err = aur_decoder_set(rx->aur, ac, params);
 	if (err)
 		return err;
 
@@ -1643,7 +1643,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		}
 
 		au->extmap_aulevel = extmap.id;
-		aur_set_extmap(au->rx.aup, au->extmap_aulevel);
+		aur_set_extmap(au->rx.aur, au->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
@@ -1740,11 +1740,11 @@ int audio_level_get(const struct audio *au, double *levelp)
 	if (!au->level_enabled)
 		return ENOTSUP;
 
-	if (!aur_level_set(au->rx.aup))
+	if (!aur_level_set(au->rx.aur))
 		return ENOENT;
 
 	if (levelp)
-		*levelp = aur_level(au->rx.aup);
+		*levelp = aur_level(au->rx.aur);
 
 	return 0;
 }
@@ -1762,7 +1762,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	const struct audio_recv *aup;
+	const struct audio_recv *aur;
 	size_t sztx;
 	int err;
 
@@ -1771,7 +1771,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	tx = &a->tx;
 	rx = &a->rx;
-	aup = a->rx.aup;
+	aur = a->rx.aur;
 
 	sztx = aufmt_sample_size(tx->src_fmt);
 
@@ -1799,7 +1799,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
 			  autx_calc_seconds(tx));
 
-	err |= aur_debug(pf, aup);
+	err |= aur_debug(pf, aur);
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,
@@ -1810,7 +1810,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 			  " %H%H",
 			  autx_print_pipeline, tx,
 			  aurx_print_pipeline, rx,
-			  aur_print_pipeline, aup);
+			  aur_print_pipeline, aur);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -1982,10 +1982,10 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
  */
 bool audio_rxaubuf_started(const struct audio *au)
 {
-	if (!au || !au->rx.aup)
+	if (!au || !au->rx.aur)
 		return false;
 
-	return aur_started(au->rx.aup);
+	return aur_started(au->rx.aur);
 }
 
 
@@ -2049,7 +2049,7 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 	if (!au)
 		return NULL;
 
-	return tx ? au->tx.ac : aur_codec(au->rx.aup);
+	return tx ? au->tx.ac : aur_codec(au->rx.aur);
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -171,7 +171,7 @@ uint64_t audio_jb_current_value(const struct audio *au)
 	if (!au)
 		return 0;
 
-	return aup_latency(au->rx.aup);
+	return aur_latency(au->rx.aup);
 }
 
 
@@ -214,7 +214,7 @@ static void stop_rx(struct aurx *rx)
 
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
-	aup_stop(rx->aup);
+	aur_stop(rx->aup);
 }
 
 
@@ -573,7 +573,7 @@ static void auplay_write_handler(struct auframe *af, void *arg)
 	if (!rx->first_write)
 		afr = *af;
 
-	aup_read(rx->aup, af);
+	aur_read(rx->aup, af);
 
 	if (!rx->first_write) {
 		(void)check_plframe(&afr, af);
@@ -710,7 +710,7 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	if (!a->rx.aup)
 		return;
 
-	aup_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
+	aur_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
 }
 
 
@@ -734,7 +734,7 @@ static int add_telev_codec(struct audio *a)
 		return err;
 
 	if (add)
-		aup_set_telev_pt(a->rx.aup, pt);
+		aur_set_telev_pt(a->rx.aup, pt);
 
 	return 0;
 }
@@ -812,7 +812,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = aup_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
+	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
 	if (err)
 		goto out;
 
@@ -845,7 +845,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (cfg->audio.level && offerer) {
 
 		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
-		aup_set_extmap(a->rx.aup, a->extmap_aulevel);
+		aur_set_extmap(a->rx.aup, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 					  "extmap",
@@ -1059,14 +1059,14 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 	int err = 0;
 
 	/* wait until we have both Encoder and Decoder */
-	if (!tx->ac || !aup_codec(rx->aup))
+	if (!tx->ac || !aur_codec(rx->aup))
 		return 0;
 
-	update_dec = aup_filt_empty(rx->aup);
+	update_dec = aur_filt_empty(rx->aup);
 	update_enc = list_isempty(&tx->filtl);
 
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&plprm, aup_codec(rx->aup), a->cfg.play_fmt);
+	aufilt_param_set(&plprm, aur_codec(rx->aup), a->cfg.play_fmt);
 	if (a->cfg.srate_play && a->cfg.srate_play != plprm.srate) {
 		plprm.srate = a->cfg.srate_play;
 	}
@@ -1102,7 +1102,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			}
 			else {
 				decst->af = af;
-				aup_filt_append(rx->aup, decst);
+				aur_filt_append(rx->aup, decst);
 			}
 		}
 
@@ -1120,7 +1120,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
-	const struct aucodec *ac = aup_codec(rx->aup);
+	const struct aucodec *ac = aur_codec(rx->aup);
 	uint32_t srate_dsp;
 	uint32_t channels_dsp;
 	int err = 0;
@@ -1286,7 +1286,7 @@ static void audio_flush_filters(struct audio *a)
 	struct aurx *rx = &a->rx;
 	struct autx *tx = &a->tx;
 
-	aup_flush(rx->aup);
+	aur_flush(rx->aup);
 
 	mtx_lock(a->tx.mtx);
 	list_flush(&tx->filtl);
@@ -1333,13 +1333,13 @@ int audio_start(struct audio *a)
 		return err;
 	}
 
-	if (a->tx.ac && aup_codec(a->rx.aup)) {
+	if (a->tx.ac && aur_codec(a->rx.aup)) {
 
 		if (!a->started) {
 			info("%H\n%H%H",
 			     autx_print_pipeline, &a->tx,
 			     aurx_print_pipeline, &a->rx,
-			     aup_print_pipeline, a->rx.aup);
+			     aur_print_pipeline, a->rx.aup);
 		}
 
 		a->started = true;
@@ -1512,12 +1512,12 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 	rx = &a->rx;
 	rx->pt = pt_rx;
 
-	if (ac != aup_codec(rx->aup)) {
+	if (ac != aur_codec(rx->aup)) {
 		struct sdp_media *m;
 		bool reset;
 
 		m = stream_sdpmedia(audio_strm(a));
-		reset  = !aucodec_equal(ac, aup_codec(rx->aup));
+		reset  = !aucodec_equal(ac, aur_codec(rx->aup));
 		reset |= !(sdp_media_dir(m) & SDP_RECVONLY);
 		if (reset) {
 			rx->auplay = mem_deref(rx->auplay);
@@ -1526,7 +1526,7 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		}
 	}
 
-	err = aup_decoder_set(rx->aup, ac, params);
+	err = aur_decoder_set(rx->aup, ac, params);
 	if (err)
 		return err;
 
@@ -1643,7 +1643,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		}
 
 		au->extmap_aulevel = extmap.id;
-		aup_set_extmap(au->rx.aup, au->extmap_aulevel);
+		aur_set_extmap(au->rx.aup, au->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
@@ -1740,11 +1740,11 @@ int audio_level_get(const struct audio *au, double *levelp)
 	if (!au->level_enabled)
 		return ENOTSUP;
 
-	if (!aup_level_set(au->rx.aup))
+	if (!aur_level_set(au->rx.aup))
 		return ENOENT;
 
 	if (levelp)
-		*levelp = aup_level(au->rx.aup);
+		*levelp = aur_level(au->rx.aup);
 
 	return 0;
 }
@@ -1799,7 +1799,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
 			  autx_calc_seconds(tx));
 
-	err |= aup_debug(pf, aup);
+	err |= aur_debug(pf, aup);
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,
@@ -1810,7 +1810,7 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 			  " %H%H",
 			  autx_print_pipeline, tx,
 			  aurx_print_pipeline, rx,
-			  aup_print_pipeline, aup);
+			  aur_print_pipeline, aup);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -1985,7 +1985,7 @@ bool audio_rxaubuf_started(const struct audio *au)
 	if (!au || !au->rx.aup)
 		return false;
 
-	return aup_started(au->rx.aup);
+	return aur_started(au->rx.aup);
 }
 
 
@@ -2049,7 +2049,7 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 	if (!au)
 		return NULL;
 
-	return tx ? au->tx.ac : aup_codec(au->rx.aup);
+	return tx ? au->tx.ac : aur_codec(au->rx.aup);
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -117,61 +117,29 @@ struct autx {
 };
 
 
-/**
- * Audio receive/decoder
- *
- \verbatim
-
- Processing decoder pipeline:
-
-       .--------.   .-------.   .--------.   .--------.
- |\    |        |   |       |   |        |   |        |
- | |<--| auplay |<--| aubuf |<--| aufilt |<--| decode |<--- RTP
- |/    |        |   |       |   |        |   |        |
-       '--------'   '-------'   '--------'   '--------'
-
- \endverbatim
- */
 struct aurx {
 	const struct auplay *ap;      /**< Audio Player module             */
 	struct auplay_st *auplay;     /**< Audio Player                    */
 	struct auplay_prm auplay_prm; /**< Audio Player parameters         */
-	const struct aucodec *ac;     /**< Current audio decoder           */
-	struct audec_state *dec;      /**< Audio decoder state (optional)  */
-	struct aubuf *aubuf;          /**< Audio buffer before auplay      */
-	uint32_t ssrc;                /**< Incoming synchronization source */
-	size_t aubuf_minsz;           /**< Minimum aubuf size in [bytes]   */
-	size_t aubuf_maxsz;           /**< Maximum aubuf size in [bytes]   */
-	size_t num_bytes;             /**< Size of one frame in [bytes]    */
-	volatile bool aubuf_started;  /**< Aubuf was started flag          */
-	struct list filtl;            /**< Audio filters in decoding order */
 	char *module;                 /**< Audio player module name        */
 	char *device;                 /**< Audio player device name        */
-	void *sampv;                  /**< Sample buffer                   */
 	uint32_t ptime;               /**< Packet time for receiving       */
 	int pt;                       /**< Payload type for incoming RTP   */
-	double level_last;            /**< Last audio level value [dBov]   */
-	bool level_set;               /**< True if level_last is set       */
 	enum aufmt play_fmt;          /**< Sample format for audio playback*/
-	enum aufmt dec_fmt;           /**< Sample format for decoder       */
-	struct timestamp_recv ts_recv;/**< Receive timestamp state         */
 
-	struct {
-		uint64_t aubuf_overrun;
-		uint64_t aubuf_underrun;
-		uint64_t n_discard;
-	} stats;
-
-	mtx_t *mtx;
-
+	struct aurpipe *aup;          /**< Audio receive pipeline          */
+	bool first_write;             /**< First write to auplay           */
 };
+
+
+struct aurpipe;
 
 
 /** Generic Audio stream */
 struct audio {
 	MAGIC_DECL                    /**< Magic number for debugging      */
 	struct autx tx;               /**< Transmit                        */
-	struct aurx rx;               /**< Receive                         */
+	struct aurx rx;               /**< Audio Receiver                  */
 	struct stream *strm;          /**< Generic media stream            */
 	struct telev *telev;          /**< Telephony events                */
 	struct config_audio cfg;      /**< Audio configuration             */
@@ -200,29 +168,10 @@ static const char *uri_aulevel = "urn:ietf:params:rtp-hdrext:ssrc-audio-level";
  */
 uint64_t audio_jb_current_value(const struct audio *au)
 {
-	const struct aurx *rx;
-
 	if (!au)
 		return 0;
 
-	rx = &au->rx;
-
-	if (rx->aubuf) {
-		uint64_t b_p_ms;  /* bytes per ms */
-
-		b_p_ms = aufmt_sample_size(rx->play_fmt) *
-			rx->auplay_prm.srate * rx->auplay_prm.ch / 1000;
-
-		if (b_p_ms) {
-			uint64_t val;
-
-			val = aubuf_cur_size(rx->aubuf) / b_p_ms;
-
-			return val;
-		}
-	}
-
-	return 0;
+	return aup_latency(au->rx.aup);
 }
 
 
@@ -236,19 +185,6 @@ static double autx_calc_seconds(const struct autx *autx)
 	dur = autx->ts_ext - autx->ts_base;
 
 	return timestamp_calc_seconds(dur, autx->ac->crate);
-}
-
-
-static double aurx_calc_seconds(const struct aurx *aurx)
-{
-	uint64_t dur;
-
-	if (!aurx->ac)
-		return .0;
-
-	dur = timestamp_duration(&aurx->ts_recv);
-
-	return timestamp_calc_seconds(dur, aurx->ac->crate);
 }
 
 
@@ -278,13 +214,7 @@ static void stop_rx(struct aurx *rx)
 
 	/* audio player must be stopped first */
 	rx->auplay = mem_deref(rx->auplay);
-	rx->aubuf  = mem_deref(rx->aubuf);
-	if (rx->mtx)
-		mtx_lock(rx->mtx);
-
-	list_flush(&rx->filtl);
-	if (rx->mtx)
-		mtx_unlock(rx->mtx);
+	aup_stop(rx->aup);
 }
 
 
@@ -298,12 +228,9 @@ static void audio_destructor(void *arg)
 	stop_rx(&a->rx);
 
 	mem_deref(a->tx.enc);
-	mem_deref(a->rx.dec);
 	mem_deref(a->tx.aubuf);
 	mem_deref(a->tx.mb);
 	mem_deref(a->tx.sampv);
-	mem_deref(a->rx.sampv);
-	mem_deref(a->rx.aubuf);
 	mem_deref(a->tx.module);
 	mem_deref(a->tx.device);
 	mem_deref(a->rx.module);
@@ -313,9 +240,9 @@ static void audio_destructor(void *arg)
 
 	mem_deref(a->strm);
 	mem_deref(a->telev);
+	mem_deref(a->rx.aup);
 
 	mem_deref(a->tx.mtx);
-	mem_deref(a->rx.mtx);
 }
 
 
@@ -604,9 +531,28 @@ bool audio_txtelev_empty(const struct audio *au)
 }
 
 
+static void check_plframe(struct auframe *af1, struct auframe *af2)
+{
+	if ((af1->srate && af1->srate != af2->srate) ||
+	    (af1->ch    && af1->ch    != af2->ch   )) {
+		warning("aurpipe: srate/ch of frame %u/%u vs "
+			"player %u/%u. Use module auresamp!\n",
+			af1->srate, af1->ch,
+			af2->srate, af2->ch);
+	}
+
+	if (af1->fmt != af2->fmt) {
+		warning("aurpipe: invalid sample formats (%s -> %s). "
+			"%s\n",
+			aufmt_name(af1->fmt), aufmt_name(af2->fmt),
+			af1->fmt == AUFMT_S16LE ?
+			"Use module auconv!" : "");
+	}
+}
+
+
 /*
- * Write samples to Audio Player. This version of the write handler is used
- * for the configuration jitter_buffer_type JBUF_FIXED.
+ * Write samples to Audio Player.
  *
  * @note This function has REAL-TIME properties
  *
@@ -620,22 +566,21 @@ bool audio_txtelev_empty(const struct audio *au)
 static void auplay_write_handler(struct auframe *af, void *arg)
 {
 	struct audio *a = arg;
+	struct auframe afr;
 	struct aurx *rx = &a->rx;
-	size_t num_bytes = auframe_size(af);
 
-	mtx_lock(rx->mtx);
-	if (rx->aubuf_started && aubuf_cur_size(rx->aubuf) < num_bytes) {
+	if (!rx->auplay)
+		return;
 
-		++rx->stats.aubuf_underrun;
+	if (!rx->first_write)
+		afr = *af;
 
-#if 0
-		debug("audio: rx aubuf underrun (total %llu)\n",
-			rx->stats.aubuf_underrun);
-#endif
+	aup_read(rx->aup, af);
+
+	if (!rx->first_write) {
+		(void)check_plframe(&afr, af);
+		rx->first_write = true;
 	}
-
-	mtx_unlock(rx->mtx);
-	aubuf_read_auframe(rx->aubuf, af);
 }
 
 
@@ -724,15 +669,6 @@ static void handle_telev(struct audio *a, struct mbuf *mb)
 }
 
 
-static bool audio_is_telev(struct audio *a, int pt)
-{
-	const struct sdp_format *lc;
-
-	lc = sdp_media_lformat(stream_sdpmedia(a->strm), pt);
-	return  lc && !str_casecmp(lc->name, "telephone-event");
-}
-
-
 static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 {
 	struct audio *a = arg;
@@ -761,233 +697,22 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 }
 
 
-static int process_decfilt(struct aurx *rx, struct auframe *af)
-{
-	int err = 0;
-
-	/* Process exactly one audio-frame in reverse list order */
-	mtx_lock(rx->mtx);
-	for (struct le *le = rx->filtl.tail; le; le = le->prev) {
-		struct aufilt_dec_st *st = le->data;
-
-		if (st->af && st->af->dech)
-			err = st->af->dech(st, af);
-
-		if (err)
-			break;
-	}
-
-	mtx_unlock(rx->mtx);
-	return err;
-}
-
-
-static int rx_push_aubuf(struct aurx *rx, const struct auframe *af)
-{
-	int err;
-
-	if (aubuf_cur_size(rx->aubuf) >= rx->aubuf_maxsz) {
-
-		++rx->stats.aubuf_overrun;
-
-#if 0
-		debug("audio: rx aubuf overrun (total %llu)\n",
-		      rx->stats.aubuf_overrun);
-#endif
-	}
-
-	if (rx->auplay_prm.srate != af->srate || rx->auplay_prm.ch != af->ch) {
-		warning("audio: srate/ch of frame %u/%u vs player %u/%u. Use "
-			"module auresamp!\n",
-			af->srate, af->ch,
-			rx->auplay_prm.srate, rx->auplay_prm.ch);
-	}
-
-	if (af->fmt != rx->play_fmt) {
-		warning("audio: rx: invalid sample formats (%s -> %s). %s\n",
-			aufmt_name(af->fmt), aufmt_name(rx->play_fmt),
-			rx->play_fmt == AUFMT_S16LE ? "Use module auconv!" : ""
-		       );
-	}
-
-	err = aubuf_write_auframe(rx->aubuf, af);
-	if (err)
-		return err;
-
-	mtx_lock(rx->mtx);
-	if (!rx->aubuf_started &&
-	    (aubuf_cur_size(rx->aubuf) >= rx->aubuf_minsz))
-		rx->aubuf_started = true;
-
-	mtx_unlock(rx->mtx);
-
-	return 0;
-}
-
-
-static int aurx_stream_decode(struct aurx *rx, const struct rtp_header *hdr,
-			      struct mbuf *mb, unsigned lostc, bool drop)
-{
-	struct auframe af;
-	size_t sampc = AUDIO_SAMPSZ;
-	bool marker = hdr->m;
-	int err = 0;
-	const struct aucodec *ac = rx->ac;
-	bool flush = rx->ssrc != hdr->ssrc;
-
-	/* No decoder set */
-	if (!ac)
-		return 0;
-
-	rx->ssrc = hdr->ssrc;
-
-	/* TODO: PLC */
-	if (lostc && ac->plch) {
-
-		err = ac->plch(rx->dec,
-				   rx->dec_fmt, rx->sampv, &sampc,
-				   mbuf_buf(mb), mbuf_get_left(mb));
-		if (err) {
-			warning("audio: %s codec decode %u bytes: %m\n",
-				ac->name, mbuf_get_left(mb), err);
-			goto out;
-		}
-	}
-	else if (mbuf_get_left(mb)) {
-
-		err = ac->dech(rx->dec,
-				   rx->dec_fmt, rx->sampv, &sampc,
-				   marker, mbuf_buf(mb), mbuf_get_left(mb));
-		if (err) {
-			warning("audio: %s codec decode %u bytes: %m\n",
-				ac->name, mbuf_get_left(mb), err);
-			goto out;
-		}
-	}
-	else {
-		/* no PLC in the codec, might be done in filters below */
-		sampc = 0;
-	}
-
-	auframe_init(&af, rx->dec_fmt, rx->sampv, sampc, ac->srate, ac->ch);
-	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
-
-	if (drop) {
-		aubuf_drop_auframe(rx->aubuf, &af);
-		goto out;
-	}
-
-	if (flush)
-		aubuf_flush(rx->aubuf);
-
-	err = process_decfilt(rx, &af);
-	if (err)
-		goto out;
-
-	if (!rx->aubuf)
-		goto out;
-
-	err = rx_push_aubuf(rx, &af);
- out:
-	return err;
-}
-
-
-/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
-static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
-					uint8_t id)
-{
-	for (size_t i=0; i<extc; i++) {
-		const struct rtpext *rtpext = &extv[i];
-
-		if (rtpext->id == id)
-			return rtpext;
-	}
-
-	return NULL;
-}
-
-
-/* Handle incoming stream data from the network */
+/**
+ * Stream receive handler for audio is called from RX thread if enabled
+ */
 static void stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc, bool *ignore,
 				void *arg)
 {
 	struct audio *a = arg;
-	struct aurx *rx = &a->rx;
-	bool discard = false;
-	bool drop = *ignore;
-	int wrap;
-	(void) lostc;
 
 	MAGIC_CHECK(a);
 
-	if (!mb)
-		goto out;
-
-	if (audio_is_telev(a, hdr->pt)) {
-		*ignore = true;
+	if (!a->rx.aup)
 		return;
-	}
 
-	*ignore = false;
-
-	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
-	const struct rtpext *ext = rtpext_find(extv, extc, a->extmap_aulevel);
-	if (ext) {
-		rx->level_last = -(double)(ext->data[0] & 0x7f);
-		rx->level_set = true;
-	}
-
-	/* Save timestamp for incoming RTP packets */
-
-	if (!rx->ts_recv.is_set)
-		timestamp_set(&rx->ts_recv, hdr->ts);
-
-	wrap = timestamp_wrap(hdr->ts, rx->ts_recv.last);
-
-	switch (wrap) {
-
-	case -1:
-		warning("audio: rtp timestamp wraps backwards"
-			" (delta = %d) -- discard\n",
-			(int32_t)(rx->ts_recv.last - hdr->ts));
-		discard = true;
-		break;
-
-	case 0:
-		break;
-
-	case 1:
-		++rx->ts_recv.num_wraps;
-		break;
-
-	default:
-		break;
-	}
-
-	rx->ts_recv.last = hdr->ts;
-
-#if 0
-	re_printf("[time=%.3f]    wrap=%d  discard=%d\n",
-		  aurx_calc_seconds(rx), wrap, discard);
-#endif
-
-	if (discard) {
-		++rx->stats.n_discard;
-		return;
-	}
-
- out:
-	/* TODO:  what if lostc > 1 ?*/
-	/* PLC should generate lostc frames here. Not only one.
-	 * aubuf should replace PLC frames with late arriving real frames.
-	 * It should use timestamp to decide if a frame should be replaced. */
-/*        if (lostc)*/
-/*                (void)aurx_stream_decode(&a->rx, hdr, mb, lostc, drop);*/
-
-	(void)aurx_stream_decode(&a->rx, hdr, mb, 0, drop);
+	aup_receive(a->rx.aup, hdr, extv, extc, mb, lostc, ignore);
 }
 
 
@@ -997,19 +722,23 @@ static int add_telev_codec(struct audio *a)
 	struct sdp_format *sf;
 	uint32_t pt = a->cfg.telev_pt;
 	char pts[11];
+	bool add = !sdp_media_lformat(m, pt);
 	int err;
 
 	(void)re_snprintf(pts, sizeof(pts), "%u", pt);
 
 	/* Use payload-type 101 if available, for CiscoGW interop */
 	err = sdp_format_add(&sf, m, false,
-			     (!sdp_media_lformat(m, pt)) ? pts : NULL,
+			     add ? pts : NULL,
 			     telev_rtpfmt, TELEV_SRATE, 1, NULL,
 			     NULL, NULL, false, "0-15");
 	if (err)
 		return err;
 
-	return err;
+	if (add)
+		aup_set_telev_pt(a->rx.aup, pt);
+
+	return 0;
 }
 
 
@@ -1074,15 +803,18 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 
 	tx->src_fmt = cfg->audio.src_fmt;
 	rx->play_fmt = cfg->audio.play_fmt;
-
 	tx->enc_fmt = cfg->audio.enc_fmt;
-	rx->dec_fmt = cfg->audio.dec_fmt;
 
 	err = stream_alloc(&a->strm, streaml,
 			   stream_prm, &cfg->avt, sdp_sess,
 			   MEDIA_AUDIO,
 			   mnat, mnat_sess, menc, menc_sess, offerer,
-			   stream_recv_handler, NULL, stream_pt_handler, a);
+			   stream_recv_handler, NULL, stream_pt_handler,
+			   a);
+	if (err)
+		goto out;
+
+	err = aup_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
 	if (err)
 		goto out;
 
@@ -1115,6 +847,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (cfg->audio.level && offerer) {
 
 		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
+		aup_set_extmap(a->rx.aup, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
 					  "extmap",
@@ -1128,9 +861,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	tx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(tx->enc_fmt),
 			       NULL);
 
-	rx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(rx->dec_fmt),
-			       NULL);
-	if (!tx->mb || !tx->sampv || !rx->sampv) {
+	if (!tx->mb || !tx->sampv) {
 		err = ENOMEM;
 		goto out;
 	}
@@ -1184,7 +915,6 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	rx->ptime  = ptime;
 
 	err  = mutex_alloc(&tx->mtx);
-	err |= mutex_alloc(&rx->mtx);
 	if (err)
 		goto out;
 
@@ -1291,7 +1021,7 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 			err |= re_hprintf(pf, " ---> %s", st->af->name);
 	}
 
-	err |= re_hprintf(pf, " ---> %s\n",
+	err |= re_hprintf(pf, " ---> %s",
 			  autx->ac ? autx->ac->name : "(encoder)");
 
 	return err;
@@ -1300,7 +1030,6 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 
 static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 {
-	struct le *le;
 	int err;
 
 	if (!rx)
@@ -1308,19 +1037,6 @@ static int aurx_print_pipeline(struct re_printf *pf, const struct aurx *rx)
 
 	err = re_hprintf(pf, "audio rx pipeline:  %10s",
 			 rx->ap ? rx->ap->name : "(play)");
-
-	err |= re_hprintf(pf, " <--- aubuf");
-	mtx_lock(rx->mtx);
-	for (le = list_head(&rx->filtl); le; le = le->next) {
-		struct aufilt_dec_st *st = le->data;
-
-		if (st->af->dech)
-			err |= re_hprintf(pf, " <--- %s", st->af->name);
-	}
-
-	mtx_unlock(rx->mtx);
-	err |= re_hprintf(pf, " <--- %s\n",
-			  rx->ac ? rx->ac->name : "(decoder)");
 
 	return err;
 }
@@ -1341,23 +1057,18 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 	struct autx *tx = &a->tx;
 	struct aurx *rx = &a->rx;
 	struct le *le;
-	bool update_enc = false, update_dec = false;
+	bool update_enc, update_dec;
 	int err = 0;
 
 	/* wait until we have both Encoder and Decoder */
-	if (!tx->ac || !rx->ac)
+	if (!tx->ac || !aup_codec(rx->aup))
 		return 0;
 
-	if (list_isempty(&tx->filtl))
-		update_enc = true;
+	update_dec = aup_filt_empty(rx->aup);
+	update_enc = list_isempty(&tx->filtl);
 
-	mtx_lock(rx->mtx);
-	if (list_isempty(&rx->filtl))
-		update_dec = true;
-
-	mtx_unlock(rx->mtx);
 	aufilt_param_set(&encprm, tx->ac, tx->enc_fmt);
-	aufilt_param_set(&plprm, rx->ac, rx->dec_fmt);
+	aufilt_param_set(&plprm, aup_codec(rx->aup), a->cfg.play_fmt);
 	if (a->cfg.srate_play && a->cfg.srate_play != plprm.srate) {
 		plprm.srate = a->cfg.srate_play;
 	}
@@ -1393,9 +1104,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			}
 			else {
 				decst->af = af;
-				mtx_lock(rx->mtx);
-				list_append(&rx->filtl, &decst->le, decst);
-				mtx_unlock(rx->mtx);
+				aup_filt_append(rx->aup, decst);
 			}
 		}
 
@@ -1413,12 +1122,9 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 static int start_player(struct aurx *rx, struct audio *a,
 			struct list *auplayl)
 {
-	const struct aucodec *ac = rx->ac;
+	const struct aucodec *ac = aup_codec(rx->aup);
 	uint32_t srate_dsp;
 	uint32_t channels_dsp;
-	size_t sz;
-	size_t min_sz;
-	size_t max_sz;
 	int err = 0;
 
 	if (!ac)
@@ -1444,36 +1150,6 @@ static int start_player(struct aurx *rx, struct audio *a,
 		prm.ptime      = rx->ptime;
 		prm.fmt        = rx->play_fmt;
 
-		if (!rx->aubuf) {
-			const uint16_t ptime_min = (uint16_t)a->cfg.buffer.min;
-			const uint16_t ptime_max = (uint16_t)a->cfg.buffer.max;
-			sz = aufmt_sample_size(rx->play_fmt);
-
-			if (!ptime_min || !ptime_max)
-				return EINVAL;
-
-			min_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_min);
-			max_sz = sz*calc_nsamp(prm.srate, prm.ch, ptime_max);
-
-			debug("audio: create auplay buffer"
-			      " [%u - %u ms]"
-			      " [%zu - %zu bytes]\n",
-			      ptime_min, ptime_max, min_sz, max_sz);
-
-			err = aubuf_alloc(&rx->aubuf, min_sz, max_sz);
-			if (err) {
-				warning("audio: aubuf alloc error (%m)\n",
-					err);
-				return err;
-			}
-
-			aubuf_set_mode(rx->aubuf, a->cfg.adaptive ?
-				       AUBUF_ADAPTIVE : AUBUF_FIXED);
-			aubuf_set_silence(rx->aubuf, a->cfg.silence);
-			rx->aubuf_minsz = min_sz;
-			rx->aubuf_maxsz = max_sz;
-		}
-
 		rx->auplay_prm = prm;
 		err = auplay_alloc(&rx->auplay, auplayl,
 				   rx->module,
@@ -1493,8 +1169,6 @@ static int start_player(struct aurx *rx, struct audio *a,
 	}
 
 out:
-	if (err)
-		rx->aubuf    = mem_deref(rx->aubuf);
 
 	return 0;
 }
@@ -1614,9 +1288,7 @@ static void audio_flush_filters(struct audio *a)
 	struct aurx *rx = &a->rx;
 	struct autx *tx = &a->tx;
 
-	mtx_lock(rx->mtx);
-	list_flush(&rx->filtl);
-	mtx_unlock(rx->mtx);
+	aup_flush(rx->aup);
 
 	mtx_lock(a->tx.mtx);
 	list_flush(&tx->filtl);
@@ -1663,12 +1335,13 @@ int audio_start(struct audio *a)
 		return err;
 	}
 
-	if (a->tx.ac && a->rx.ac) {
+	if (a->tx.ac && aup_codec(a->rx.aup)) {
 
 		if (!a->started) {
-			info("%H%H",
+			info("%H\n%H%H",
 			     autx_print_pipeline, &a->tx,
-			     aurx_print_pipeline, &a->rx);
+			     aurx_print_pipeline, &a->rx,
+			     aup_print_pipeline, a->rx.aup);
 		}
 
 		a->started = true;
@@ -1839,36 +1512,25 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		return EINVAL;
 
 	rx = &a->rx;
+	rx->pt = pt_rx;
 
-	if (ac != rx->ac) {
+	if (ac != aup_codec(rx->aup)) {
 		struct sdp_media *m;
 		bool reset;
 
 		m = stream_sdpmedia(audio_strm(a));
-		reset  = !aucodec_equal(ac, rx->ac);
+		reset  = !aucodec_equal(ac, aup_codec(rx->aup));
 		reset |= !(sdp_media_dir(m) & SDP_RECVONLY);
 		if (reset) {
 			rx->auplay = mem_deref(rx->auplay);
 			audio_flush_filters(a);
-			aubuf_flush(rx->aubuf);
 			stream_flush(a->strm);
 		}
-
-		info("audio: Set audio decoder: %s %uHz %dch\n",
-		     ac->name, ac->srate, ac->ch);
-
-		rx->pt = pt_rx;
-		rx->ac = ac;
-		rx->dec = mem_deref(rx->dec);
 	}
 
-	if (ac->decupdh) {
-		err = ac->decupdh(&rx->dec, ac, params);
-		if (err) {
-			warning("audio: alloc decoder: %m\n", err);
-			return err;
-		}
-	}
+	err = aup_decoder_set(rx->aup, ac, params);
+	if (err)
+		return err;
 
 	stream_set_srate(a->strm, 0, ac->crate);
 
@@ -1983,6 +1645,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		}
 
 		au->extmap_aulevel = extmap.id;
+		aup_set_extmap(au->rx.aup, au->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(au->strm), true,
 					  "extmap",
@@ -2079,11 +1742,11 @@ int audio_level_get(const struct audio *au, double *levelp)
 	if (!au->level_enabled)
 		return ENOTSUP;
 
-	if (!au->rx.level_set)
+	if (!aup_level_set(au->rx.aup))
 		return ENOENT;
 
 	if (levelp)
-		*levelp = au->rx.level_last;
+		*levelp = aup_level(au->rx.aup);
 
 	return 0;
 }
@@ -2101,7 +1764,8 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 {
 	const struct autx *tx;
 	const struct aurx *rx;
-	size_t sztx, szrx;
+	const struct aurpipe *aup;
+	size_t sztx;
 	int err;
 
 	if (!a)
@@ -2109,9 +1773,9 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 
 	tx = &a->tx;
 	rx = &a->rx;
+	aup = a->rx.aup;
 
 	sztx = aufmt_sample_size(tx->src_fmt);
-	szrx = aufmt_sample_size(rx->play_fmt);
 
 	err  = re_hprintf(pf, "\n--- Audio stream ---\n");
 
@@ -2137,44 +1801,18 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
 			  autx_calc_seconds(tx));
 
-	err |= re_hprintf(pf,
-			  " rx:   decode: %H %s\n",
-			  aucodec_print, rx->ac, aufmt_name(rx->dec_fmt));
-	err |= re_hprintf(pf, "       aubuf: %H"
-			  " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
-			  aubuf_debug, rx->aubuf,
-			  calc_ptime(aubuf_cur_size(rx->aubuf)/szrx,
-				     rx->auplay_prm.srate,
-				     rx->auplay_prm.ch),
-			  calc_ptime(rx->aubuf_maxsz/szrx,
-				     rx->auplay_prm.srate,
-				     rx->auplay_prm.ch),
-			  rx->stats.aubuf_overrun,
-			  rx->stats.aubuf_underrun
-			  );
+	err |= aup_debug(pf, aup);
 	err |= re_hprintf(pf, "       player: %s,%s %s\n",
 			  rx->ap ? rx->ap->name : "none",
 			  rx->device,
 			  aufmt_name(rx->play_fmt));
-	err |= re_hprintf(pf, "       n_discard:%llu\n",
-			  rx->stats.n_discard);
-	if (rx->level_set) {
-		err |= re_hprintf(pf, "       level %.3f dBov\n",
-				  rx->level_last);
-	}
-	if (rx->ts_recv.is_set) {
-		err |= re_hprintf(pf, "       time = %.3f sec\n",
-				  aurx_calc_seconds(rx));
-	}
-	else {
-		err |= re_hprintf(pf, "       time = (not started)\n");
-	}
 
 	err |= re_hprintf(pf,
-			  " %H"
-			  " %H",
+			  " %H\n"
+			  " %H%H",
 			  autx_print_pipeline, tx,
-			  aurx_print_pipeline, rx);
+			  aurx_print_pipeline, rx,
+			  aup_print_pipeline, aup);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -2346,14 +1984,10 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
  */
 bool audio_rxaubuf_started(const struct audio *au)
 {
-	const struct aurx *rx;
-
-	if (!au)
+	if (!au || !au->rx.aup)
 		return false;
 
-	rx = &au->rx;
-
-	return rx->aubuf_started;
+	return aup_started(au->rx.aup);
 }
 
 
@@ -2417,7 +2051,7 @@ const struct aucodec *audio_codec(const struct audio *au, bool tx)
 	if (!au)
 		return NULL;
 
-	return tx ? au->tx.ac : au->rx.ac;
+	return tx ? au->tx.ac : aup_codec(au->rx.aup);
 }
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -812,7 +812,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ);
+	err = aur_alloc(&a->rx.aup, &a->cfg, AUDIO_SAMPSZ, ptime);
 	if (err)
 		goto out;
 

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -1,0 +1,654 @@
+/**
+ * @file src/aureceiver.c  Audio stream receiver
+ *
+ * Copyright (C) 2023 Alfred E. Heggestad, Christian Spielberger
+ */
+#include <string.h>
+#include <re.h>
+#include <re_atomic.h>
+#include <rem.h>
+#include <baresip.h>
+#include "core.h"
+
+
+/**
+ * Audio receive pipeline
+ *
+ \verbatim
+
+ Processing decoder pipeline:
+
+       .--------.   .-------.   .--------.   .--------.
+ |\    |        |   |       |   |        |   |        |
+ | |<--| auplay |<--| aubuf |<--| aufilt |<--| decode |<--- RTP
+ |/    |        |   |       |   |        |   |        |
+       '--------'   '-------'   '--------'   '--------'
+
+ \endverbatim
+ */
+struct aurpipe {
+	uint32_t srate;               /**< Decoder sample rate               */
+	uint32_t ch;                  /**< Decoder channel number            */
+	enum aufmt fmt;               /**< Decoder sample format             */
+	const struct config_audio *cfg;  /**< Audio configuration            */
+	struct audec_state *dec;      /**< Audio decoder state (optional)    */
+	const struct aucodec *ac;     /**< Current audio decoder             */
+	struct aubuf *aubuf;          /**< Audio buffer before auplay        */
+	size_t aubuf_minsz;           /**< Minimum aubuf size in [bytes]     */
+	size_t aubuf_maxsz;           /**< Maximum aubuf size in [bytes]     */
+	bool aubuf_started;           /**< Aubuf started flag                */
+	uint32_t ssrc;                /**< Incoming synchronization source   */
+	struct list filtl;            /**< Audio filters in decoding order   */
+	void *sampv;                  /**< Sample buffer                     */
+	size_t sampvsz;               /**< Sample buffer size                */
+
+	double level_last;            /**< Last audio level value [dBov]     */
+	bool level_set;               /**< True if level_last is set         */
+	struct timestamp_recv ts_recv;/**< Receive timestamp state           */
+	uint8_t extmap_aulevel;       /**< ID Range 1-14 inclusive           */
+	uint32_t telev_pt;            /**< Payload type for telephone-events */
+
+	struct {
+		uint64_t aubuf_overrun;
+		uint64_t aubuf_underrun;
+		uint64_t n_discard;
+	} stats;
+
+	mtx_t *mtx;
+};
+
+
+static void destructor(void *arg)
+{
+	struct aurpipe *rp = arg;
+
+	mem_deref(rp->dec);
+	mem_deref(rp->aubuf);
+	mem_deref(rp->sampv);
+	mem_deref(rp->mtx);
+	list_flush(&rp->filtl);
+}
+
+
+static int aup_process_decfilt(struct aurpipe *rp, struct auframe *af)
+{
+	int err = 0;
+
+	/* Process exactly one audio-frame in reverse list order */
+	for (struct le *le = rp->filtl.tail; le; le = le->prev) {
+		struct aufilt_dec_st *st = le->data;
+
+		if (st->af && st->af->dech)
+			err = st->af->dech(st, af);
+
+		if (err)
+			break;
+	}
+
+	return err;
+}
+
+
+static double aup_calc_seconds(const struct aurpipe *rp)
+{
+	uint64_t dur;
+	double seconds;
+
+	if (!rp->ac)
+		return .0;
+
+	dur = timestamp_duration(&rp->ts_recv);
+	seconds = timestamp_calc_seconds(dur, rp->ac->crate);
+
+	return seconds;
+}
+
+
+static int aup_alloc_aubuf(struct aurpipe *rp, const struct auframe *af)
+{
+	size_t min_sz;
+	size_t max_sz;
+	size_t sz;
+	const struct config_audio *cfg = rp->cfg;
+	int err;
+
+	sz = aufmt_sample_size(cfg->play_fmt);
+	min_sz = sz * calc_nsamp(af->srate, af->ch, cfg->buffer.min);
+	max_sz = sz * calc_nsamp(af->srate, af->ch, cfg->buffer.max);
+
+	debug("aurpipe: create audio buffer"
+	      " [%u - %u ms]"
+	      " [%zu - %zu bytes]\n",
+	      (unsigned) cfg->buffer.min, (unsigned) cfg->buffer.max,
+	      min_sz, max_sz);
+
+	err = aubuf_alloc(&rp->aubuf, min_sz, max_sz);
+	if (err) {
+		warning("aurpipe: aubuf alloc error (%m)\n",
+			err);
+	}
+
+	aubuf_set_mode(rp->aubuf, cfg->adaptive ?
+		       AUBUF_ADAPTIVE : AUBUF_FIXED);
+	aubuf_set_silence(rp->aubuf, cfg->silence);
+	rp->aubuf_minsz = min_sz;
+	rp->aubuf_maxsz = max_sz;
+	return err;
+}
+
+
+static int aup_push_aubuf(struct aurpipe *rp, const struct auframe *af)
+{
+	int err;
+
+	if (!rp->aubuf) {
+		err = aup_alloc_aubuf(rp, af);
+		if (err)
+			return err;
+	}
+
+	if (aubuf_cur_size(rp->aubuf) >= rp->aubuf_maxsz) {
+
+		++rp->stats.aubuf_overrun;
+
+#if 0
+		debug("audio: rx aubuf overrun (total %llu)\n",
+		      rp->stats.aubuf_overrun);
+#endif
+	}
+
+	err = aubuf_write_auframe(rp->aubuf, af);
+	if (err)
+		return err;
+
+	rp->srate = af->srate;
+	rp->ch    = af->ch;
+	rp->fmt   = af->fmt;
+
+	if (!rp->aubuf_started &&
+	    (aubuf_cur_size(rp->aubuf) >= rp->aubuf_minsz))
+		rp->aubuf_started = true;
+
+	return 0;
+}
+
+
+static int aup_stream_decode(struct aurpipe *rp, const struct rtp_header *hdr,
+			    struct mbuf *mb, unsigned lostc, bool drop)
+{
+	struct auframe af;
+	size_t sampc = rp->sampvsz / aufmt_sample_size(rp->fmt);
+	bool marker = hdr->m;
+	int err = 0;
+	const struct aucodec *ac = rp->ac;
+	bool flush = rp->ssrc != hdr->ssrc;
+
+	/* No decoder set */
+	if (!ac)
+		return 0;
+
+	rp->ssrc = hdr->ssrc;
+
+	/* TODO: PLC */
+	if (lostc && ac->plch) {
+
+		err = ac->plch(rp->dec,
+				   rp->fmt, rp->sampv, &sampc,
+				   mbuf_buf(mb), mbuf_get_left(mb));
+		if (err) {
+			warning("audio: %s codec decode %u bytes: %m\n",
+				ac->name, mbuf_get_left(mb), err);
+			goto out;
+		}
+	}
+	else if (mbuf_get_left(mb)) {
+
+		err = ac->dech(rp->dec,
+				   rp->fmt, rp->sampv, &sampc,
+				   marker, mbuf_buf(mb), mbuf_get_left(mb));
+		if (err) {
+			warning("audio: %s codec decode %u bytes: %m\n",
+				ac->name, mbuf_get_left(mb), err);
+			goto out;
+		}
+	}
+	else {
+		/* no PLC in the codec, might be done in filters below */
+		sampc = 0;
+	}
+
+	auframe_init(&af, rp->fmt, rp->sampv, sampc, ac->srate, ac->ch);
+	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
+
+	if (drop) {
+		aubuf_drop_auframe(rp->aubuf, &af);
+		goto out;
+	}
+
+	if (flush)
+		aubuf_flush(rp->aubuf);
+
+	err = aup_process_decfilt(rp, &af);
+	if (err)
+		goto out;
+
+	err = aup_push_aubuf(rp, &af);
+ out:
+	return err;
+}
+
+
+/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
+static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
+					uint8_t id)
+{
+	for (size_t i=0; i<extc; i++) {
+		const struct rtpext *rtpext = &extv[i];
+
+		if (rtpext->id == id)
+			return rtpext;
+	}
+
+	return NULL;
+}
+
+
+/* Handle incoming stream data from the network */
+void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+		 struct rtpext *extv, size_t extc,
+		 struct mbuf *mb, unsigned lostc, bool *ignore)
+{
+	bool discard = false;
+	bool drop = *ignore;
+	int wrap;
+	(void) lostc;
+
+	if (!mb)
+		goto out;
+
+	mtx_lock(rp->mtx);
+	if (hdr->pt == rp->telev_pt) {
+		mtx_unlock(rp->mtx);
+		*ignore = true;
+		return;
+	}
+
+	*ignore = false;
+
+	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
+	const struct rtpext *ext = rtpext_find(extv, extc, rp->extmap_aulevel);
+	if (ext) {
+		rp->level_last = -(double)(ext->data[0] & 0x7f);
+		rp->level_set = true;
+	}
+
+	/* Save timestamp for incoming RTP packets */
+
+	if (!rp->ts_recv.is_set)
+		timestamp_set(&rp->ts_recv, hdr->ts);
+
+	wrap = timestamp_wrap(hdr->ts, rp->ts_recv.last);
+
+	switch (wrap) {
+
+	case -1:
+		warning("audio: rtp timestamp wraps backwards"
+			" (delta = %d) -- discard\n",
+			(int32_t)(rp->ts_recv.last - hdr->ts));
+		discard = true;
+		break;
+
+	case 0:
+		break;
+
+	case 1:
+		++rp->ts_recv.num_wraps;
+		break;
+
+	default:
+		break;
+	}
+
+	rp->ts_recv.last = hdr->ts;
+
+	if (discard) {
+		++rp->stats.n_discard;
+		goto unlock;
+	}
+
+ out:
+	/* TODO:  what if lostc > 1 ?*/
+	/* PLC should generate lostc frames here. Not only one.
+	 * aubuf should replace PLC frames with late arriving real frames.
+	 * It should use timestamp to decide if a frame should be replaced. */
+/*        if (lostc)*/
+/*                (void)aup_stream_decode(rp, hdr, mb, lostc, drop);*/
+
+	(void)aup_stream_decode(rp, hdr, mb, 0, drop);
+
+unlock:
+	mtx_unlock(rp->mtx);
+}
+
+
+void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->extmap_aulevel = aulevel;
+	mtx_unlock(rp->mtx);
+}
+
+
+void aup_set_telev_pt(struct aurpipe *rp, int pt)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->telev_pt = pt;
+	mtx_unlock(rp->mtx);
+}
+
+
+uint64_t aup_latency(const struct aurpipe *rp)
+{
+	uint64_t bpms;
+	if (!rp || !rp->aubuf)
+		return 0;
+
+	mtx_lock(rp->mtx);
+	bpms = rp->srate * rp->ch * aufmt_sample_size(rp->fmt) / 1000;
+	mtx_unlock(rp->mtx);
+	if (bpms) {
+		uint64_t val = aubuf_cur_size(rp->aubuf) / bpms;
+
+		return val;
+	}
+
+	return 0;
+}
+
+
+int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+	      size_t sampc)
+{
+	struct aurpipe *rp;
+	int err;
+
+	if (!aupp)
+		return EINVAL;
+
+	rp = mem_zalloc(sizeof(*rp), destructor);
+	if (!rp)
+		return ENOMEM;
+
+	rp->cfg = cfg;
+	rp->srate = cfg->srate_play;
+	rp->ch    = cfg->channels_play;
+	rp->fmt   = cfg->play_fmt;
+	rp->sampvsz = sampc * aufmt_sample_size(rp->fmt);
+	rp->sampv   = mem_zalloc(rp->sampvsz, NULL);
+	if (!rp->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	err = mutex_alloc(&rp->mtx);
+
+out:
+	if (err)
+		rp = mem_deref(rp);
+	else
+		*aupp = rp;
+
+	return err;
+}
+
+
+void aup_flush(struct aurpipe *rp)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	aubuf_flush(rp->aubuf);
+
+	/* Reset audio filter chain */
+	list_flush(&rp->filtl);
+	mtx_unlock(rp->mtx);
+}
+
+
+int aup_decoder_set(struct aurpipe *rp,
+		    const struct aucodec *ac, const char *params)
+{
+	int err = 0;
+
+	if (!rp || !ac)
+		return EINVAL;
+
+	info("audio: Set audio decoder: %s %uHz %dch\n",
+	     ac->name, ac->srate, ac->ch);
+
+	mtx_lock(rp->mtx);
+	if (ac != rp->ac) {
+		rp->ac = ac;
+		rp->dec = mem_deref(rp->dec);
+	}
+
+	if (ac->decupdh) {
+		err = ac->decupdh(&rp->dec, ac, params);
+		if (err) {
+			warning("aurpipe: alloc decoder: %m\n", err);
+			goto out;
+		}
+	}
+
+out:
+	mtx_unlock(rp->mtx);
+	return err;
+}
+
+
+int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst)
+{
+	if (!rp || !decst)
+		return EINVAL;
+
+	mtx_lock(rp->mtx);
+	list_append(&rp->filtl, &decst->le, decst);
+	mtx_unlock(rp->mtx);
+
+	return 0;
+}
+
+
+bool aup_filt_empty(const struct aurpipe *rp)
+{
+	bool empty;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	empty = list_isempty(&rp->filtl);
+	mtx_unlock(rp->mtx);
+
+	return empty;
+}
+
+
+bool aup_level_set(const struct aurpipe *rp)
+{
+	bool set;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	set = rp->level_set;
+	mtx_unlock(rp->mtx);
+
+	return set;
+}
+
+
+double aup_level(const struct aurpipe *rp)
+{
+	double v;
+	if (!rp)
+		return 0.0;
+
+	mtx_lock(rp->mtx);
+	v = rp->level_last;
+	mtx_unlock(rp->mtx);
+
+	return v;
+}
+
+
+const struct aucodec *aup_codec(const struct aurpipe *rp)
+{
+	const struct aucodec *ac;
+
+	if (!rp)
+		return NULL;
+
+	mtx_lock(rp->mtx);
+	ac = rp->ac;
+	mtx_unlock(rp->mtx);
+	return ac;
+}
+
+
+void aup_read(struct aurpipe *rp, struct auframe *af)
+{
+	size_t num_bytes = auframe_size(af);
+
+	mtx_lock(rp->mtx);
+	if (rp->aubuf_started && aubuf_cur_size(rp->aubuf) < num_bytes) {
+
+		++rp->stats.aubuf_underrun;
+
+#if 0
+		debug("aurpipe: aubuf underrun (total %llu)\n",
+			rp->stats.aubuf_underrun);
+#endif
+	}
+
+	mtx_unlock(rp->mtx);
+	aubuf_read_auframe(rp->aubuf, af);
+}
+
+
+void aup_stop(struct aurpipe *rp)
+{
+	if (!rp)
+		return;
+
+	mtx_lock(rp->mtx);
+	rp->ac = NULL;
+	mtx_unlock(rp->mtx);
+}
+
+
+bool aup_started(const struct aurpipe *rp)
+{
+	bool started;
+	if (!rp)
+		return false;
+
+	mtx_lock(rp->mtx);
+	started = rp->aubuf_started;
+	mtx_unlock(rp->mtx);
+
+	return started;
+}
+
+
+int aup_debug(struct re_printf *pf, const struct aurpipe *rp)
+{
+	struct mbuf *mb;
+	uint64_t bpms;
+	int err;
+
+	if (!rp)
+		return 0;
+
+	mb = mbuf_alloc(32);
+	if (!mb)
+		return ENOMEM;
+
+	mtx_lock(rp->mtx);
+	bpms = rp->srate * rp->ch * aufmt_sample_size(rp->fmt) / 1000;
+	err  = mbuf_printf(mb,
+			   " rx:   decode: %H %s\n",
+			   aucodec_print, rp->ac,
+			   aufmt_name(rp->fmt));
+	err |= mbuf_printf(mb, "       aubuf: %H"
+			   " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
+			   aubuf_debug, rp->aubuf,
+			   aubuf_cur_size(rp->aubuf) / bpms,
+			   rp->aubuf_maxsz / bpms,
+			   rp->stats.aubuf_overrun,
+			   rp->stats.aubuf_underrun);
+	err |= mbuf_printf(mb, "       n_discard:%llu\n",
+			   rp->stats.n_discard);
+	if (rp->level_set) {
+		err |= mbuf_printf(mb, "       level %.3f dBov\n",
+				   rp->level_last);
+	}
+	if (rp->ts_recv.is_set) {
+		err |= mbuf_printf(mb, "       time = %.3f sec\n",
+				   aup_calc_seconds(rp));
+	}
+	else {
+		err |= mbuf_printf(mb, "       time = (not started)\n");
+	}
+	mtx_unlock(rp->mtx);
+
+	if (err)
+		goto out;
+
+	err = re_hprintf(pf, "%b", mb->buf, mb->pos);
+out:
+	mem_deref(mb);
+	return err;
+}
+
+
+int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp)
+{
+	struct mbuf *mb;
+	struct le *le;
+	int err;
+
+	if (!rp)
+		return 0;
+
+	mb = mbuf_alloc(32);
+	if (!mb)
+		return ENOMEM;
+
+	err = mbuf_printf(mb, " <--- aubuf");
+	mtx_lock(rp->mtx);
+	for (le = list_head(&rp->filtl); le; le = le->next) {
+		struct aufilt_dec_st *st = le->data;
+
+		if (st->af->dech)
+			err |= mbuf_printf(mb, " <--- %s", st->af->name);
+	}
+
+	err |= mbuf_printf(mb, " <--- %s\n",
+			  rp->ac ? rp->ac->name : "(decoder)");
+	mtx_unlock(rp->mtx);
+
+	if (err)
+		goto out;
+
+	err = re_hprintf(pf, "%b", mb->buf, mb->pos);
+out:
+	mem_deref(mb);
+	return err;
+}

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -68,7 +68,7 @@ static void destructor(void *arg)
 }
 
 
-static int aup_process_decfilt(struct audio_recv *ar, struct auframe *af)
+static int aur_process_decfilt(struct audio_recv *ar, struct auframe *af)
 {
 	int err = 0;
 
@@ -87,7 +87,7 @@ static int aup_process_decfilt(struct audio_recv *ar, struct auframe *af)
 }
 
 
-static double aup_calc_seconds(const struct audio_recv *ar)
+static double aur_calc_seconds(const struct audio_recv *ar)
 {
 	uint64_t dur;
 	double seconds;
@@ -102,7 +102,7 @@ static double aup_calc_seconds(const struct audio_recv *ar)
 }
 
 
-static int aup_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
+static int aur_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
 {
 	size_t min_sz;
 	size_t max_sz;
@@ -133,14 +133,14 @@ static int aup_alloc_aubuf(struct audio_recv *ar, const struct auframe *af)
 }
 
 
-static int aup_push_aubuf(struct audio_recv *ar, const struct auframe *af)
+static int aur_push_aubuf(struct audio_recv *ar, const struct auframe *af)
 {
 	int err;
 	uint64_t bpms;
 
 	if (!ar->aubuf) {
 		mtx_lock(ar->aubuf_mtx);
-		err = aup_alloc_aubuf(ar, af);
+		err = aur_alloc_aubuf(ar, af);
 		mtx_unlock(ar->aubuf_mtx);
 		if (err)
 			return err;
@@ -163,7 +163,7 @@ static int aup_push_aubuf(struct audio_recv *ar, const struct auframe *af)
 }
 
 
-static int aup_stream_decode(struct audio_recv *ar,
+static int aur_stream_decode(struct audio_recv *ar,
 			     const struct rtp_header *hdr,
 			     struct mbuf *mb, unsigned lostc, bool drop)
 {
@@ -219,11 +219,11 @@ static int aup_stream_decode(struct audio_recv *ar,
 	if (flush)
 		aubuf_flush(ar->aubuf);
 
-	err = aup_process_decfilt(ar, &af);
+	err = aur_process_decfilt(ar, &af);
 	if (err)
 		goto out;
 
-	err = aup_push_aubuf(ar, &af);
+	err = aur_push_aubuf(ar, &af);
  out:
 	return err;
 }
@@ -245,7 +245,7 @@ static const struct rtpext *rtpext_find(const struct rtpext *extv, size_t extc,
 
 
 /* Handle incoming stream data from the network */
-void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+void aur_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore)
 {
@@ -313,16 +313,16 @@ void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 	 * aubuf should replace PLC frames with late arriving real frames.
 	 * It should use timestamp to decide if a frame should be replaced. */
 /*        if (lostc)*/
-/*                (void)aup_stream_decode(ar, hdr, mb, lostc, drop);*/
+/*                (void)aur_stream_decode(ar, hdr, mb, lostc, drop);*/
 
-	(void)aup_stream_decode(ar, hdr, mb, 0, drop);
+	(void)aur_stream_decode(ar, hdr, mb, 0, drop);
 
 unlock:
 	mtx_unlock(ar->mtx);
 }
 
 
-void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel)
+void aur_set_extmap(struct audio_recv *ar, uint8_t aulevel)
 {
 	if (!ar)
 		return;
@@ -333,7 +333,7 @@ void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel)
 }
 
 
-void aup_set_telev_pt(struct audio_recv *ar, int pt)
+void aur_set_telev_pt(struct audio_recv *ar, int pt)
 {
 	if (!ar)
 		return;
@@ -344,7 +344,7 @@ void aup_set_telev_pt(struct audio_recv *ar, int pt)
 }
 
 
-uint64_t aup_latency(const struct audio_recv *ar)
+uint64_t aur_latency(const struct audio_recv *ar)
 {
 	if (!ar)
 		return 0;
@@ -353,7 +353,7 @@ uint64_t aup_latency(const struct audio_recv *ar)
 }
 
 
-int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
+int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc)
 {
 	struct audio_recv *ar;
@@ -390,7 +390,7 @@ out:
 }
 
 
-void aup_flush(struct audio_recv *ar)
+void aur_flush(struct audio_recv *ar)
 {
 	if (!ar)
 		return;
@@ -404,7 +404,7 @@ void aup_flush(struct audio_recv *ar)
 }
 
 
-int aup_decoder_set(struct audio_recv *ar,
+int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params)
 {
 	int err = 0;
@@ -435,7 +435,7 @@ out:
 }
 
 
-int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
+int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
 {
 	if (!ar || !decst)
 		return EINVAL;
@@ -448,7 +448,7 @@ int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst)
 }
 
 
-bool aup_filt_empty(const struct audio_recv *ar)
+bool aur_filt_empty(const struct audio_recv *ar)
 {
 	bool empty;
 	if (!ar)
@@ -462,7 +462,7 @@ bool aup_filt_empty(const struct audio_recv *ar)
 }
 
 
-bool aup_level_set(const struct audio_recv *ar)
+bool aur_level_set(const struct audio_recv *ar)
 {
 	bool set;
 	if (!ar)
@@ -476,7 +476,7 @@ bool aup_level_set(const struct audio_recv *ar)
 }
 
 
-double aup_level(const struct audio_recv *ar)
+double aur_level(const struct audio_recv *ar)
 {
 	double v;
 	if (!ar)
@@ -490,7 +490,7 @@ double aup_level(const struct audio_recv *ar)
 }
 
 
-const struct aucodec *aup_codec(const struct audio_recv *ar)
+const struct aucodec *aur_codec(const struct audio_recv *ar)
 {
 	const struct aucodec *ac;
 
@@ -504,7 +504,7 @@ const struct aucodec *aup_codec(const struct audio_recv *ar)
 }
 
 
-void aup_read(struct audio_recv *ar, struct auframe *af)
+void aur_read(struct audio_recv *ar, struct auframe *af)
 {
 	if (!ar || mtx_trylock(ar->aubuf_mtx) != thrd_success)
 		return;
@@ -514,7 +514,7 @@ void aup_read(struct audio_recv *ar, struct auframe *af)
 }
 
 
-void aup_stop(struct audio_recv *ar)
+void aur_stop(struct audio_recv *ar)
 {
 	if (!ar)
 		return;
@@ -525,7 +525,7 @@ void aup_stop(struct audio_recv *ar)
 }
 
 
-bool aup_started(const struct audio_recv *ar)
+bool aur_started(const struct audio_recv *ar)
 {
 	bool ret;
 
@@ -538,7 +538,7 @@ bool aup_started(const struct audio_recv *ar)
 }
 
 
-int aup_debug(struct re_printf *pf, const struct audio_recv *ar)
+int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
 	uint64_t bpms;
@@ -572,7 +572,7 @@ int aup_debug(struct re_printf *pf, const struct audio_recv *ar)
 	}
 	if (ar->ts_recv.is_set) {
 		err |= mbuf_printf(mb, "       time = %.3f sec\n",
-				   aup_calc_seconds(ar));
+				   aur_calc_seconds(ar));
 	}
 	else {
 		err |= mbuf_printf(mb, "       time = (not started)\n");
@@ -590,7 +590,7 @@ out:
 }
 
 
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar)
+int aur_print_pipeline(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
 	struct le *le;

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -137,7 +137,7 @@ static int aup_push_aubuf(struct aurpipe *rp, const struct auframe *af)
 	int err;
 	uint64_t bpms;
 
-	if (!rp->aubuf) {
+	if (!re_atomic_rlx(&rp->ready)) {
 		err = aup_alloc_aubuf(rp, af);
 		if (err)
 			return err;

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -566,7 +566,7 @@ bool aur_started(const struct audio_recv *ar)
 int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;
-	uint64_t bpms;
+	double bpms;
 	int err;
 
 	if (!ar || mtx_trylock(ar->aubuf_mtx) != thrd_success)
@@ -579,7 +579,8 @@ int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 	}
 
 	mtx_lock(ar->mtx);
-	bpms = ar->srate * ar->ch * aufmt_sample_size(ar->fmt) / 1000;
+	bpms = (double) (uint64_t) (ar->srate * ar->ch *
+				    aufmt_sample_size(ar->fmt) / 1000);
 	err  = mbuf_printf(mb,
 			   " rx:   decode: %H %s\n",
 			   aucodec_print, ar->ac,
@@ -590,8 +591,10 @@ int aur_debug(struct re_printf *pf, const struct audio_recv *ar)
 			   aubuf_cur_size(ar->aubuf) / bpms,
 			   aubuf_maxsz(ar->aubuf) / bpms);
 #ifndef RELEASE
-	err |= mbuf_printf(mb, "       SW jitter: %u\n", ar->stats.jitter);
-	err |= mbuf_printf(mb, "       deviation: %d\n", ar->stats.dmax);
+	err |= mbuf_printf(mb, "       SW jitter: %.2fms\n",
+			   (double) ar->stats.jitter / 1000);
+	err |= mbuf_printf(mb, "       deviation: %.2fms\n",
+			   (double) ar->stats.dmax / 1000);
 #endif
 	err |= mbuf_printf(mb, "       n_discard: %llu\n",
 			   ar->stats.n_discard);

--- a/src/core.h
+++ b/src/core.h
@@ -113,6 +113,36 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 
 /*
+ * Audio Receiver Pipeline
+ */
+
+struct aurpipe;
+
+int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+	      size_t sampc);
+int aup_decoder_set(struct aurpipe *rp,
+		    const struct aucodec *ac, const char *params);
+int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst);
+void aup_flush(struct aurpipe *rp);
+void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel);
+void aup_set_telev_pt(struct aurpipe *rp, int pt);
+void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+		 struct rtpext *extv, size_t extc,
+		 struct mbuf *mb, unsigned lostc, bool *ignore);
+void aup_read(struct aurpipe *rp, struct auframe *af);
+void aup_stop(struct aurpipe *rp);
+
+const struct aucodec *aup_codec(const struct aurpipe *rp);
+uint64_t aup_latency(const struct aurpipe *rp);
+bool aup_started(const struct aurpipe *rp);
+bool aup_filt_empty(const struct aurpipe *rp);
+bool aup_level_set(const struct aurpipe *rp);
+double aup_level(const struct aurpipe *rp);
+int aup_debug(struct re_printf *pf, const struct aurpipe *rp);
+int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp);
+
+
+/*
  * Call Control
  */
 

--- a/src/core.h
+++ b/src/core.h
@@ -116,30 +116,30 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
  * Audio Receiver Pipeline
  */
 
-struct aurpipe;
+struct audio_recv;
 
-int aup_alloc(struct aurpipe **aupp, const struct config_audio *cfg,
+int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct aurpipe *rp,
+int aup_decoder_set(struct audio_recv *rp,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct aurpipe *rp, struct aufilt_dec_st *decst);
-void aup_flush(struct aurpipe *rp);
-void aup_set_extmap(struct aurpipe *rp, uint8_t aulevel);
-void aup_set_telev_pt(struct aurpipe *rp, int pt);
-void aup_receive(struct aurpipe *rp, const struct rtp_header *hdr,
+int aup_filt_append(struct audio_recv *rp, struct aufilt_dec_st *decst);
+void aup_flush(struct audio_recv *rp);
+void aup_set_extmap(struct audio_recv *rp, uint8_t aulevel);
+void aup_set_telev_pt(struct audio_recv *rp, int pt);
+void aup_receive(struct audio_recv *rp, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct aurpipe *rp, struct auframe *af);
-void aup_stop(struct aurpipe *rp);
+void aup_read(struct audio_recv *rp, struct auframe *af);
+void aup_stop(struct audio_recv *rp);
 
-const struct aucodec *aup_codec(const struct aurpipe *rp);
-uint64_t aup_latency(const struct aurpipe *rp);
-bool aup_started(const struct aurpipe *rp);
-bool aup_filt_empty(const struct aurpipe *rp);
-bool aup_level_set(const struct aurpipe *rp);
-double aup_level(const struct aurpipe *rp);
-int aup_debug(struct re_printf *pf, const struct aurpipe *rp);
-int aup_print_pipeline(struct re_printf *pf, const struct aurpipe *rp);
+const struct aucodec *aup_codec(const struct audio_recv *rp);
+uint64_t aup_latency(const struct audio_recv *rp);
+bool aup_started(const struct audio_recv *rp);
+bool aup_filt_empty(const struct audio_recv *rp);
+bool aup_level_set(const struct audio_recv *rp);
+double aup_level(const struct audio_recv *rp);
+int aup_debug(struct re_printf *pf, const struct audio_recv *rp);
+int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *rp);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -119,7 +119,7 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 struct audio_recv;
 
 int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
-	      size_t sampc);
+	      size_t sampc, uint32_t ptime);
 int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
 int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);

--- a/src/core.h
+++ b/src/core.h
@@ -120,26 +120,26 @@ struct audio_recv;
 
 int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct audio_recv *rp,
+int aup_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct audio_recv *rp, struct aufilt_dec_st *decst);
-void aup_flush(struct audio_recv *rp);
-void aup_set_extmap(struct audio_recv *rp, uint8_t aulevel);
-void aup_set_telev_pt(struct audio_recv *rp, int pt);
-void aup_receive(struct audio_recv *rp, const struct rtp_header *hdr,
+int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
+void aup_flush(struct audio_recv *ar);
+void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel);
+void aup_set_telev_pt(struct audio_recv *ar, int pt);
+void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct audio_recv *rp, struct auframe *af);
-void aup_stop(struct audio_recv *rp);
+void aup_read(struct audio_recv *ar, struct auframe *af);
+void aup_stop(struct audio_recv *ar);
 
-const struct aucodec *aup_codec(const struct audio_recv *rp);
-uint64_t aup_latency(const struct audio_recv *rp);
-bool aup_started(const struct audio_recv *rp);
-bool aup_filt_empty(const struct audio_recv *rp);
-bool aup_level_set(const struct audio_recv *rp);
-double aup_level(const struct audio_recv *rp);
-int aup_debug(struct re_printf *pf, const struct audio_recv *rp);
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *rp);
+const struct aucodec *aup_codec(const struct audio_recv *ar);
+uint64_t aup_latency(const struct audio_recv *ar);
+bool aup_started(const struct audio_recv *ar);
+bool aup_filt_empty(const struct audio_recv *ar);
+bool aup_level_set(const struct audio_recv *ar);
+double aup_level(const struct audio_recv *ar);
+int aup_debug(struct re_printf *pf, const struct audio_recv *ar);
+int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
 
 
 /*

--- a/src/core.h
+++ b/src/core.h
@@ -118,28 +118,28 @@ int aucodec_print(struct re_printf *pf, const struct aucodec *ac);
 
 struct audio_recv;
 
-int aup_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
+int aur_alloc(struct audio_recv **aupp, const struct config_audio *cfg,
 	      size_t sampc);
-int aup_decoder_set(struct audio_recv *ar,
+int aur_decoder_set(struct audio_recv *ar,
 		    const struct aucodec *ac, const char *params);
-int aup_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
-void aup_flush(struct audio_recv *ar);
-void aup_set_extmap(struct audio_recv *ar, uint8_t aulevel);
-void aup_set_telev_pt(struct audio_recv *ar, int pt);
-void aup_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+int aur_filt_append(struct audio_recv *ar, struct aufilt_dec_st *decst);
+void aur_flush(struct audio_recv *ar);
+void aur_set_extmap(struct audio_recv *ar, uint8_t aulevel);
+void aur_set_telev_pt(struct audio_recv *ar, int pt);
+void aur_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		 struct rtpext *extv, size_t extc,
 		 struct mbuf *mb, unsigned lostc, bool *ignore);
-void aup_read(struct audio_recv *ar, struct auframe *af);
-void aup_stop(struct audio_recv *ar);
+void aur_read(struct audio_recv *ar, struct auframe *af);
+void aur_stop(struct audio_recv *ar);
 
-const struct aucodec *aup_codec(const struct audio_recv *ar);
-uint64_t aup_latency(const struct audio_recv *ar);
-bool aup_started(const struct audio_recv *ar);
-bool aup_filt_empty(const struct audio_recv *ar);
-bool aup_level_set(const struct audio_recv *ar);
-double aup_level(const struct audio_recv *ar);
-int aup_debug(struct re_printf *pf, const struct audio_recv *ar);
-int aup_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
+const struct aucodec *aur_codec(const struct audio_recv *ar);
+uint64_t aur_latency(const struct audio_recv *ar);
+bool aur_started(const struct audio_recv *ar);
+bool aur_filt_empty(const struct audio_recv *ar);
+bool aur_level_set(const struct audio_recv *ar);
+double aur_level(const struct audio_recv *ar);
+int aur_debug(struct re_printf *pf, const struct audio_recv *ar);
+int aur_print_pipeline(struct re_printf *pf, const struct audio_recv *ar);
 
 
 /*

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -460,6 +460,8 @@ int rtprecv_alloc(struct rtp_receiver **rxp,
 	rx->pt     = -1;
 	err  = str_dup(&rx->name, name);
 	err |= mutex_alloc(&rx->mtx);
+	if (err)
+		goto out;
 
 	/* Audio Jitter buffer */
 	if (stream_type(strm) == MEDIA_AUDIO &&
@@ -476,17 +478,19 @@ int rtprecv_alloc(struct rtp_receiver **rxp,
 
 		err = jbuf_alloc(&rx->jbuf, cfg->video.jbuf_del.min,
 				 cfg->video.jbuf_del.max);
-		err |= jbuf_set_type(rx->jbuf, cfg->video.jbtype);
+		if (err)
+			goto out;
+
+		err = jbuf_set_type(rx->jbuf, cfg->video.jbtype);
+		if (err)
+			goto out;
 	}
 
 	rx->metric = metric_alloc();
 	if (!rx->metric)
-		err |= ENOMEM;
+		err = ENOMEM;
 	else
-		err |= metric_init(rx->metric);
-
-	if (err)
-		goto out;
+		err = metric_init(rx->metric);
 
 out:
 	if (err)

--- a/src/video.c
+++ b/src/video.c
@@ -277,6 +277,8 @@ static void video_destructor(void *arg)
 	struct vtx *vtx = &v->vtx;
 	struct vrx *vrx = &v->vrx;
 
+	stream_enable(v->strm, false);
+
 	/* transmit */
 	if (re_atomic_rlx(&vtx->run)) {
 		re_atomic_rlx_set(&vtx->run, false);


### PR DESCRIPTION
- audio: separate aureceiver
- aureceiver: simplify logging of over/underruns
- aup: concurrency safe check if aubuf exists
- aup: use atomic instead mtx lock for latency
- audio: fix sanitizer warning in auplay_write_handler
- aucodec: move aucodec_print to internal API
- audio/video: disable stream in destructor
- aup: correctly read/write atomic
- aup: check atomic ready flag instead of aubuf pointer
- aup: replace atomic by mtx avoids thread sanitizer warnings
- aur: rename aurpipe to audio_recv
- aur: rename audio_recv pointer from rp to ar
- aur: rename functin prefix aup_ to aur_
- audio,aur: measure SW decoding jitter
- aur: print times in ms float numbers
- audio: rename pointer aup to aur
- rtprecv: correct error handling
