### PR TITLE
audio: fix inbound dtmf END event

### DIFF
--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -223,14 +223,9 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 	}
 	mtx_unlock(rx->mtx);
 
-	/* payload-type changed? */
-	if (hdr->pt != rx->pt) {
-		rx->pt = hdr->pt;
-
-		err = rx->pth(hdr->pt, mb, rx->arg);
-		if (err && err != ENODATA)
-			return;
-	}
+	err = rx->pth(hdr->pt, mb, rx->arg);
+	if (err && err != ENODATA)
+		return;
 
 	if (rx->jbuf) {
 


### PR DESCRIPTION
DTMF END is missing when registered to Asterisk.

Asterisk sends less RTP EVENT packets than baresip and does not mix audio RTP packets and DTMF packets like baresip. If the "DTMF end" follows directly a normal DTMF packet than it was not recognized.

- call `stream_pt_handler()` always
- `stream_pt_handler()` in audio and video have a lightweight check at top
- NULL pointer check of audio.rx is not needed

Alternative check with less lines, but more difficult to read:
```c
	if (pt == rx->pt && (!rx->pt_tel || pt != rx->pt_tel))
		return 0;
```

Does somebody prefer the shorter check?