### PR TITLE
menu: add follow up invite timer

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -470,7 +470,12 @@ static void invite_handler(void *arg)
 	if (!str_isset(uri))
 		return;
 
-	ua_connect(uag_find_requri(uri), NULL, NULL, uri, VIDMODE_ON);
+	int err;
+	err = ua_connect(uag_find_requri(uri), NULL, NULL, uri, VIDMODE_ON);
+	if (err)
+		warning("menu: call to %s failed (%m)\n", menu.invite_uri,
+			err);
+
 	menu.invite_uri = mem_deref(menu.invite_uri);
 }
 

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -22,12 +22,14 @@ struct menu{
 	bool ringback_disabled;       /**< no ringback on sip 180 respons */
 	bool ringback;                /**< Ringback played currently      */
 	struct tmr tmr_redial;        /**< Timer for auto-reconnect       */
+	struct tmr tmr_invite;        /**< Timer for follow up invite     */
 	uint32_t redial_delay;        /**< Redial delay in [seconds]      */
 	uint32_t redial_attempts;     /**< Number of re-dial attempts     */
 	uint32_t current_attempts;    /**< Current number of re-dials     */
 	uint64_t start_ticks;         /**< Ticks when app started         */
 	enum statmode statmode;       /**< Status mode                    */
 	bool clean_number;            /**< Remove -/() from diald numbers */
+	char *invite_uri;             /**< Follow up invite URI           */
 	char redial_aor[128];
 	int32_t adelay;               /**< Outgoing auto answer delay     */
 	char *ansval;                 /**< Call-Info/Alert-Info value     */


### PR DESCRIPTION
This change fixes an issue that occurs by calling `ua_connect()` in the UA
event handler. The OUTGOING event was sent to the application before the
REFER or REDIRECT events that should trigger a follow up SIP call.

The UA events should be sent in this order to the application:
- REFER, then OUTGOING
- REDIRECT, then OUTGOING
