### PR TITLE
Decode url in custom header

### DIFF
--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -1275,6 +1275,7 @@ static int cmd_addheader(struct re_printf *pf, void *arg)
 	const char *usage = "usage: /uaaddheader <key>=<value> <ua-idx>\n";
 	struct pl n, v;
 	int err;
+	int ret;
 
 	if (!ua) {
 		re_hprintf(pf, usage);
@@ -1289,13 +1290,16 @@ static int cmd_addheader(struct re_printf *pf, void *arg)
 	}
 
 	struct mbuf mbe;
-	err = mbuf_printf(&mbe, "%H", uri_header_unescape, &v);
-	if (err == 0) {
+	mbuf_init(&mbe);
+	ret = mbuf_printf(&mbe, "%H", uri_header_unescape, &v);
+	if (ret == 0) {
 		v.p = (const char *)mbe.buf;
 		v.l = mbe.end;
 	}
 
-	return ua_add_custom_hdr(ua, &n, &v);
+	ret = ua_add_custom_hdr(ua, &n, &v);
+	mem_deref(mbe.buf);
+	return ret;
 }
 
 


### PR DESCRIPTION
**Problem:**
utilize /uaaddheader to add a custom header
usage: /uaaddheader <key>=<value> <ua-idx>
So that it is impossible to custom header containing space (' '). 
**My solution:**
implement decode URL format before pushing to custom headers