### PR TITLE
sipsess: refactor and simplify SDP negotiation state

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -264,9 +264,9 @@ const char   *call_user_data(const struct call *call);
 int call_set_user_data(struct call *call, const char *user_data);
 void call_set_evstop(struct call *call, bool stop);
 bool call_is_evstop(struct call *call);
-bool call_sent_answer(const struct call *call);
 int call_msg_src(const struct call *call, struct sa *sa);
 enum sip_transp call_transp(const struct call *call);
+enum sdp_neg_state call_sdp_neg_state(const struct call *call);
 
 /*
  * Custom headers

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -267,6 +267,7 @@ bool call_is_evstop(struct call *call);
 int call_msg_src(const struct call *call, struct sa *sa);
 enum sip_transp call_transp(const struct call *call);
 enum sdp_neg_state call_sdp_neg_state(const struct call *call);
+bool call_sdp_change_allowed(const struct call *call);
 
 /*
  * Custom headers

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -158,9 +158,10 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 
-	if (call_sent_answer(call))
-		(void)call_set_media_estdir(call, adir, vdir);
-	else
+	(void)call_set_media_estdir(call, adir, vdir);
+
+	enum sdp_neg_state sdp_state = call_sdp_neg_state(call);
+	if (sdp_state == SDP_NEG_NONE || sdp_state == SDP_NEG_REMOTE_OFFER)
 		(void)call_set_media_direction(call, adir, vdir);
 
 	err = answer_call(ua, call);

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -160,8 +160,7 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 
 	(void)call_set_media_estdir(call, adir, vdir);
 
-	enum sdp_neg_state sdp_state = call_sdp_neg_state(call);
-	if (sdp_state == SDP_NEG_NONE || sdp_state == SDP_NEG_REMOTE_OFFER)
+	if (call_sdp_change_allowed(call))
 		(void)call_set_media_direction(call, adir, vdir);
 
 	err = answer_call(ua, call);

--- a/src/call.c
+++ b/src/call.c
@@ -3232,10 +3232,30 @@ enum sip_transp call_transp(const struct call *call)
  *
  * @param call Call object
  *
- * @return 0 on success, non-zero otherwise
  * @return SDP negotiation state
  */
 enum sdp_neg_state call_sdp_neg_state(const struct call *call)
 {
 	return call ? sipsess_sdp_neg_state(call->sess) : SDP_NEG_NONE;
+}
+
+
+/**
+ * Check if an SDP change is allowed currently
+ *
+ * @param call Call object
+ *
+ * @return true if SDP change is currently allowed, false otherwise
+ */
+bool call_sdp_change_allowed(const struct call *call)
+{
+	if (!call)
+		return false;
+
+	enum sdp_neg_state sdp_state = call_sdp_neg_state(call);
+
+	return (call->state == CALL_STATE_ESTABLISHED
+		&& sdp_state == SDP_NEG_DONE)
+		|| (sdp_state == SDP_NEG_NONE
+		|| sdp_state == SDP_NEG_REMOTE_OFFER);
 }

--- a/src/ua.c
+++ b/src/ua.c
@@ -1317,7 +1317,8 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 		goto out;
 
 	if (adir != SDP_SENDRECV || vdir != SDP_SENDRECV) {
-		err = call_set_media_direction(call, adir, vdir);
+		err = call_set_media_estdir(call, adir, vdir);
+		err |= call_set_media_direction(call, adir, vdir);
 		if (err) {
 			mem_deref(call);
 			goto out;

--- a/test/call.c
+++ b/test/call.c
@@ -1677,7 +1677,9 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 1, 0);
 	cr->prm = "answer";
 
-	err = call_set_media_direction(ua_call(f->a.ua), SDP_INACTIVE,
+	err = call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE,
+				    SDP_INACTIVE);
+	err |= call_set_media_direction(ua_call(f->a.ua), SDP_INACTIVE,
 				       SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));
@@ -1703,7 +1705,9 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 
 	f->a.n_auframe=0;
 	f->b.n_auframe=0;
-	err = call_set_media_direction(ua_call(f->a.ua), SDP_SENDRECV,
+	err = call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE,
+				    SDP_INACTIVE);
+	err |= call_set_media_direction(ua_call(f->a.ua), SDP_SENDRECV,
 				       SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));


### PR DESCRIPTION
fix and simplify SDP negotiation state handling

The bool sent_answer is removed and instead the sdp_neg_state of the sipsess is used which accurately tracks the state of the SDP negotiation.

Further, call_set_mdir was removed and unified in call_set_media_direction.

Related re PR:

- https://github.com/baresip/re/pull/1016