### PR TITLE
pulse: log underruns/overruns after stream terminated

### DIFF
--- a/modules/pulse/pastream.c
+++ b/modules/pulse/pastream.c
@@ -80,6 +80,9 @@ static void pastream_destructor(void *arg)
 	}
 
 	pa_threaded_mainloop_unlock(c->mainloop);
+
+	info("pulse: %s [overrun=%zu underrun=%zu]\n",
+	     st->sname, st->stats.overrun, st->stats.underrun);
 }
 
 
@@ -104,7 +107,7 @@ static void stream_underflow_cb(pa_stream *s, void *arg)
 	(void)s;
 
 	if (!st->shutdown)
-		warning("pulse: stream %s underrun\n",  st->sname);
+		++st->stats.underrun;
 }
 
 
@@ -113,7 +116,7 @@ static void stream_overflow_cb(pa_stream *s, void *arg)
 	struct pastream_st *st = arg;
 	(void)s;
 
-	warning("pulse: stream %s overrun\n", st->sname);
+	++st->stats.overrun;
 }
 
 

--- a/modules/pulse/pulse.h
+++ b/modules/pulse/pulse.h
@@ -31,6 +31,11 @@ struct pastream_st {
 	pa_sample_spec ss;
 	pa_buffer_attr attr;
 	pa_stream_direction_t direction;
+
+	struct {
+		size_t overrun;
+		size_t underrun;
+	} stats;
 };
 
 


### PR DESCRIPTION
Only the main thread should write to stdout
