### PR TITLE
misc: rx thread activate

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,4 +43,4 @@ jobs:
       run: cmake -B build -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: valgrind test
-      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest
+      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest -v

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,4 +43,4 @@ jobs:
       run: cmake -B build -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: valgrind test
-      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest -v
+      run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -72,6 +72,7 @@ video_jitter_buffer_delay	5-10	# (min. frames)-(max. packets)
 rtp_stats		no
 #rtp_timeout		60
 #avt_bundle		no
+#rtp_rxmode		main            # main,thread
 
 # Network
 #dns_server		1.1.1.1:53

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -334,6 +334,10 @@ enum rtp_receive_mode {
 	RECEIVE_MODE_THREAD,    /**< RTP RX is processed in separate thread  */
 };
 
+enum rtp_receive_mode resolve_receive_mode(const struct pl *fmt);
+const char *rtp_receive_mode_str(enum rtp_receive_mode rxmode);
+
+
 /** SIP User-Agent */
 struct config_sip {
 	char uuid[64];          /**< Universally Unique Identifier  */

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -328,6 +328,12 @@ enum audio_mode {
 	AUDIO_MODE_THREAD,           /**< Use dedicated thread          */
 };
 
+/** RTP receive mode */
+enum rtp_receive_mode {
+	RECEIVE_MODE_MAIN = 0,  /**< RTP RX is processed in main thread      */
+	RECEIVE_MODE_THREAD,    /**< RTP RX is processed in separate thread  */
+};
+
 /** SIP User-Agent */
 struct config_sip {
 	char uuid[64];          /**< Universally Unique Identifier  */
@@ -406,6 +412,7 @@ struct config_avt {
 	bool rtp_stats;         /**< Enable RTP statistics          */
 	uint32_t rtp_timeout;   /**< RTP Timeout in seconds (0=off) */
 	bool bundle;            /**< Media Multiplexing (BUNDLE)    */
+	enum rtp_receive_mode rxmode;   /**< RTP RX processing mode */
 };
 
 /** Network Configuration */

--- a/src/audio.c
+++ b/src/audio.c
@@ -1256,6 +1256,7 @@ void audio_stop(struct audio *a)
 		return;
 
 	stop_tx(&a->tx, a);
+	stream_enable(a->strm, false);
 	stop_aur(a->aur);
 	a->started = false;
 }

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -292,9 +292,11 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 	if (!mb)
 		goto out;
 
+	mtx_lock(ar->mtx);
 	if (hdr->pt != ar->pt) {
+		mtx_unlock(ar->mtx);
 		*ignore = true;
-		return;
+		goto unlock;
 	}
 
 	*ignore = false;
@@ -349,6 +351,9 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 /*                (void)aurecv_stream_decode(ar, hdr, mb, lostc, drop);*/
 
 	(void)aurecv_stream_decode(ar, hdr, mb, 0, drop);
+
+unlock:
+	mtx_unlock(ar->mtx);
 }
 
 
@@ -357,7 +362,9 @@ void aurecv_set_extmap(struct audio_recv *ar, uint8_t aulevel)
 	if (!ar)
 		return;
 
+	mtx_lock(ar->mtx);
 	ar->extmap_aulevel = aulevel;
+	mtx_unlock(ar->mtx);
 }
 
 
@@ -435,10 +442,10 @@ void aurecv_flush(struct audio_recv *ar)
 	if (!ar)
 		return;
 
+	mtx_lock(ar->mtx);
 	aubuf_flush(ar->aubuf);
 
 	/* Reset audio filter chain */
-	mtx_lock(ar->mtx);
 	list_flush(&ar->filtl);
 	mtx_unlock(ar->mtx);
 }
@@ -455,6 +462,7 @@ int aurecv_decoder_set(struct audio_recv *ar,
 	info("audio: Set audio decoder: %s %uHz %dch\n",
 	     ac->name, ac->srate, ac->ch);
 
+	mtx_lock(ar->mtx);
 	if (ac != ar->ac) {
 		ar->ac = ac;
 		ar->dec = mem_deref(ar->dec);
@@ -471,6 +479,7 @@ int aurecv_decoder_set(struct audio_recv *ar,
 	ar->pt = pt;
 
 out:
+	mtx_unlock(ar->mtx);
 	return err;
 }
 
@@ -517,7 +526,9 @@ bool aurecv_level_set(const struct audio_recv *ar)
 	if (!ar)
 		return false;
 
+	mtx_lock(ar->mtx);
 	set = ar->level_set;
+	mtx_unlock(ar->mtx);
 
 	return set;
 }
@@ -529,7 +540,9 @@ double aurecv_level(const struct audio_recv *ar)
 	if (!ar)
 		return 0.0;
 
+	mtx_lock(ar->mtx);
 	v = ar->level_last;
+	mtx_unlock(ar->mtx);
 
 	return v;
 }
@@ -542,7 +555,9 @@ const struct aucodec *aurecv_codec(const struct audio_recv *ar)
 	if (!ar)
 		return NULL;
 
+	mtx_lock(ar->mtx);
 	ac = ar->ac;
+	mtx_unlock(ar->mtx);
 	return ac;
 }
 
@@ -567,7 +582,9 @@ void aurecv_stop(struct audio_recv *ar)
 		return;
 
 	ar->auplay = mem_deref(ar->auplay);
+	mtx_lock(ar->mtx);
 	ar->ac = NULL;
+	mtx_unlock(ar->mtx);
 }
 
 
@@ -713,6 +730,7 @@ int aurecv_debug(struct re_printf *pf, const struct audio_recv *ar)
 		goto out;
 	}
 
+	mtx_lock(ar->mtx);
 	bpms = (double)ar->srate * ar->ch * aufmt_sample_size(ar->fmt) /
 	       1000.0;
 	err  = mbuf_printf(mb,
@@ -750,6 +768,8 @@ int aurecv_debug(struct re_printf *pf, const struct audio_recv *ar)
 			  ar->ap ? ar->ap->name : "none",
 			  ar->device,
 			  aufmt_name(ar->play_fmt));
+	mtx_unlock(ar->mtx);
+
 	if (err)
 		goto out;
 

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -290,13 +290,13 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 	(void) lostc;
 
 	if (!mb)
-		goto out;
+		return;
 
 	mtx_lock(ar->mtx);
 	if (hdr->pt != ar->pt) {
 		mtx_unlock(ar->mtx);
 		*ignore = true;
-		goto unlock;
+		return;
 	}
 
 	*ignore = false;
@@ -342,7 +342,6 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		return;
 	}
 
- out:
 	/* TODO:  what if lostc > 1 ?*/
 	/* PLC should generate lostc frames here. Not only one.
 	 * aubuf should replace PLC frames with late arriving real frames.
@@ -352,7 +351,6 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 
 	(void)aurecv_stream_decode(ar, hdr, mb, 0, drop);
 
-unlock:
 	mtx_unlock(ar->mtx);
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -474,10 +474,14 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
 	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
 
-		if (0 == pl_strcasecmp(&rxmode, "thread")) {
+		if (0 == pl_strcasecmp(&rxmode, "main")) {
+			cfg->avt.rxmode = RECEIVE_MODE_MAIN;
+		} else if (0 == pl_strcasecmp(&rxmode, "thread")) {
 			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
 			warning("rtp_rxmode thread is currently "
 				"experimental\n");
+		} else {
+			warning("rtp_rxmode %r is not supported\n", &rxmode);
 		}
 	}
 

--- a/src/config.c
+++ b/src/config.c
@@ -184,7 +184,7 @@ static enum aufmt resolve_aufmt(const struct pl *fmt)
 }
 
 
-static enum rtp_receive_mode resolve_receive_mode(const struct pl *fmt)
+enum rtp_receive_mode resolve_receive_mode(const struct pl *fmt)
 {
 	if (0 == pl_strcasecmp(fmt, "main"))     return RECEIVE_MODE_MAIN;
 	if (0 == pl_strcasecmp(fmt, "thread")) {
@@ -198,7 +198,7 @@ static enum rtp_receive_mode resolve_receive_mode(const struct pl *fmt)
 }
 
 
-static const char *rtp_receive_mode_str(enum rtp_receive_mode rxmode)
+const char *rtp_receive_mode_str(enum rtp_receive_mode rxmode)
 {
 	switch (rxmode) {
 	case RECEIVE_MODE_MAIN:

--- a/src/config.c
+++ b/src/config.c
@@ -98,7 +98,8 @@ static struct config core_config = {
 		},
 		false,
 		0,
-		false
+		false,
+		RECEIVE_MODE_MAIN,
 	},
 
 	/* Network */
@@ -313,6 +314,7 @@ static const char *net_af_str(int af)
 int config_parse_conf(struct config *cfg, const struct conf *conf)
 {
 	struct vidsz size = {0, 0};
+	struct pl rxmode;
 	struct pl txmode;
 	struct pl jbtype;
 	struct pl tr;
@@ -470,6 +472,14 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 	(void)conf_get_u32(conf, "rtp_timeout", &cfg->avt.rtp_timeout);
 
 	(void)conf_get_bool(conf, "avt_bundle", &cfg->avt.bundle);
+	if (0 == conf_get(conf, "rtp_rxmode", &rxmode)) {
+
+		if (0 == pl_strcasecmp(&rxmode, "thread")) {
+			cfg->avt.rxmode = RECEIVE_MODE_THREAD;
+			warning("rtp_rxmode thread is currently "
+				"experimental\n");
+		}
+	}
 
 	if (err) {
 		warning("config: configure parse error (%m)\n", err);
@@ -616,6 +626,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "rtp_stats\t\t%s\n"
 			 "rtp_timeout\t\t%u # in seconds\n"
 			 "avt_bundle\t\t%s\n"
+			 "rtp_rxmode\t\t\t%s\n"
 			 "\n"
 			 "# Network\n"
 			 "net_interface\t\t%s\n"
@@ -633,6 +644,8 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 cfg->avt.rtp_stats ? "yes" : "no",
 			 cfg->avt.rtp_timeout,
 			 cfg->avt.bundle ? "yes" : "no",
+			 cfg->avt.rxmode == RECEIVE_MODE_THREAD ? "thread" :
+								  "main",
 
 			 cfg->net.ifname,
 			 net_af_str(cfg->net.af)
@@ -843,6 +856,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "rtp_stats\t\tno\n"
 			  "#rtp_timeout\t\t60\n"
 			  "#avt_bundle\t\tno\n"
+			  "#rtp_rxmode\t\tmain\n"
 			  "\n# Network\n"
 			  "#dns_server\t\t1.1.1.1:53\n"
 			  "#dns_server\t\t1.0.0.1:53\n"

--- a/src/core.h
+++ b/src/core.h
@@ -517,4 +517,6 @@ int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
 int  rtprecv_start_thread(struct rtp_receiver *rx);
 void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 				    const struct sa *raddr2, void *arg);
+int  rtprecv_start_rtcp(struct rtp_receiver *rx, const char *cname,
+			const struct sa *peer, bool pinhole);
 bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/core.h
+++ b/src/core.h
@@ -514,5 +514,7 @@ void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);
+int  rtprecv_start_thread(struct rtp_receiver *rx);
 void rtprecv_mnat_connected_handler(const struct sa *raddr1,
 				    const struct sa *raddr2, void *arg);
+bool rtprecv_running(const struct rtp_receiver *rx);

--- a/src/core.h
+++ b/src/core.h
@@ -510,7 +510,7 @@ void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc);
 uint64_t rtprecv_ts_last(struct rtp_receiver *rx);
 void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last);
 void rtprecv_flush(struct rtp_receiver *rx);
-void rtprecv_set_enable(struct rtp_receiver *rx, bool enable);
+void rtprecv_enable(struct rtp_receiver *rx, bool enable);
 int  rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc);
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable);
 int  rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -705,16 +705,16 @@ int rtprecv_start_thread(struct rtp_receiver *rx)
 	if (re_atomic_rlx(&rx->run))
 		return 0;
 
+	udp_thread_detach(rtp_sock(rx->rtp));
+	udp_thread_detach(rtcp_sock(rx->rtp));
 	re_atomic_rlx_set(&rx->run, true);
 	err = thread_create_name(&rx->thr,
 				 "RX thread",
 				 rtprecv_thread, rx);
 	if (err) {
 		re_atomic_rlx_set(&rx->run, false);
-	}
-	else {
-		udp_thread_detach(rtp_sock(rx->rtp));
-		udp_thread_detach(rtcp_sock(rx->rtp));
+		udp_thread_attach(rtp_sock(rx->rtp));
+		udp_thread_attach(rtcp_sock(rx->rtp));
 	}
 
 	return err;

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -173,8 +173,8 @@ static void rtprecv_periodic(void *arg)
 		if (rx->start_rtcp) {
 			int err = 0;
 			rx->start_rtcp = false;
-			mtx_unlock(rx->mtx);
 			rtcp_start(rx->rtp, rx->cname, &rx->rtcp_peer);
+			mtx_unlock(rx->mtx);
 			if (pinhole) {
 				err = rtcp_send_app(rx->rtp, "PING",
 						    (void *)"PONG", 4);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -160,10 +160,14 @@ static void rtprecv_check_stop(void *arg)
 {
 	struct rtp_receiver *rx = arg;
 
-	if (re_atomic_rlx(&rx->run))
+	if (re_atomic_rlx(&rx->run)) {
 		tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
-	else
+	}
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
 		re_cancel();
+	}
 }
 
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -177,6 +177,7 @@ static int rtprecv_thread(void *arg)
 	int err;
 
 	re_thread_init();
+	info("rtp_receiver: RTP RX thread started\n");
 	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
 
 	err = udp_thread_attach(rtp_sock(rx->rtp));

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -180,12 +180,18 @@ static int rtprecv_thread(void *arg)
 	tmr_start(&rx->tmr, 10, rtprecv_check_stop, rx);
 
 	err = udp_thread_attach(rtp_sock(rx->rtp));
-	if (err)
+	if (err) {
+		warning("rtp_receiver: could not attach to RTP socket (%m)\n",
+			err);
 		return err;
+	}
 
 	err = udp_thread_attach(rtcp_sock(rx->rtp));
-	if (err)
+	if (err) {
+		warning("rtp_receiver: could not attach to RTCP socket (%m)\n",
+			err);
 		return err;
+	}
 
 	err = re_main(NULL);
 
@@ -240,7 +246,7 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 
 		size_t ext_len = hdr->x.len*sizeof(uint32_t);
 		if (mb->pos < ext_len) {
-			warning("stream: corrupt rtp packet,"
+			warning("rtp_receiver: corrupt rtp packet,"
 				" not enough space for rtpext of %zu bytes\n",
 				ext_len);
 			return 0;
@@ -253,8 +259,8 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 
 			err = rtpext_decode(&extv[i], mb);
 			if (err) {
-				warning("stream: rtpext_decode failed (%m)\n",
-					err);
+				warning("rtp_receiver: rtpext_decode failed "
+					"(%m)\n", err);
 				return 0;
 			}
 		}

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -346,10 +346,10 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 	bool first = false;
 	int err = 0;
 
-	MAGIC_CHECK(rx);
 	if (!rx)
 		return;
 
+	MAGIC_CHECK(rx);
 	mtx_lock(rx->mtx);
 	if (!rx->enabled) {
 		mtx_unlock(rx->mtx);
@@ -500,6 +500,10 @@ uint64_t rtprecv_ts_last(struct rtp_receiver *rx)
 		return 0;
 
 	uint64_t ts_last;
+
+	if (!rx)
+		return 0;
+
 	mtx_lock(rx->mtx);
 	ts_last = rx->ts_last;
 	mtx_unlock(rx->mtx);
@@ -528,7 +532,7 @@ void rtprecv_flush(struct rtp_receiver *rx)
 }
 
 
-void rtprecv_set_enable(struct rtp_receiver *rx, bool enable)
+void rtprecv_enable(struct rtp_receiver *rx, bool enable)
 {
 	if (!rx)
 		return;
@@ -604,9 +608,12 @@ static void destructor(void *arg)
 	if (re_atomic_rlx(&rx->run)) {
 		re_atomic_rlx_set(&rx->run, false);
 		thrd_join(rx->thr, NULL);
+		re_thread_async_main_cancel((intptr_t)rx);
 	}
-
-	re_thread_async_main_cancel((intptr_t)rx);
+	else {
+		udp_thread_detach(rtp_sock(rx->rtp));
+		udp_thread_detach(rtcp_sock(rx->rtp));
+	}
 
 	mem_deref(rx->metric);
 	mem_deref(rx->name);

--- a/src/stream.c
+++ b/src/stream.c
@@ -248,7 +248,7 @@ int stream_enable_rx(struct stream *strm, bool enable)
 		debug("stream: disable %s RTP receiver\n",
 		      media_name(strm->type));
 
-		rtprecv_set_enable(strm->rx, false);
+		rtprecv_enable(strm->rx, false);
 		return 0;
 	}
 
@@ -256,7 +256,7 @@ int stream_enable_rx(struct stream *strm, bool enable)
 		return ENOTSUP;
 
 	debug("stream: enable %s RTP receiver\n", media_name(strm->type));
-	rtprecv_set_enable(strm->rx, true);
+	rtprecv_enable(strm->rx, true);
 
 	if (strm->rtp && strm->cfg.rxmode == RECEIVE_MODE_THREAD &&
 	    strm->type == MEDIA_AUDIO && !rtprecv_running(strm->rx)) {

--- a/src/stream.c
+++ b/src/stream.c
@@ -42,6 +42,7 @@ struct rxmain {
 	struct tmr tmr_rtp;    /**< Timer for detecting RTP timeout  */
 	uint32_t rtp_timeout;  /**< RTP Timeout value in [ms]        */
 	struct tmr tmr_rec;    /**< Timer for rtp_receiver start     */
+	bool use_rxthread;     /**< Use RX thread flag               */
 };
 
 
@@ -266,6 +267,7 @@ int stream_enable_rx(struct stream *strm, bool enable)
 				"with avt_bundle\n");
 		}
 		else {
+			strm->rxm.use_rxthread = true;
 			tmr_start(&strm->rxm.tmr_rec, 1, stream_start_receiver,
 				  strm);
 		}
@@ -1361,7 +1363,7 @@ bool stream_is_secure(const struct stream *strm)
  */
 int stream_start_rtcp(const struct stream *strm)
 {
-	int err;
+	int err = 0;
 
 	if (!strm)
 		return EINVAL;
@@ -1369,18 +1371,26 @@ int stream_start_rtcp(const struct stream *strm)
 	debug("stream: %s: starting RTCP with remote %J\n",
 	      media_name(strm->type), &strm->tx.raddr_rtcp);
 
-	rtcp_start(strm->rtp, strm->cname, &strm->tx.raddr_rtcp);
+	if (strm->rxm.use_rxthread) {
+		err = rtprecv_start_rtcp(strm->rx, strm->cname,
+					 &strm->tx.raddr_rtcp, !strm->mnat);
+	}
+	else {
+		rtcp_start(strm->rtp, strm->cname, &strm->tx.raddr_rtcp);
 
-	if (!strm->mnat) {
-		/* Send a dummy RTCP packet to open NAT pinhole */
-		err = rtcp_send_app(strm->rtp, "PING", (void *)"PONG", 4);
-		if (err) {
-			warning("stream: rtcp_send_app failed (%m)\n", err);
-			return err;
+		if (!strm->mnat) {
+			/* Send a dummy RTCP packet to open NAT pinhole */
+			err = rtcp_send_app(strm->rtp, "PING",
+					    (void *)"PONG", 4);
+			if (err) {
+				warning("stream: rtcp_send_app failed (%m)\n",
+					err);
+				return err;
+			}
 		}
 	}
 
-	return 0;
+	return err;
 }
 
 

--- a/test/call.c
+++ b/test/call.c
@@ -1861,6 +1861,9 @@ static int test_media_base(enum audio_mode txmode)
 	ASSERT_EQ(0, fix.b.n_closed);
 
  out:
+	if (err)
+		failure_debug(f, false);
+
 	conf_config()->audio.src_fmt = AUFMT_S16LE;
 	conf_config()->audio.play_fmt = AUFMT_S16LE;
 	conf_config()->audio.txmode = AUDIO_MODE_POLL;

--- a/test/call.c
+++ b/test/call.c
@@ -2703,6 +2703,9 @@ int test_call_bundle(void)
 {
 	int err = 0;
 
+	if (conf_config()->avt.rxmode == RECEIVE_MODE_THREAD)
+		return 0;
+
 	err |= test_call_bundle_base(false, false);
 	err |= test_call_bundle_base(true,  false);
 	err |= test_call_bundle_base(false, true);

--- a/test/call.c
+++ b/test/call.c
@@ -2344,7 +2344,7 @@ static void delayed_audio_debug(void *arg)
 	ua_event(ag->ua, UA_EVENT_CUSTOM, ua_call(ag->ua), "audebug %u",
 		 ag->n_audebug);
 
-	tmr_start(&ag->tmr, 1, delayed_audio_debug, ag);
+	tmr_start(&ag->tmr, 2, delayed_audio_debug, ag);
 out:
 	if (err)
 		ag->fix->err |= err;
@@ -2389,17 +2389,17 @@ static int test_call_rtcp_base(bool rtcp_mux)
 	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
 	TEST_ERR(err);
 
-	stream_set_rtcp_interval(audio_strm(call_audio(ua_call(f->a.ua))), 1);
+	stream_set_rtcp_interval(audio_strm(call_audio(ua_call(f->a.ua))), 2);
 
 	/* wait for UA b ESTABLISHED */
 	err = re_main_timeout(5000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 
-	stream_set_rtcp_interval(audio_strm(call_audio(ua_call(f->b.ua))), 1);
+	stream_set_rtcp_interval(audio_strm(call_audio(ua_call(f->b.ua))), 2);
 	stream_start_rtcp(audio_strm(call_audio(ua_call(f->b.ua))));
-	tmr_start(&f->a.tmr, 1, delayed_audio_debug, &f->a);
-	tmr_start(&f->b.tmr, 1, delayed_audio_debug, &f->b);
+	tmr_start(&f->a.tmr, 2, delayed_audio_debug, &f->a);
+	tmr_start(&f->b.tmr, 2, delayed_audio_debug, &f->b);
 
 	/* wait for RTCP on both sides */
 	err = re_main_timeout(5000);

--- a/test/main.c
+++ b/test/main.c
@@ -10,6 +10,7 @@
 #include <baresip.h>
 #include "test.h"
 
+enum { ASYNC_WORKERS = 4 };
 
 typedef int (test_exec_h)(void);
 
@@ -192,6 +193,7 @@ int main(int argc, char *argv[])
 		return err;
 
 	log_enable_info(false);
+	re_thread_async_init(ASYNC_WORKERS);
 
 #ifdef HAVE_GETOPT
 	for (;;) {

--- a/test/main.c
+++ b/test/main.c
@@ -80,14 +80,17 @@ static const struct test tests[] = {
 
 static int run_one_test(const struct test *test)
 {
+	struct config *config = conf_config();
+	enum rtp_receive_mode rxmode = config->avt.rxmode;
 	int err;
 
-	re_printf("[ RUN      ] %s\n", test->name);
+	re_printf("[ RUN      ] %s (rx %s)\n",
+		  test->name, rtp_receive_mode_str(rxmode));
 
 	err = test->exec();
 	if (err) {
-		warning("%s: test failed (%m)\n",
-			test->name, err);
+		warning("%s (rx %s): test failed (%m)\n",
+			test->name, rtp_receive_mode_str(rxmode), err);
 		return err;
 	}
 
@@ -97,23 +100,81 @@ static int run_one_test(const struct test *test)
 }
 
 
+static int run_one_test_rxmode(const struct test *test, struct pl *rxmode)
+{
+	struct config *config = conf_config();
+	int err;
+
+	if (pl_isset(rxmode)) {
+		config->avt.rxmode = resolve_receive_mode(rxmode);
+		err = run_one_test(test);
+		if (err)
+			return err;
+	}
+	else {
+		config->avt.rxmode = RECEIVE_MODE_MAIN;
+		err = run_one_test(test);
+		if (err)
+			return err;
+
+		config->avt.rxmode = RECEIVE_MODE_THREAD;
+		err = run_one_test(test);
+		if (err)
+			return err;
+	}
+
+	return 0;
+}
+
+
 static int run_tests(void)
 {
 	size_t i;
+	struct config *config = conf_config();
+	enum rtp_receive_mode rxmode = config->avt.rxmode;
 	int err;
 
 	for (i=0; i<RE_ARRAY_SIZE(tests); i++) {
 
-		re_printf("[ RUN      ] %s\n", tests[i].name);
+		re_printf("[ RUN      ] %s (rx %s)\n",
+			  tests[i].name, rtp_receive_mode_str(rxmode));
 
 		err = tests[i].exec();
 		if (err) {
-			warning("%s: test failed (%m)\n",
-				tests[i].name, err);
+			warning("%s (rx %s): test failed (%m)\n",
+				tests[i].name, rtp_receive_mode_str(rxmode),
+				err);
 			return err;
 		}
 
 		re_printf("[       OK ]\n");
+	}
+
+	return 0;
+}
+
+
+static int run_tests_rxmode(struct pl *rxmode)
+{
+	struct config *config = conf_config();
+	int err;
+
+	if (pl_isset(rxmode)) {
+		config->avt.rxmode = resolve_receive_mode(rxmode);
+		err = run_tests();
+		if (err)
+			return err;
+	}
+	else {
+		config->avt.rxmode = RECEIVE_MODE_MAIN;
+		err = run_tests();
+		if (err)
+			return err;
+
+		config->avt.rxmode = RECEIVE_MODE_THREAD;
+		err = run_tests();
+		if (err)
+			return err;
 	}
 
 	return 0;
@@ -168,6 +229,8 @@ static void usage(void)
 			 "Usage: selftest [options] <testcases..>\n"
 			 "options:\n"
 			 "\t-l               List all testcases and exit\n"
+			 "\t-r <rxmode>      RTP RX processing mode "
+			 "[main, thread]\n"
 			 "\t-v               Verbose output (INFO level)\n"
 			 );
 }
@@ -184,6 +247,7 @@ int main(int argc, char *argv[])
 	size_t ntests;
 	struct sa sa;
 	bool verbose = false;
+	struct pl rxmode = PL_INIT;
 	int err;
 
 	libre_exception_btrace(true);
@@ -197,7 +261,7 @@ int main(int argc, char *argv[])
 
 #ifdef HAVE_GETOPT
 	for (;;) {
-		const int c = getopt(argc, argv, "hlv");
+		const int c = getopt(argc, argv, "hlvr:");
 		if (0 > c)
 			break;
 
@@ -211,6 +275,10 @@ int main(int argc, char *argv[])
 		case 'l':
 			test_listcases();
 			return 0;
+
+		case 'r':
+			pl_set_str(&rxmode, optarg);
+			break;
 
 		case 'v':
 			if (verbose)
@@ -271,7 +339,7 @@ int main(int argc, char *argv[])
 
 			test = find_test(name);
 			if (test) {
-				err = run_one_test(test);
+				err = run_one_test_rxmode(test, &rxmode);
 				if (err)
 					goto out;
 			}
@@ -285,12 +353,12 @@ int main(int argc, char *argv[])
 		}
 	}
 	else {
-		err = run_tests();
+		err = run_tests_rxmode(&rxmode);
 		if (err)
 			goto out;
 	}
 #else
-	err = run_tests();
+	err = run_tests_rxmode(&rxmode);
 	if (err)
 		goto out;
 #endif


### PR DESCRIPTION
The last part for the audio RX "real-time" thread.

Enables RX thread via config, uses worker for passing work to the main thread and adds tests to ensure thread safety.

- stream,rtprecv: activate RX thread via config
- test: run call tests with RX_MODE_THREAD
- test: main - init async workers
- rtprecv: detach from RTP/RTCP sockets before re_cancel
- stream,rtprecv: detach from RTP/RTCP also in RECEIVE_MODE_MAIN
- test: call - add AUDIO_MODE_THREAD for test_call_aufilt
- test: call - reset to RECEIVE_MODE_MAIN
- rtprecv: use enable flag to prevent data race on stream termination
- test: call - do not test unsupported combination
- test: call - failure debug for test_media_base()
- rtprecv: detach sockets before attach
- rtprecv: warnings for UDP thread attach
- aur: add mutex locks
- aur: add aubuf_mtx
