### PR TITLE
menu autoanswer handling

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -349,13 +349,10 @@ static bool menu_play(const struct call *call,
 
 static void play_incoming(const struct call *call)
 {
-	enum answermode am = account_answermode(call_account(call));
-
 	/* stop any ringtones */
 	menu_stop_play();
 
-	if (am != ANSWERMODE_MANUAL && (am != ANSWERMODE_EARLY_VIDEO &&
-		call_early_video_available(call)))
+	if (call_state(call) != CALL_STATE_INCOMING)
 		return;
 
 	if (menu_find_call(active_call_test, call)) {
@@ -807,6 +804,10 @@ static void ua_event_handler(struct ua *ua, enum ua_event ev,
 				tmr_start(&menu.tmr_play, 0,
 					  delayed_play, NULL);
 			}
+		}
+		else if (call_state(call) == CALL_STATE_ESTABLISHED) {
+			tmr_start(&menu.tmr_play, 0,
+				  delayed_play, NULL);
 		}
 
 		hash_apply(menu.ovaufile->ht, ovaufile_del, call);


### PR DESCRIPTION
- menu: avoid parallel established calls with autoanswer
- menu: fix call waiting tone for auto-answer

When `;answermode=auto` is set for the account the expected behavior is:
- If there is an established call, ignore the auto answer setting. --> start call-waiting tone
- If there is an outgoing call, then terminate the outgoing call and answer the incoming call immediately.
