### PR TITLE
cmake: bump minimum to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # Versioning
 #
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 
 project(baresip VERSION 3.7.0)
 


### PR DESCRIPTION
CMake 3.28 is latest version: https://cmake.org/download/
