### PR TITLE
readme: update supported OpenSSL/LibreSSL versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,10 +415,8 @@ x11           X11 video output driver
 
 ### Supported versions of OpenSSL
 
-* OpenSSL version 1.1.0
 * OpenSSL version 1.1.1
-* OpenSSL version 3.0.x
-* LibreSSL version 2.x
+* OpenSSL version 3.x.x
 * LibreSSL version 3.x
 
 

--- a/modules/debug_cmd/debug_cmd.c
+++ b/modules/debug_cmd/debug_cmd.c
@@ -57,12 +57,7 @@ static int print_system_info(struct re_printf *pf, void *arg)
 	err |= re_hprintf(pf, " Compiler: %s\n", __VERSION__);
 #endif
 
-#if defined (USE_OPENSSL) && (OPENSSL_VERSION_NUMBER < 0x10100000L)
-	err |= re_hprintf(pf, " OpenSSL:  %s\n",
-			  SSLeay_version(SSLEAY_VERSION));
-#endif
-
-#if defined (USE_OPENSSL) && (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#ifdef USE_OPENSSL
 	err |= re_hprintf(pf, " OpenSSL:  %s\n",
 			  OpenSSL_version(OPENSSL_VERSION));
 #endif


### PR DESCRIPTION
As libre requires OpenSSL >= 1.1.1 or LibreSSL 3.x, I am unable to build baresip (requiring libre) against something older…

Additionally: Output of cmake while building baresip:

> -- Found OpenSSL: /usr/lib64/openssl3/libcrypto.so (found suitable version "3.0.7", minimum required is "1.1.1")  