### PR TITLE
readme: update supported compiler versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,8 @@ x11           X11 video output driver
 
 ### Supported compilers:
 
-* gcc 4.x or later
-* ms VS2019 compiler
+* gcc 4.9 or later
+* MSVC 2019
 * clang 3.x or later
 
 


### PR DESCRIPTION
Since baresip has atomic support, gcc 4.8.x (as shipped in RHEL/CentOS 7) doesn't work for me any longer to build baresip, thus it seems to require gcc >= 4.9 (like libre does already).