### PR TITLE
Renamed gzrtp ARRAY_SIZE macro

### DIFF
--- a/modules/gzrtp/gzrtp.cpp
+++ b/modules/gzrtp/gzrtp.cpp
@@ -209,7 +209,7 @@ static int module_init(void)
 
 	menc_register(baresip_mencl(), &menc_zrtp);
 
-	return cmd_register(baresip_commands(), cmdv, ARRAY_SIZE(cmdv));
+	return cmd_register(baresip_commands(), cmdv, RE_ARRAY_SIZE(cmdv));
 }
 
 


### PR DESCRIPTION
gzrtp module didn't compile anymore after https://github.com/baresip/re/commit/c64974a8e424b12974c2508eb289b96363c728b5.