### PR TITLE
audio: solve concurrency failures of TX thread

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -167,7 +167,9 @@ static double autx_calc_seconds(const struct autx *autx)
 	if (!autx->ac)
 		return .0;
 
+	mtx_lock(autx->mtx);
 	dur = autx->ts_ext - autx->ts_base;
+	mtx_unlock(autx->mtx);
 
 	return timestamp_calc_seconds(dur, autx->ac->crate);
 }
@@ -387,7 +389,9 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 		}
 
 		if (ts_delta) {
+			mtx_lock(a->tx.mtx);
 			tx->ts_ext += ts_delta;
+			mtx_unlock(a->tx.mtx);
 			goto out;
 		}
 	}
@@ -402,7 +406,9 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	 */
 	frame_size = sampc_rtp / tx->ac->ch;
 
+	mtx_lock(a->tx.mtx);
 	tx->ts_ext += (uint32_t)frame_size;
+	mtx_unlock(a->tx.mtx);
 
  out:
 	tx->marker = false;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1565,7 +1565,9 @@ int stream_debug(struct re_printf *pf, const struct stream *s)
 	err |= re_hprintf(pf, " tx.enabled: %s\n",
 			  re_atomic_rlx(&s->tx.enabled) ? "yes" : "no");
 	err |= rtprecv_debug(pf, s->rx);
+	mtx_lock(s->tx.lock);
 	err |= rtp_debug(pf, s->rtp);
+	mtx_unlock(s->tx.lock);
 
 	if (s->bundle)
 		err |= bundle_debug(pf, s->bundle);


### PR DESCRIPTION
Adds three calls to `audio_debug()` to `test_call_rtcp` which shows that there are concurrency failures in `main`. Further provides the fixes.

- test: call - concurrency test for audio_debug()
- audio: lock r/w of tx->ts_ext
- stream: lock rtp_send() vs rtp_debug()
