### PR TITLE
call: remove unused error handling of some API functions

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -255,9 +255,9 @@ struct call  *call_find_linenum(const struct list *calls, uint32_t linenum);
 struct call  *call_find_id(const struct list *calls, const char *id);
 void call_set_current(struct list *calls, struct call *call);
 const struct list *call_get_custom_hdrs(const struct call *call);
-int call_set_media_direction(struct call *call, enum sdp_dir a,
+void call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
-int call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
+void call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
 const char   *call_user_data(const struct call *call);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -331,7 +331,6 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	struct pl callid = PL_INIT;
 	char *cid = NULL;
 	bool ok = false;
-	int err;
 
 	const char *usage = "usage: /medialdir"
 			" audio=<inactive, sendonly, recvonly, sendrecv>"
@@ -372,10 +371,9 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	err  = call_set_media_estdir(call, adir, vdir);
-	err |= call_set_media_direction(call, adir, vdir);
-
-	return err;
+	call_set_media_estdir(call, adir, vdir);
+	call_set_media_direction(call, adir, vdir);
+	return 0;
 }
 
 

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -158,10 +158,9 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 		ua = call_get_ua(call);
 	}
 
-	(void)call_set_media_estdir(call, adir, vdir);
-
+	call_set_media_estdir(call, adir, vdir);
 	if (call_sdp_change_allowed(call))
-		(void)call_set_media_direction(call, adir, vdir);
+		call_set_media_direction(call, adir, vdir);
 
 	err = answer_call(ua, call);
 	if (err)

--- a/src/call.c
+++ b/src/call.c
@@ -1133,8 +1133,7 @@ int call_connect(struct call *call, const struct pl *paddr)
 		if (err)
 			return err;
 
-		(void)call_set_media_direction(call, call->estadir,
-					       call->estvdir);
+		call_set_media_direction(call, call->estadir, call->estvdir);
 	}
 
 	return err;
@@ -1279,7 +1278,7 @@ int call_progress_dir(struct call *call, enum sdp_dir adir, enum sdp_dir vdir)
 	tmr_cancel(&call->tmr_inv);
 
 	if (adir != call->estadir || vdir != call->estvdir)
-		(void)call_set_media_direction(call, adir, vdir);
+		call_set_media_direction(call, adir, vdir);
 
 	err = call_sdp_get(call, &desc, false);
 	if (err)
@@ -1905,8 +1904,7 @@ static void set_established_mdir(void *arg)
 	MAGIC_CHECK(call);
 
 	if (call_need_modify(call)) {
-		(void)call_set_media_direction(call, call->estadir,
-					       call->estvdir);
+		call_set_media_direction(call, call->estadir, call->estvdir);
 		call_modify(call);
 	}
 }
@@ -2427,8 +2425,7 @@ static int sipsess_desc_handler(struct mbuf **descp, const struct sa *src,
 		if (err)
 			return err;
 
-		(void)call_set_media_direction(call, call->estadir,
-					       call->estvdir);
+		call_set_media_direction(call, call->estadir, call->estvdir);
 	}
 
 	err = call_sdp_get(call, descp, true);
@@ -3069,13 +3066,12 @@ void call_set_current(struct list *calls, struct call *call)
  * @param call Call object
  * @param a    Audio SDP direction
  * @param v    Video SDP direction if video available
- *
- * @return 0 if success, otherwise errorcode
  */
-int call_set_media_direction(struct call *call, enum sdp_dir a, enum sdp_dir v)
+void call_set_media_direction(struct call *call, enum sdp_dir a,
+			      enum sdp_dir v)
 {
 	if (!call)
-		return EINVAL;
+		return;
 
 	stream_set_ldir(audio_strm(call_audio(call)), a);
 
@@ -3087,8 +3083,6 @@ int call_set_media_direction(struct call *call, enum sdp_dir a, enum sdp_dir v)
 			stream_set_ldir(video_strm(call_video(call)), v);
 
 	}
-
-	return 0;
 }
 
 
@@ -3098,18 +3092,14 @@ int call_set_media_direction(struct call *call, enum sdp_dir a, enum sdp_dir v)
  * @param call Call object
  * @param a    Audio SDP direction
  * @param v    Video SDP direction if video available
- *
- * @return int	0 if success, errorcode otherwise
  */
-int call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v)
+void call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v)
 {
 	if (!call)
-		return EINVAL;
+		return;
 
 	call->estadir = a;
 	call->estvdir = call->use_video ? v : SDP_INACTIVE;
-
-	return 0;
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1317,12 +1317,8 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 		goto out;
 
 	if (adir != SDP_SENDRECV || vdir != SDP_SENDRECV) {
-		err = call_set_media_estdir(call, adir, vdir);
-		err |= call_set_media_direction(call, adir, vdir);
-		if (err) {
-			mem_deref(call);
-			goto out;
-		}
+		call_set_media_estdir(call, adir, vdir);
+		call_set_media_direction(call, adir, vdir);
 	}
 
 	err = call_connect(call, &pl);

--- a/test/call.c
+++ b/test/call.c
@@ -1698,10 +1698,8 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 1, 0);
 	cr->prm = "answer";
 
-	err = call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE,
-				    SDP_INACTIVE);
-	err |= call_set_media_direction(ua_call(f->a.ua), SDP_INACTIVE,
-				       SDP_INACTIVE);
+	call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
+	call_set_media_direction(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));
 	TEST_ERR(err);
@@ -1726,10 +1724,8 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 
 	f->a.n_auframe=0;
 	f->b.n_auframe=0;
-	err = call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE,
-				    SDP_INACTIVE);
-	err |= call_set_media_direction(ua_call(f->a.ua), SDP_SENDRECV,
-				       SDP_INACTIVE);
+	call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
+	call_set_media_direction(ua_call(f->a.ua), SDP_SENDRECV, SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));
 	TEST_ERR(err);
@@ -3004,9 +3000,7 @@ static int test_call_hold_resume_base(bool tcp)
 	ASSERT_TRUE(!call_ack_pending(ua_call(f->b.ua)));
 
 	/* set media inactive from B */
-	err = call_set_media_direction(ua_call(f->b.ua), SDP_INACTIVE,
-				       SDP_INACTIVE);
-	TEST_ERR(err);
+	call_set_media_direction(ua_call(f->b.ua), SDP_INACTIVE, SDP_INACTIVE);
 	err = call_modify(ua_call(f->b.ua));
 	TEST_ERR(err);
 
@@ -3021,9 +3015,7 @@ static int test_call_hold_resume_base(bool tcp)
 	ASSERT_EQ(1, f->b.n_hold_cnt);
 
 	/* set call to resume from B */
-	err = call_set_media_direction(ua_call(f->b.ua), SDP_SENDRECV,
-				       SDP_SENDRECV);
-	TEST_ERR(err);
+	call_set_media_direction(ua_call(f->b.ua), SDP_SENDRECV, SDP_SENDRECV);
 	err = call_hold(ua_call(f->b.ua), false);
 	TEST_ERR(err);
 	tmr_start(&f->a.tmr_ack, 1, check_ack, &f->a);


### PR DESCRIPTION
call_set_media_direction() and call_set_media_estdir() doesn't need an error
handling.
