### PR TITLE
ua: improve SIP 404 warning

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -696,8 +696,8 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 
 	ua = uag_find_msg(msg);
 	if (!ua) {
-		info("ua: %r: UA not found: %r\n",
-		     &msg->from.auri, &msg->uri.user);
+		info("ua: %r: UA not found: %H\n",
+		     &msg->from.auri, uri_encode, &msg->uri);
 		(void)sip_treply(NULL, uag_sip(), msg, 404, "Not Found");
 		return;
 	}


### PR DESCRIPTION
If someone calls to the local IP (e.g. 1.2.3.4) with a user less dial URI, then the call is rejected and a warning is printed. The warning currently shows an empty msg URI.

e.g. `msg->uri = "sip:1.2.3.4"`