### PR TITLE
account,message,ua: secure incoming SIP MESSAGEs

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -41,7 +41,7 @@
 #    ;stunpass=STUN/TURN/ICE-password
 #    ;stunserver=stun:[user:pass]@host[:port]  # see RFC 3986: Use of the format "user:password" in the userinfo field is deprecated.
 #    ;tcpsrcport=6060
-#    ;uas_req={yes, no, tls}  # default: no
+#    ;inreq_allowed={yes, no}  # default: no
 #    ;uas_user=username
 #    ;uas_pass=password
 #    ;video_codecs=h264,vp8,...

--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -41,6 +41,7 @@
 #    ;stunpass=STUN/TURN/ICE-password
 #    ;stunserver=stun:[user:pass]@host[:port]  # see RFC 3986: Use of the format "user:password" in the userinfo field is deprecated.
 #    ;tcpsrcport=6060
+#    ;uas_req={yes, no, tls}  # default: no
 #    ;uas_user=username
 #    ;uas_pass=password
 #    ;video_codecs=h264,vp8,...

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -79,11 +79,10 @@ enum jbuf_type {
 	JBUF_ADAPTIVE
 };
 
-/** Defines the UAS request mode */
-enum uas_req_mode {
-	UAS_REQ_MODE_OFF = 0,
-	UAS_REQ_MODE_ON,
-	UAS_REQ_MODE_TLS
+/** Defines the incoming out-of-dialog request mode */
+enum inreq_mode {
+	INREQ_MODE_OFF = 0,
+	INREQ_MODE_ON,
 };
 
 struct account;
@@ -99,7 +98,7 @@ int account_set_sipnat(struct account *acc, const char *sipnat);
 int account_set_answermode(struct account *acc, enum answermode mode);
 int account_set_rel100_mode(struct account *acc, enum rel100_mode mode);
 int account_set_dtmfmode(struct account *acc, enum dtmfmode mode);
-int account_set_uas_req_mode(struct account *acc, enum uas_req_mode mode);
+int account_set_inreq_mode(struct account *acc, enum inreq_mode mode);
 int account_set_display_name(struct account *acc, const char *dname);
 int account_set_regint(struct account *acc, uint32_t regint);
 int account_set_stun_uri(struct account *acc, const char *uri);
@@ -128,7 +127,7 @@ uint32_t account_prio(const struct account *acc);
 enum answermode account_answermode(const struct account *acc);
 enum rel100_mode account_rel100_mode(const struct account *acc);
 enum dtmfmode account_dtmfmode(const struct account *acc);
-enum uas_req_mode account_uas_req_mode(const struct account *acc);
+enum inreq_mode account_inreq_mode(const struct account *acc);
 const char *account_display_name(const struct account *acc);
 const char *account_aor(const struct account *acc);
 const char *account_auth_user(const struct account *acc);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -79,6 +79,13 @@ enum jbuf_type {
 	JBUF_ADAPTIVE
 };
 
+/** Defines the UAS request mode */
+enum uas_req_mode {
+	UAS_REQ_MODE_OFF = 0,
+	UAS_REQ_MODE_ON,
+	UAS_REQ_MODE_TLS
+};
+
 struct account;
 
 int account_alloc(struct account **accp, const char *sipaddr);
@@ -92,6 +99,7 @@ int account_set_sipnat(struct account *acc, const char *sipnat);
 int account_set_answermode(struct account *acc, enum answermode mode);
 int account_set_rel100_mode(struct account *acc, enum rel100_mode mode);
 int account_set_dtmfmode(struct account *acc, enum dtmfmode mode);
+int account_set_uas_req_mode(struct account *acc, enum uas_req_mode mode);
 int account_set_display_name(struct account *acc, const char *dname);
 int account_set_regint(struct account *acc, uint32_t regint);
 int account_set_stun_uri(struct account *acc, const char *uri);
@@ -120,6 +128,7 @@ uint32_t account_prio(const struct account *acc);
 enum answermode account_answermode(const struct account *acc);
 enum rel100_mode account_rel100_mode(const struct account *acc);
 enum dtmfmode account_dtmfmode(const struct account *acc);
+enum uas_req_mode account_uas_req_mode(const struct account *acc);
 const char *account_display_name(const struct account *acc);
 const char *account_aor(const struct account *acc);
 const char *account_auth_user(const struct account *acc);
@@ -153,6 +162,7 @@ void account_set_autelev_pt(struct account *acc, uint32_t pt);
 uint32_t account_autelev_pt(struct account *acc);
 const char* account_uas_user(const struct account *acc);
 const char* account_uas_pass(const struct account *acc);
+bool account_uas_isset(const struct account *acc);
 
 /*
  * Call
@@ -927,6 +937,7 @@ int ua_raise(struct ua *ua);
 int ua_set_autoanswer_value(struct ua *ua, const char *value);
 void ua_add_extension(struct ua *ua, const char *extension);
 void ua_remove_extension(struct ua *ua, const char *extension);
+bool ua_req_allowed(const struct ua *ua, const struct sip_msg *msg);
 
 
 /* One instance */

--- a/src/account.c
+++ b/src/account.c
@@ -317,25 +317,23 @@ static void dtmfmode_decode(struct account *prm, const struct pl *pl)
 }
 
 
-static void uas_req_mode_decode(struct account *prm, const struct pl *pl)
+static void inreq_mode_decode(struct account *prm, const struct pl *pl)
 {
 	struct pl mode;
 
-	prm->uasmode = UAS_REQ_MODE_OFF;
+	prm->inreq_mode = INREQ_MODE_OFF;
 
-	if (0 == msg_param_decode(pl, "uas_req", &mode)) {
+	if (0 == msg_param_decode(pl, "inreq_allowed", &mode)) {
 
 		if (0 == pl_strcasecmp(&mode, "no")) {
-			prm->uasmode = UAS_REQ_MODE_OFF;
+			prm->inreq_mode = INREQ_MODE_OFF;
 		}
 		else if (0 == pl_strcasecmp(&mode, "yes")) {
-			prm->uasmode = UAS_REQ_MODE_ON;
-		}
-		else if (0 == pl_strcasecmp(&mode, "tls")) {
-			prm->uasmode = UAS_REQ_MODE_TLS;
+			prm->inreq_mode = INREQ_MODE_ON;
 		}
 		else {
-			warning("account: uas_req mode unknown (%r)\n", &mode);
+			warning("account: inreq_allowed mode unknown (%r)\n",
+				&mode);
 		}
 	}
 }
@@ -618,7 +616,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	       autoanswer_decode(acc, &acc->laddr.params);
 	       dtmfmode_decode(acc, &acc->laddr.params);
 	       uasauth_decode(acc, &acc->laddr.params);
-	       uas_req_mode_decode(acc, &acc->laddr.params);
+	       inreq_mode_decode(acc, &acc->laddr.params);
 	err |= audio_codecs_decode(acc, &acc->laddr.params);
 	err |= video_codecs_decode(acc, &acc->laddr.params);
 	err |= media_decode(acc, &acc->laddr.params);
@@ -1702,13 +1700,12 @@ static const char *sipansbeep_str(enum sipansbeep beep)
 }
 
 
-static const char *uas_req_mode_str(enum uas_req_mode mode)
+static const char *inreq_mode_str(enum inreq_mode mode)
 {
 	switch (mode) {
 
-	case UAS_REQ_MODE_OFF:      return "no";
-	case UAS_REQ_MODE_ON:       return "yes";
-	case UAS_REQ_MODE_TLS:      return "tls";
+	case INREQ_MODE_OFF:      return "no";
+	case INREQ_MODE_ON:       return "yes";
 	default: return "???";
 	}
 }
@@ -2002,8 +1999,8 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 	err |= re_hprintf(pf, " prio:         %u\n", acc->prio);
 	err |= re_hprintf(pf, " pubint:       %u\n", acc->pubint);
 	err |= re_hprintf(pf, " regq:         %s\n", acc->regq);
-	err |= re_hprintf(pf, " uas_req:      %s\n",
-			  uas_req_mode_str(acc->uasmode));
+	err |= re_hprintf(pf, " inreq_allowed:%s\n",
+			  inreq_mode_str(acc->inreq_mode));
 	err |= re_hprintf(pf, " sipnat:       %s\n", acc->sipnat);
 	err |= re_hprintf(pf, " stunuser:     %s\n", acc->stun_user);
 	err |= re_hprintf(pf, " stunserver:   %H\n",
@@ -2084,8 +2081,8 @@ int account_json_api(struct odict *od, struct odict *odcfg,
 			rel100_mode_str(acc->rel100_mode));
 	err |= odict_entry_add(odcfg, "answer_mode", ODICT_STRING,
 			answermode_str(acc->answermode));
-	err |= odict_entry_add(odcfg, "uas_req", ODICT_STRING,
-			uas_req_mode_str(acc->uasmode));
+	err |= odict_entry_add(odcfg, "inreq_allowed", ODICT_STRING,
+			inreq_mode_str(acc->inreq_mode));
 	err |= odict_entry_add(odcfg, "call_transfer", ODICT_BOOL, acc->refer);
 
 	err |= odict_entry_add(odcfg, "packet_time", ODICT_INT,
@@ -2124,38 +2121,37 @@ bool account_uas_isset(const struct account *acc)
 
 
 /**
- * Get the UAS request mode of an account
+ * Get the incoming out-of-dialog request mode of an account
  *
  * @param acc User-Agent account
  *
- * @return uas_req_mode mode
+ * @return inreq_mode
  */
-enum uas_req_mode account_uas_req_mode(const struct account *acc)
+enum inreq_mode account_inreq_mode(const struct account *acc)
 {
-	return acc ? acc->uasmode : UAS_REQ_MODE_OFF;
+	return acc ? acc->inreq_mode : INREQ_MODE_OFF;
 }
 
 
 /**
- * Set the UAS request mode of an account
+ * Set the incoming out-of-dialog request mode of an account
  *
  * @param acc  User-Agent account
- * @param mode uas_req_mode
+ * @param mode Incoming request mode
  *
  * @return 0 if success, otherwise errorcode
  */
-int account_set_uas_req_mode(struct account *acc, enum uas_req_mode mode)
+int account_set_inreq_mode(struct account *acc, enum inreq_mode mode)
 {
 	if (!acc)
 		return EINVAL;
 
-	if ((mode != UAS_REQ_MODE_OFF) && (mode != UAS_REQ_MODE_ON) &&
-	    (mode != UAS_REQ_MODE_TLS)) {
-		warning("account: invalid uas_req_mode : '%d'\n", mode);
+	if ((mode != INREQ_MODE_OFF) && (mode != INREQ_MODE_ON)) {
+		warning("account: invalid inreq_allowed : '%d'\n", mode);
 		return EINVAL;
 	}
 
-	acc->uasmode = mode;
+	acc->inreq_mode = mode;
 
 	return 0;
 }

--- a/src/core.h
+++ b/src/core.h
@@ -56,6 +56,7 @@ struct account {
 	bool autoredirect;           /**< Autoredirect on 3xx reply on/off   */
 	int32_t adelay;              /**< Delay for delayed auto answer [ms] */
 	enum dtmfmode dtmfmode;      /**< Send type for DTMF tones           */
+	enum uas_req_mode uasmode;   /**< UAS request mode                   */
 	struct le acv[16];           /**< List elements for aucodecl         */
 	struct list aucodecl;        /**< List of preferred audio-codecs     */
 	char *auth_user;             /**< Authentication username            */
@@ -371,6 +372,7 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg);
 void sipsess_conn_handler(const struct sip_msg *msg, void *arg);
 bool ua_catchall(struct ua *ua);
 bool ua_reghasladdr(const struct ua *ua, const struct sa *laddr);
+int uas_req_auth(struct ua *ua, const struct sip_msg *msg);
 
 /*
  * User-Agent Group

--- a/src/core.h
+++ b/src/core.h
@@ -56,7 +56,7 @@ struct account {
 	bool autoredirect;           /**< Autoredirect on 3xx reply on/off   */
 	int32_t adelay;              /**< Delay for delayed auto answer [ms] */
 	enum dtmfmode dtmfmode;      /**< Send type for DTMF tones           */
-	enum uas_req_mode uasmode;   /**< UAS request mode                   */
+	enum inreq_mode inreq_mode;  /**< Incoming request mode              */
 	struct le acv[16];           /**< List elements for aucodecl         */
 	struct list aucodecl;        /**< List of preferred audio-codecs     */
 	char *auth_user;             /**< Authentication username            */

--- a/src/ua.c
+++ b/src/ua.c
@@ -2197,10 +2197,5 @@ bool ua_req_allowed(const struct ua *ua, const struct sip_msg *msg)
 	if (!ua || !msg)
 		return false;
 
-	if ((account_uas_req_mode(ua->acc) == UAS_REQ_MODE_OFF) ||
-	    (account_uas_req_mode(ua->acc) & UAS_REQ_MODE_TLS &&
-	    msg->tp != SIP_TRANSP_TLS))
-		return false;
-
-	return true;
+	return account_inreq_mode(ua->acc) == INREQ_MODE_ON;
 }

--- a/test/message.c
+++ b/test/message.c
@@ -143,7 +143,7 @@ static void endpoint_destructor(void *data)
 
 static int endpoint_alloc(struct endpoint **epp, struct test *test,
 			  const char *name, enum sip_transp transp,
-			  const char *uas_req_mode)
+			  const char *inreq_mode)
 {
 	struct endpoint *ep = NULL;
 	struct sa laddr;
@@ -160,9 +160,10 @@ static int endpoint_alloc(struct endpoint **epp, struct test *test,
 	ep->test = test;
 
 	if (re_snprintf(aor, sizeof(aor),
-			"%s <sip:%s@%j;transport=%s>;regint=0;uas_req=%s",
+			"%s <sip:%s@%j;transport=%s>;regint=0;"
+			"inreq_allowed=%s",
 			name, name, &laddr,
-			sip_transp_name(transp), uas_req_mode) < 0) {
+			sip_transp_name(transp), inreq_mode) < 0) {
 		err = ENOMEM;
 		goto out;
 	}
@@ -192,7 +193,7 @@ static int endpoint_alloc(struct endpoint **epp, struct test *test,
 
 
 static int test_message_transp(enum sip_transp transp,
-			       const char *uas_req_mode)
+			       const char *inreq_allowed)
 {
 	struct test test;
 	struct endpoint *a = NULL, *b = NULL;
@@ -213,13 +214,13 @@ static int test_message_transp(enum sip_transp transp,
 	err = ua_init("test", enable_udp, enable_tcp, false);
 	TEST_ERR(err);
 
-	err = endpoint_alloc(&a, &test, "a", transp, uas_req_mode);
+	err = endpoint_alloc(&a, &test, "a", transp, inreq_allowed);
 	TEST_ERR(err);
 
-	err = endpoint_alloc(&b, &test, "b", transp, uas_req_mode);
+	err = endpoint_alloc(&b, &test, "b", transp, inreq_allowed);
 	TEST_ERR(err);
 
-	if (!pl_strcmp(&pl_no, uas_req_mode)) {
+	if (!pl_strcmp(&pl_no, inreq_allowed)) {
 		resp_handler = send_resp_handler_488;
 		b_exp_msg_cnt = 0;
 	}


### PR DESCRIPTION
Currently, BareSIP accepts all incoming SIP MESSAGE requests as long as they are addressed to a valid UA. This poses a security risk and is not conformant to the security considerations in [RFC 3428 section 11](https://www.rfc-editor.org/rfc/rfc3428#section-11).

With this change, SIP MESSAGEs can be enabled per account using the new account option `uas_req` (the default is off) and can be set to require TLS. If `uas_user` or `uas_pass` are set, authentication is required.

Further, a foundation was built to extend this to other out-of-dialog requests like REFER.