### PR TITLE
account/debug: fix wrong and redundant rtcp_mux printf

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -1965,7 +1965,6 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 	err |= re_hprintf(pf, " prio:         %u\n", acc->prio);
 	err |= re_hprintf(pf, " pubint:       %u\n", acc->pubint);
 	err |= re_hprintf(pf, " regq:         %s\n", acc->regq);
-	err |= re_hprintf(pf, " rtcp_mux:     %s\n", acc->rtcp_mux);
 	err |= re_hprintf(pf, " sipnat:       %s\n", acc->sipnat);
 	err |= re_hprintf(pf, " stunuser:     %s\n", acc->stun_user);
 	err |= re_hprintf(pf, " stunserver:   %H\n",


### PR DESCRIPTION
`acc->rtcp_mux` is already printed and a boolean, so this leads to segfaults