### PR TITLE
cmake: add /usr/{local,}/include/re and /usr/{local,}/lib{64,} to FindRE.cmake

### DIFF
--- a/cmake/FindRE.cmake
+++ b/cmake/FindRE.cmake
@@ -1,12 +1,25 @@
 find_package(PkgConfig QUIET)
 pkg_check_modules(PC_LIBRE QUIET libre)
 
-find_path(RE_INCLUDE_DIR re.h
-  HINTS ../re/include ${PC_LIBRE_INCLUDEDIR} ${PC_LIBRE_INCLUDE_DIRS})
+find_path(RE_INCLUDE_DIR
+  NAME re.h
+  HINTS
+    ../re/include
+    ${PC_LIBRE_INCLUDEDIR}
+    ${PC_LIBRE_INCLUDE_DIRS}
+  PATHS /usr/local/include/re /usr/include/re
+)
 
-find_library(RE_LIBRARY NAMES re libre re-static
-  HINTS ../re ../re/build ../re/build/Debug
-  ${PC_LIBRE_LIBDIR} ${PC_LIBRE_LIBRARY_DIRS})
+find_library(RE_LIBRARY
+  NAMES re libre re-static
+  HINTS
+    ../re
+    ../re/build
+    ../re/build/Debug
+    ${PC_LIBRE_LIBDIR}
+    ${PC_LIBRE_LIBRARY_DIRS}
+  PATHS /usr/local/lib64 /usr/lib64 /usr/local/lib /usr/lib
+)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(RE DEFAULT_MSG RE_LIBRARY RE_INCLUDE_DIR)


### PR DESCRIPTION
Effectively, `PATHS /usr/local/include/re /usr/include/re` and `PATHS /usr/local/lib64 /usr/lib64 /usr/local/lib /usr/lib` are added to match other `Find*.cmake` files more closely and also to address "Could NOT find RE (missing: RE_INCLUDE_DIR)" from #2899.