### PR TITLE
config: support distribution-specific/default CA paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,10 @@ if(DEFAULT_CAFILE)
   add_definitions(-DDEFAULT_CAFILE="${DEFAULT_CAFILE}")
 endif()
 
+if(DEFAULT_CAPATH)
+  add_definitions(-DDEFAULT_CAPATH="${DEFAULT_CAPATH}")
+endif()
+
 if(DEFAULT_AUDIO_DEVICE)
   add_definitions(-DDEFAULT_AUDIO_DEVICE="${DEFAULT_AUDIO_DEVICE}")
 endif()

--- a/docs/examples/config
+++ b/docs/examples/config
@@ -8,6 +8,7 @@
 #sip_listen		0.0.0.0:5060
 #sip_certificate	cert.pem
 sip_cafile		/etc/ssl/certs/ca-certificates.crt
+sip_capath		/etc/ssl/certs
 #sip_transports		udp,tcp,tls,ws,wss
 #sip_trans_def		udp
 sip_verify_server	yes

--- a/src/config.c
+++ b/src/config.c
@@ -688,6 +688,16 @@ static const char *default_cafile(void)
 }
 
 
+static const char *default_capath(void)
+{
+#if defined (DEFAULT_CAPATH)
+	return DEFAULT_CAPATH;
+#else
+	return "/etc/ssl/certs";
+#endif
+}
+
+
 static const char *default_audio_device(void)
 {
 #if defined (DEFAULT_AUDIO_DEVICE)
@@ -778,6 +788,7 @@ static const char *default_audio_path(void)
 static int core_config_template(struct re_printf *pf, const struct config *cfg)
 {
 	bool have_cafile = false;
+	bool have_capath = false;
 	int err = 0;
 
 	if (!cfg)
@@ -788,11 +799,16 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 	have_cafile = true;
 #endif
 
+#if defined (DEFAULT_CAPATH) || defined (LINUX)
+	have_capath = true;
+#endif
+
 	err |= re_hprintf(pf,
 			  "\n# SIP\n"
 			  "#sip_listen\t\t0.0.0.0:5060\n"
 			  "#sip_certificate\tcert.pem\n"
 			  "%ssip_cafile\t\t%s\n"
+			  "%ssip_capath\t\t%s\n"
 			  "#sip_transports\t\tudp,tcp,tls,ws,wss\n"
 			  "#sip_trans_def\t\tudp\n"
 			  "#sip_verify_server\tyes\n"
@@ -800,7 +816,9 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "\n"
 			  ,
 			  have_cafile ? "" : "#",
-			  default_cafile());
+			  default_cafile(),
+			  have_capath ? "" : "#",
+			  default_capath());
 
 	err |= re_hprintf(pf,
 			  "# Call\n"


### PR DESCRIPTION
Especially Linux distributions support, additionally to the already existing CA file, also CA paths, such as `/etc/ssl/certs` (Debian, openSUSE, SLES), `/etc/pki/tls/certs` (Fedora, CentOS/RHEL) or `/system/etc/security/cacerts` (Android).

This makes a default CA path configurable for downstreams during build-time (and provides a proper default aligned with CA file).