### PR TITLE
video: add video_req_keyframe api

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1420,6 +1420,7 @@ int   video_debug(struct re_printf *pf, const struct video *v);
 struct stream *video_strm(const struct video *v);
 const struct vidcodec *video_codec(const struct video *vid, bool tx);
 void video_sdp_attr_decode(struct video *v);
+void video_req_keyframe(struct video *vid);
 
 double video_calc_seconds(uint64_t rtp_ts);
 double video_timestamp_to_seconds(uint64_t timestamp);

--- a/src/video.c
+++ b/src/video.c
@@ -1901,3 +1901,19 @@ const struct vidcodec *video_codec(const struct video *vid, bool tx)
 
 	return tx ? vid->vtx.vc : vid->vrx.vc;
 }
+
+
+/**
+ * Request new keyframe from encoder (vtx)
+ *
+ * @param vid Video object
+ */
+void video_req_keyframe(struct video *vid)
+{
+	if (!vid)
+		return;
+
+	mtx_lock(vid->vtx.lock_enc);
+	vid->vtx.picup = true;
+	mtx_unlock(vid->vtx.lock_enc);
+}


### PR DESCRIPTION
It's useful for an SFU (Selective Forwarding Unit) to request a picture update (new keyframe) from the encoder, when a new subscriber is added.