### PR TITLE
aufile: join thread if write fails

### DIFF
--- a/modules/aufile/aufile_play.c
+++ b/modules/aufile/aufile_play.c
@@ -73,8 +73,6 @@ static int write_thread(void *arg)
 		sys_msleep(dt);
 	}
 
-	re_atomic_rlx_set(&st->run, false);
-
 	return 0;
 }
 


### PR DESCRIPTION
This fixes the error case that `aufile_write()` fails. In this case the thread
was not joined in the destructor and the threads cleanup was missed.
