### PR TITLE
call: improve glare handling

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1921,6 +1921,7 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 {
 	struct call *call = arg;
+	uint32_t wait;
 	(void)msg;
 
 	MAGIC_CHECK(call);
@@ -1947,9 +1948,11 @@ static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 		(void)call_notify_sipfrag(call, 200, "OK");
 	}
 
+	wait = call_is_outgoing(call) ? 150 : 0;
+	wait += randwait(50, 150);
+
 	/* modify call after call_event_established handlers are executed */
-	tmr_start(&call->tmr_reinv, randwait(50, 150),
-		  set_established_mdir, call);
+	tmr_start(&call->tmr_reinv, wait, set_established_mdir, call);
 
 	/* must be done last, the handler might deref this call */
 	call_event_handler(call, CALL_EVENT_ESTABLISHED, "%s", call->peer_uri);


### PR DESCRIPTION
In certain configurations involving early-media BareSIP sends a re-INVITE once the dialog is established to have different stream configurations in the established state and in the early media state (e.g. early state: audio=inactive,video=recvonly; established: audio=sendrecv,video=sendrecv). Other UAs often like to send re-INVITEs too once the dialog is established (e.g. Asterisk).

This can lead to glare situations becoming very common where both UAs send re-INVITEs at the exact same time, resulting in long delays in getting the streams to the desired state.

To mitigate this (especially for the case when a BareSIP UA calls another BareSIP UA), we'd like to propose to slightly change the timer for `set_established_mdir` depending on whether the call is outgoing or incoming. We have this mitigation in use in production and it has drastically decreased the occurrence of glare situations.

This kind of differentiation is not without precedence and a similar behavior is defined in [RFC 3261 section 14.1](https://www.rfc-editor.org/rfc/rfc3261#section-14.1) when it comes to handling glare situations (different timers for caller and callee):

```
   If a UAC receives a 491 response to a re-INVITE, it SHOULD start a
   timer with a value T chosen as follows:

      1. If the UAC is the owner of the Call-ID of the dialog ID
         (meaning it generated the value), T has a randomly chosen value
         between 2.1 and 4 seconds in units of 10 ms.

      2. If the UAC is not the owner of the Call-ID of the dialog ID, T
         has a randomly chosen value of between 0 and 2 seconds in units
         of 10 ms.
```