### PR TITLE
call: set estdir in call_set_media_direction

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -266,6 +266,7 @@ void call_set_current(struct list *calls, struct call *call);
 const struct list *call_get_custom_hdrs(const struct call *call);
 void call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
+void call_set_mdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);

--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -371,7 +371,6 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	if (!call)
 		return EINVAL;
 
-	call_set_media_estdir(call, adir, vdir);
 	call_set_media_direction(call, adir, vdir);
 	return 0;
 }

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -160,7 +160,7 @@ static int cmd_answerdir(struct re_printf *pf, void *arg)
 
 	call_set_media_estdir(call, adir, vdir);
 	if (call_sdp_change_allowed(call))
-		call_set_media_direction(call, adir, vdir);
+		call_set_mdir(call, adir, vdir);
 
 	err = answer_call(ua, call);
 	if (err)

--- a/src/call.c
+++ b/src/call.c
@@ -1157,7 +1157,7 @@ int call_connect(struct call *call, const struct pl *paddr)
 		if (err)
 			return err;
 
-		call_set_media_direction(call, call->estadir, call->estvdir);
+		call_set_mdir(call, call->estadir, call->estvdir);
 	}
 
 	return err;
@@ -1302,7 +1302,7 @@ int call_progress_dir(struct call *call, enum sdp_dir adir, enum sdp_dir vdir)
 	tmr_cancel(&call->tmr_inv);
 
 	if (adir != call->estadir || vdir != call->estvdir)
-		call_set_media_direction(call, adir, vdir);
+		call_set_mdir(call, adir, vdir);
 
 	err = call_sdp_get(call, &desc, false);
 	if (err)
@@ -1925,7 +1925,7 @@ static void set_established_mdir(void *arg)
 	MAGIC_CHECK(call);
 
 	if (call_need_modify(call)) {
-		call_set_media_direction(call, call->estadir, call->estvdir);
+		call_set_mdir(call, call->estadir, call->estvdir);
 		call_modify(call);
 	}
 }
@@ -2452,7 +2452,7 @@ static int sipsess_desc_handler(struct mbuf **descp, const struct sa *src,
 		if (err)
 			return err;
 
-		call_set_media_direction(call, call->estadir, call->estvdir);
+		call_set_mdir(call, call->estadir, call->estvdir);
 	}
 
 	err = call_sdp_get(call, descp, true);
@@ -3088,7 +3088,7 @@ void call_set_current(struct list *calls, struct call *call)
 
 
 /**
- * Set stream sdp media line direction attribute
+ * Set stream sdp media line direction attribute and established media dir
  *
  * @param call Call object
  * @param a    Audio SDP direction
@@ -3096,6 +3096,23 @@ void call_set_current(struct list *calls, struct call *call)
  */
 void call_set_media_direction(struct call *call, enum sdp_dir a,
 			      enum sdp_dir v)
+{
+	if (!call)
+		return;
+
+	call_set_media_estdir(call, a, v);
+	call_set_mdir(call, a, v);
+}
+
+
+/**
+ * Set stream sdp media line direction attribute
+ *
+ * @param call Call object
+ * @param a    Audio SDP direction
+ * @param v    Video SDP direction if video available
+ */
+void call_set_mdir(struct call *call, enum sdp_dir a, enum sdp_dir v)
 {
 	if (!call)
 		return;

--- a/src/ua.c
+++ b/src/ua.c
@@ -1337,10 +1337,8 @@ int ua_connect_dir(struct ua *ua, struct call **callp,
 	if (err)
 		goto out;
 
-	if (adir != SDP_SENDRECV || vdir != SDP_SENDRECV) {
-		call_set_media_estdir(call, adir, vdir);
+	if (adir != SDP_SENDRECV || vdir != SDP_SENDRECV)
 		call_set_media_direction(call, adir, vdir);
-	}
 
 	err = call_connect(call, &pl);
 

--- a/test/call.c
+++ b/test/call.c
@@ -1698,7 +1698,6 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 	cancel_rule_and(UA_EVENT_CALL_REMOTE_SDP, f->a.ua, 0, 1, 0);
 	cr->prm = "answer";
 
-	call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
 	call_set_media_direction(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));
@@ -1724,7 +1723,6 @@ static int test_100rel_audio_base(enum audio_mode txmode)
 
 	f->a.n_auframe=0;
 	f->b.n_auframe=0;
-	call_set_media_estdir(ua_call(f->a.ua), SDP_INACTIVE, SDP_INACTIVE);
 	call_set_media_direction(ua_call(f->a.ua), SDP_SENDRECV, SDP_INACTIVE);
 	TEST_ERR(err);
 	err = call_modify(ua_call(f->a.ua));


### PR DESCRIPTION
This reverts the behavior of `call_set_media_direction` to how it used to be. Further, re-introduce `call_set_mdir` which only sets the current media direction.

The change in behavior was introduced in #2818 in order to simplify and clarify the setting of media directions.

Resolves: #2939.