### PR TITLE
audio,aur: start audio player after early-video

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1383,7 +1383,7 @@ int audio_decoder_set(struct audio *a, const struct aucodec *ac,
 		return err;
 
 	stream_set_srate(a->strm, 0, ac->crate);
-	if (reset)
+	if (reset || !aurecv_player_started(a->aur))
 		err |= audio_start(a);
 
 	return err;

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -713,6 +713,12 @@ bool aurecv_started(const struct audio_recv *ar)
 }
 
 
+bool aurecv_player_started(const struct audio_recv *ar)
+{
+	return ar ? ar->auplay != NULL : false;
+}
+
+
 int aurecv_debug(struct re_printf *pf, const struct audio_recv *ar)
 {
 	struct mbuf *mb;

--- a/src/core.h
+++ b/src/core.h
@@ -133,6 +133,7 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		    struct rtpext *extv, size_t extc,
 		    struct mbuf *mb, unsigned lostc, bool *ignore);
 int  aurecv_start_player(struct audio_recv *ar, struct list *auplayl);
+bool aurecv_player_started(const struct audio_recv *ar);
 void aurecv_stop(struct audio_recv *ar);
 void aurecv_stop_auplay(struct audio_recv *ar);
 


### PR DESCRIPTION
Fixes #2935.

This is a minimal fix which we should merge now. Similar to `audio_encoder_set()` the audio player is started in `audio_decoder_set()`.

@maximilianfridrich and me plan to do some redundancy cleanup after the upcoming release for
- `call_stream_start()` vs
- `update_streams()`
- `update_audio()`
- `start_audio()`
- `audio_decoder_set()`
- `audio_encoder_set()`
- `audio_start()`
