### PR TITLE
call,audio: cleanup audio start/stop redundancy

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1383,7 +1383,7 @@ struct stream *audio_strm(const struct audio *au);
 uint64_t audio_jb_current_value(const struct audio *au);
 int  audio_set_bitrate(struct audio *au, uint32_t bitrate);
 bool audio_rxaubuf_started(const struct audio *au);
-int  audio_start(struct audio *a);
+int  audio_update(struct audio *a);
 int  audio_start_source(struct audio *a, struct list *ausrcl,
 			struct list *aufiltl);
 void audio_stop(struct audio *a);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1384,6 +1384,7 @@ uint64_t audio_jb_current_value(const struct audio *au);
 int  audio_set_bitrate(struct audio *au, uint32_t bitrate);
 bool audio_rxaubuf_started(const struct audio *au);
 int  audio_update(struct audio *a);
+int  audio_start(struct audio *a);
 int  audio_start_source(struct audio *a, struct list *ausrcl,
 			struct list *aufiltl);
 void audio_stop(struct audio *a);

--- a/src/audio.c
+++ b/src/audio.c
@@ -1229,6 +1229,22 @@ int audio_update(struct audio *a)
 
 
 /**
+ * This function simply calls audio_update() and kept for backward
+ * compatibility
+ *
+ * @param a Audio object
+ *
+ * @return 0 if success, otherwise errorcode
+ *
+ * @deprecated Use audio_update() instead
+ */
+int audio_start(struct audio *a)
+{
+	return audio_update(a);
+}
+
+
+/**
  * Start the audio source
  *
  * @param a       Audio object


### PR DESCRIPTION
mentioned here: https://github.com/baresip/baresip/pull/2941

- Similar to `video_update()`
  - Replace `start_audio()` and `audio_start()` by `audio_update()`.
  - start/stop NAT pinhole for recv-only audio
  - start/stop audio rx/tx for re-INVITE, 183 Session Progress, SIP UPDATE which respects media direction
- Remove expendable `stop_aur()`
- start audio source and player at unique point