### PR TITLE
account: use correct format %zu for printing outbound

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -2005,7 +2005,7 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 			  acc->pinhole ? "yes" : "no");
 	for (i=0; i<RE_ARRAY_SIZE(acc->outboundv); i++) {
 		if (acc->outboundv[i]) {
-			err |= re_hprintf(pf, " outbound%d:    %s\n",
+			err |= re_hprintf(pf, " outbound%zu:    %s\n",
 					  i+1, acc->outboundv[i]);
 		}
 	}


### PR DESCRIPTION
This caused a `SIGABRT` when an outbound proxy is set and account debug information is printed (because of the `RE_VA_ARG` usage in `print.c`).