### PR TITLE
ci/sanitizers: add mmap rnd_bits workaround

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -34,7 +34,11 @@ jobs:
     - name: install packages
       run: |
         sudo apt-get update && sudo apt-get install -y libssl-dev ninja-build
-   
+
+    - name: mmap rnd_bits workaround
+      run: |
+        sudo sysctl -w vm.mmap_rnd_bits=28
+
     - uses: sreimers/pr-dependency-action@v0.6
       with:
         name: re


### PR DESCRIPTION
`vm.mmap_rnd_bits` has been recently changed to 32 on GHA, which triggers issues in ASAN builds that spuriously fail on startup.

Fixes #2966 