### PR TITLE
stream: Retransmission Payload Format for resends (RFC 4588)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ x11           X11 video output driver
 * RFC 4574  The SDP Label Attribute
 * RFC 4585  Extended RTP Profile for RTCP-Based Feedback (RTP/AVPF)
 * RFC 4587  RTP Payload Format for H.261 Video Streams
+* RFC 4588  RTP Retransmission Payload Format
 * RFC 4796  The SDP Content Attribute
 * RFC 4867  RTP Payload Format for the AMR and AMR-WB Audio Codecs
 * RFC 4961  Symmetric RTP / RTP Control Protocol (RTCP)

--- a/src/stream.c
+++ b/src/stream.c
@@ -842,17 +842,19 @@ static void stream_remote_set(struct stream *s)
 			mtx_unlock(s->tx.lock);
 		}
 
-		const struct list *fmtl = sdp_media_format_lst(s->sdp, false);
-		LIST_FOREACH(fmtl, le)
+		const struct list *rfmtl = sdp_media_format_lst(s->sdp, false);
+		LIST_FOREACH(rfmtl, le)
 		{
 			struct sdp_format *fmt = le->data;
 			struct pl rtx_apt;
-			char *p = fmt->params;
+			struct pl p;
+
+			pl_set_str(&p, fmt->params);
 
 			if (0 != str_cmp("rtx", fmt->name))
 				continue;
-			if (0 ==
-			    re_regex(p, str_len(p), "apt=[0-9]+", &rtx_apt)) {
+
+			if (0 == re_regex(p.p, p.l, "apt=[0-9]+", &rtx_apt)) {
 				int apt = pl_i32(&rtx_apt);
 				mtx_lock(s->tx.lock);
 				if (apt == s->tx.pt_enc) {


### PR DESCRIPTION
Work in Progress: Adding RFC 4588 retransmission support (video `stream_resend` only)

```
Retransmission Payload Format

   The format of a retransmission packet is shown below:

    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                         RTP Header                            |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |            OSN                |                               |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
   |                  Original RTP Packet Payload                  |
   |                                                               |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

