### PR TITLE
tls: add session resumption setter

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -13,6 +13,7 @@ sip_capath		/etc/ssl/certs
 #sip_trans_def		udp
 sip_verify_server	yes
 #sip_verify_client	no
+#sip_tls_resumption	all		# none, ids, tickets
 sip_tos			160 # See TOS fields!
 
 ## TOS fields ##

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -360,6 +360,7 @@ struct config_sip {
 	enum sip_transp transp; /**< Default outgoing SIP transport protocol */
 	bool verify_server;     /**< Enable SIP TLS verify server   */
 	bool verify_client;     /**< Enable SIP TLS verify client   */
+	enum tls_resume_mode tls_resume; /** TLS resumption mode    */
 	uint8_t tos;            /**< Type-of-Service for SIP        */
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -37,6 +37,7 @@ static struct config core_config = {
 		SIP_TRANSP_UDP,
 		false,
 		false,
+		TLS_RESUMPTION_ALL,
 		0xa0,
 	},
 
@@ -331,6 +332,23 @@ static const char *net_af_str(int af)
 }
 
 
+static const char *tls_resume_mode_str(enum tls_resume_mode mode)
+{
+	switch (mode) {
+	case TLS_RESUMPTION_NONE:
+		return "none";
+	case TLS_RESUMPTION_ALL:
+		return "all";
+	case TLS_RESUMPTION_IDS:
+		return "ids";
+	case TLS_RESUMPTION_TICKETS:
+		return "tickets";
+	}
+
+	return "?";
+}
+
+
 /**
  * Parse the core configuration file and update baresip core config
  *
@@ -374,6 +392,20 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 
 	(void)conf_get_bool(conf, "sip_verify_client",
 			&cfg->sip.verify_client);
+
+	if (0 == conf_get(conf, "sip_tls_resumption", &pl)) {
+		if (0 == pl_strcasecmp(&pl, "none"))
+			cfg->sip.tls_resume = TLS_RESUMPTION_NONE;
+		else if (0 == pl_strcasecmp(&pl, "ids"))
+			cfg->sip.tls_resume = TLS_RESUMPTION_IDS;
+		else if (0 == pl_strcasecmp(&pl, "tickets"))
+			cfg->sip.tls_resume = TLS_RESUMPTION_TICKETS;
+		else
+			cfg->sip.tls_resume = TLS_RESUMPTION_ALL;
+	}
+	else {
+		cfg->sip.tls_resume = TLS_RESUMPTION_ALL;
+	}
 
 	if (!conf_get(conf, "sip_trans_def", &tr))
 		cfg->sip.transp = sip_transp_decode(&tr);
@@ -559,6 +591,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "sip_trans_def\t%s\n"
 			 "sip_verify_server\t\t\t%s\n"
 			 "sip_verify_client\t\t\t%s\n"
+			 "sip_tls_resumption\t\t\t%s\n"
 			 "sip_tos\t%u\n"
 			 "\n"
 			 "# Call\n"
@@ -572,6 +605,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 sip_transp_name(cfg->sip.transp),
 			 cfg->sip.verify_server ? "yes" : "no",
 			 cfg->sip.verify_client ? "yes" : "no",
+			 tls_resume_mode_str(cfg->sip.tls_resume),
 			 cfg->sip.tos,
 
 			 cfg->call.local_timeout,
@@ -821,6 +855,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "#sip_trans_def\t\tudp\n"
 			  "#sip_verify_server\tyes\n"
 			  "#sip_verify_client\tno\n"
+			  "#sip_tls_resumption\tall\n"
 			  "sip_tos\t\t\t160\n"
 			  "\n"
 			  ,

--- a/src/uag.c
+++ b/src/uag.c
@@ -376,6 +376,8 @@ static int uag_transp_add(const struct sa *laddr)
 
 			if (uag.cfg->verify_client)
 				tls_enable_verify_client(uag.tls, true);
+
+			tls_set_resumption(uag.tls, uag.cfg->tls_resume);
 		}
 
 		if (sa_isset(&local, SA_PORT))


### PR DESCRIPTION
config,uag: add sip_tls_resumption config

TLS session resumption through tickets can compromise forward secrecy if the session ticket key is not rotated regularly (see [RFC 9325 section 3.4](https://www.rfc-editor.org/rfc/rfc9325#section-3.4) for details). Per default, this does not happen in OpenSSL, so we should allow to turn off the use of session tickets ([Mozilla recommends this](https://github.com/mozilla/server-side-tls/issues/135), [Apache warns about this](https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslsessiontickets)).

Note: The current behavior of BareSIP stays the exact same unless the `sip_tls_resumption` option is specifically set.