### PR TITLE
ua: ua_event for DnD rejected call

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1652,8 +1652,8 @@ void ua_event(struct ua *ua, enum ua_event ev, struct call *call,
 	      const char *fmt, ...);
 void module_event(const char *module, const char *event, struct ua *ua,
 		struct call *call, const char *fmt, ...);
-void ua_event_rejected(struct ua *ua, const char *reason,
-		       const struct sip_msg *msg);
+int ua_event_rejected(struct ua *ua, const char *reason,
+		      const struct sip_msg *msg);
 const char  *uag_event_str(enum ua_event ev);
 
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -858,6 +858,7 @@ enum ua_event {
 	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
 	UA_EVENT_CALL_HOLD,           /**< Call put on-hold by peer          */
 	UA_EVENT_CALL_RESUME,         /**< Call resumed by peer              */
+	UA_EVENT_CALL_REJECTED,       /**< Incoming call rejected            */
 	UA_EVENT_REFER,
 	UA_EVENT_MODULE,
 	UA_EVENT_END_OF_FILE,
@@ -1651,6 +1652,8 @@ void ua_event(struct ua *ua, enum ua_event ev, struct call *call,
 	      const char *fmt, ...);
 void module_event(const char *module, const char *event, struct ua *ua,
 		struct call *call, const char *fmt, ...);
+void ua_event_rejected(struct ua *ua, const char *reason,
+		       const struct sip_msg *msg);
 const char  *uag_event_str(enum ua_event ev);
 
 

--- a/src/event.c
+++ b/src/event.c
@@ -71,6 +71,7 @@ static const char *event_class_name(enum ua_event ev)
 	case UA_EVENT_CALL_REMOTE_SDP:
 	case UA_EVENT_CALL_HOLD:
 	case UA_EVENT_CALL_RESUME:
+	case UA_EVENT_CALL_REJECTED:
 		return "call";
 	case UA_EVENT_VU_RX:
 	case UA_EVENT_VU_TX:
@@ -411,6 +412,26 @@ out:
 
 
 /**
+ * Send a call rejected User-Agent event to all UA event handlers
+ *
+ * @param ua     User-Agent object (optional)
+ * @param reason Call object (optional)
+ * @param msg    SIP Message
+ */
+void ua_event_rejected(struct ua *ua, const char *reason,
+			  const struct sip_msg *msg)
+{
+	const struct sip_hdr *hdr;
+	hdr = sip_msg_hdr(msg, SIP_HDR_CONTACT);
+	ua_event(ua, UA_EVENT_CALL_REJECTED, NULL,
+		 "{\"reason\":\"%s\",\"contact\":\"%r\","
+		 "\"display\":\"%r\",\"from\":\"%H\"}",
+		 reason, hdr ? &hdr->val : NULL,
+		 &msg->from.dname, uri_encode, &msg->from.uri);
+}
+
+
+/**
  * Get the name of the User-Agent event
  *
  * @param ev User-Agent event
@@ -453,6 +474,7 @@ const char *uag_event_str(enum ua_event ev)
 	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
 	case UA_EVENT_CALL_HOLD:            return "CALL_HOLD";
 	case UA_EVENT_CALL_RESUME:          return "CALL_RESUME";
+	case UA_EVENT_CALL_REJECTED:        return "CALL_REJECTED";
 	case UA_EVENT_REFER:                return "REFER";
 	case UA_EVENT_MODULE:               return "MODULE";
 	case UA_EVENT_END_OF_FILE:          return "END_OF_FILE";

--- a/src/ua.c
+++ b/src/ua.c
@@ -704,6 +704,8 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 	if (uag_dnd()) {
 		(void)sip_treply(NULL, uag_sip(), msg,
 			480,"Temporarily Unavailable");
+
+		ua_event_rejected(ua, "DnD", msg);
 		return;
 	}
 


### PR DESCRIPTION
Adds a UA event for rejected incoming calls due to activated DnD.

The UA event contains
- Contact header: Can be used by the application in order to call back.
- Display name of the From header: Can be used by the application to display the peer of the rejected call.
- From Uri: May also be used to display the peer.