### PR TITLE
ci/build: add and fix baresip-apps build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,12 @@ jobs:
         repo: https://github.com/baresip/re
         secret: ${{ secrets.GITHUB_TOKEN }}
 
+    - uses: sreimers/pr-dependency-action@v0.6
+      with:
+        name: baresip-apps
+        repo: https://github.com/baresip/baresip-apps
+        secret: ${{ secrets.GITHUB_TOKEN }}
+
     - name: make re
       run: |
         cmake -S re -B re/build
@@ -115,15 +121,17 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: sudo ldconfig
 
-    - name: make baresip linux
-      if: ${{ runner.os == 'Linux' }}
+    - name: make baresip
       run: |
         cmake -B build -DCMAKE_C_FLAGS="-Werror" && cmake --build build -j
 
-    - name: make baresip macOS
-      if: ${{ runner.os == 'macOS' }}
+    - name: make baresip-apps
       run: |
-        cmake -B build -DCMAKE_C_FLAGS="-Werror" && cmake --build build -j
+        mv $p ../.
+        cmake -S ../$p -B ../$p/build
+        cmake --build ../$p/build -j
+      env:
+        p: baresip-apps
 
     - name: baresip static
       if: ${{ matrix.os == 'ubuntu-22.04' }}


### PR DESCRIPTION
Currently baresip-apps does not build.

This PR should add baresip-apps build to the workflows.
A baresip-apps PR with same name will fix the build

edit:
For discussion. Is this a good idea?
In re workflows, baresip is not built.

fix: https://github.com/baresip/baresip-apps/pull/45