### PR TITLE
srtp: lock possible re-keying against usage in receive handler

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -750,6 +750,8 @@ typedef int  (menc_media_h)(struct menc_media **mp, struct menc_sess *sess,
 			   struct sdp_media *sdpm,
 			   const struct stream *strm);
 
+typedef int (menc_txrekey_h)(struct menc_media *m);
+
 struct menc {
 	struct le le;
 	const char *id;
@@ -757,6 +759,7 @@ struct menc {
 	bool wait_secure;
 	menc_sess_h *sessh;
 	menc_media_h *mediah;
+	menc_txrekey_h *txrekeyh;
 };
 
 void menc_register(struct list *mencl, struct menc *menc);

--- a/modules/srtp/srtp.c
+++ b/modules/srtp/srtp.c
@@ -268,6 +268,7 @@ static bool recv_handler(struct sa *src, struct mbuf *mb, void *arg)
 	if (!st->srtp_rx) {
 		err = EBUSY;
 		warning("srtp: srtp_rx not ready (%m)\n", err);
+		mtx_unlock(st->mtx_rx);
 		goto out;
 	}
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -956,21 +956,17 @@ int stream_update(struct stream *s)
 
 
 /**
- * Removes the media encryption state from a stream.
+ * Calls the transmission rekeying handler of the media encryption
  *
- * Only apply if SRTP module is used!
- *
- * The encryption consists of 1 encryption session state and N encryption
- * media states.
- *
- * @param strm Stream to remove the media encryption state.
+ * @param strm Stream to rekey
  */
 void stream_remove_menc_media_state(struct stream *strm)
 {
 	if (!strm)
 		return;
 
-	strm->mes = mem_deref(strm->mes);
+	if (strm->menc->txrekeyh)
+		strm->menc->txrekeyh(strm->mes);
 }
 
 

--- a/test/main.c
+++ b/test/main.c
@@ -53,7 +53,7 @@ static const struct test tests[] = {
 	TEST(test_call_100rel_audio),
 	TEST(test_call_100rel_video),
 	TEST(test_call_hold_resume),
-	/* TEST(test_call_srtp_tx_rekey), */
+	TEST(test_call_srtp_tx_rekey),
 	TEST(test_cmd),
 	TEST(test_cmd_long),
 	TEST(test_contact),


### PR DESCRIPTION
 * while the main thread may remove the st->srtp_rx struct, the rx thread accessed the freed memory.
 * concurrent access of st->srtp_rx is mitigated with lock.
 * critical section is between first possible removal of st->srtp_rx, until new st->srtp_rx is ready. for the rx thread the access to srtcp_decrypt and srtp_decrypt.