### PR TITLE
call.c: allow INFO requests with no body

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1946,6 +1946,9 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 			}
 		}
 	}
+	else if (!mbuf_get_left(msg->mb)) {
+		(void)sip_reply(sip, msg, 200, "OK");
+	}
 	else {
 		(void)sip_reply(sip, msg, 488, "Not Acceptable Here");
 	}


### PR DESCRIPTION
[RFC 2976 section 2.2](https://www.rfc-editor.org/rfc/rfc2976#section-2) states that INFO requests with no message body MUST be answered with 200 OK.