### PR TITLE
audio,stream: video only call if no common audio codecs

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1169,7 +1169,7 @@ int audio_update(struct audio *a)
 		sc = sdp_media_rformat(m, NULL);
 	}
 
-	if (!sc) {
+	if (!sc || !sc->data) {
 		info("audio: stream is disabled\n");
 		audio_stop(a);
 		return 0;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1070,10 +1070,20 @@ void stream_flush(struct stream *s)
 
 void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
 {
+	struct sdp_media *m;
+
 	if (!strm)
 		return;
 
-	if (!sdp_media_has_media(stream_sdpmedia(strm)))
+	m = stream_sdpmedia(strm);
+	if (!sdp_media_has_media(m))
+		return;
+
+	if (sdp_media_disabled(m))
+		return;
+
+	const struct sdp_format *sc = sdp_media_rformat(m, NULL);
+	if (!sc || !sc->data)
 		return;
 
 	strm->rxm.rtp_timeout = timeout_ms;


### PR DESCRIPTION
Fixes call termination if there are no common audio codecs, but video is
possible. In this case now the audio stream is stopped and the call proceeds
with the video stream. In bound DTMF is not possible.

Related: https://github.com/baresip/re/pull/1128 which fixes a further issue:  the BYE was not sent.
