### PR TITLE
ua: avoid empty IP in SDP as local address

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -676,6 +676,9 @@ static int sdp_connection(const struct mbuf *mb, int *af, struct sa *sa)
 		err |= net_set_dst_scopeid(net, sa);
 
 out:
+	if (!err && !sa_isset(sa, SA_ADDR))
+	    return EINVAL;
+
 	return err;
 }
 


### PR DESCRIPTION
A c line with address 0.0.0.0 is allowed. In this case this should not be used
as laddr.
