### PR TITLE
test: call - complete test for auconv

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ldconfig
 
     - name: make baresip selftest
-      run: cmake -B build -DSTATIC=1 -DCMAKE_C_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage" -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
+      run: cmake -B build -DSTATIC=1 -DCMAKE_C_FLAGS="--coverage" -DCMAKE_EXE_LINKER_FLAGS="--coverage" -DMODULES="g711;ausine;fakevideo;auconv;auresamp;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: selftest
       run: ./build/test/selftest

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -55,7 +55,7 @@ jobs:
       run: sudo ldconfig
 
     - name: make baresip selftest
-      run: cmake -B build -DHAVE_THREADS= -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
+      run: cmake -B build -DHAVE_THREADS= -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;auresamp;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: run selftest
       run: ./build/test/selftest

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo ldconfig
 
     - name: make baresip selftest
-      run: cmake -B build -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;dtls_srtp;srtp;aufile" && cmake --build build -j
+      run: cmake -B build -DSTATIC=1 -DMODULES="g711;ausine;fakevideo;auconv;auresamp;dtls_srtp;srtp;aufile" && cmake --build build -j
 
     - name: valgrind test
       run: valgrind --leak-check=full --show-reachable=yes --error-exitcode=42 ./build/test/selftest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(${PROJECT_NAME}
 
   mock/cert.c
 
+  mock/mock_aucodec.c
   mock/mock_auplay.c
   mock/mock_mnat.c
   mock/mock_vidcodec.c

--- a/test/main.c
+++ b/test/main.c
@@ -27,7 +27,6 @@ static const struct test tests[] = {
 	TEST(test_call_answer),
 	TEST(test_call_answer_hangup_a),
 	TEST(test_call_answer_hangup_b),
-	TEST(test_call_aufilt),
 	TEST(test_call_aulevel),
 	TEST(test_call_custom_headers),
 	TEST(test_call_dtmf),

--- a/test/mock/mock_aucodec.c
+++ b/test/mock/mock_aucodec.c
@@ -1,0 +1,93 @@
+/**
+ * @file mock_aucodec.c mockup for audio codec with float support
+ *
+ * Copyright (C) 2024 commend.com - Christian Spielberger
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <string.h>
+#include "../test.h"
+
+
+static int encode(struct auenc_state *aes, bool *marker, uint8_t *buf,
+		       size_t *len, int fmt, const void *sampv, size_t sampc)
+{
+	const uint8_t *p = sampv;
+	size_t sz = aufmt_sample_size(fmt);
+	size_t psize = sampc * sz;
+
+	(void)aes;
+	(void)marker;
+
+	if (!buf || !len || !sampv)
+		return EINVAL;
+
+	if (*len < psize)
+		return ENOMEM;
+
+	*len = psize;
+
+	while (sampc--) {
+		/* raw format */
+		memcpy(buf, p, sz);
+
+		buf += sz;
+		p += sz;
+	}
+
+	return 0;
+}
+
+
+static int decode(struct audec_state *ads, int fmt, void *sampv,
+		       size_t *sampc, bool marker,
+		       const uint8_t *buf, size_t len)
+{
+	uint8_t *p = sampv;
+	size_t sz = aufmt_sample_size(fmt);
+
+	(void)ads;
+	(void)marker;
+
+	if (!sampv || !sampc || !buf || !len)
+		return EINVAL;
+
+	if (*sampc < len)
+		return ENOMEM;
+
+	*sampc = len/sz;
+
+	while (len) {
+		memcpy(p, buf, sz);
+		buf += sz;
+		p += sz;
+		len -= sz;
+	}
+
+	return 0;
+}
+
+
+static struct aucodec aucmock = {
+	.name  = "aucmock",
+	.srate = 48000,
+	.crate = 48000,
+	.ch    = 2,
+	.pch   = 2,
+	.ench  = encode,
+	.dech  = decode,
+};
+
+
+void mock_aucodec_register(void)
+{
+	aucodec_register(baresip_aucodecl(), &aucmock);
+}
+
+
+void mock_aucodec_unregister(void)
+{
+	aucodec_unregister(&aucmock);
+}

--- a/test/test.h
+++ b/test/test.h
@@ -153,6 +153,8 @@ struct auplay;
 
 typedef void (mock_sample_h)(struct auframe *af, const char *dev, void *arg);
 
+void mock_aucodec_register(void);
+void mock_aucodec_unregister(void);
 int mock_auplay_register(struct auplay **auplayp, struct list *auplayl,
 			 mock_sample_h *sampleh, void *arg);
 
@@ -195,7 +197,6 @@ int test_aulevel(void);
 int test_call_answer(void);
 int test_call_answer_hangup_a(void);
 int test_call_answer_hangup_b(void);
-int test_call_aufilt(void);
 int test_call_aulevel(void);
 int test_call_custom_headers(void);
 int test_call_dtmf(void);


### PR DESCRIPTION
This PR adds a test for audio filters. More concretely:
- auconv
- auresamp

```
audio tx pipeline:      ausine ---> aubuf ---> auconv ---> auresamp ---> aucmock
audio rx pipeline:  mock-auplay <--- aubuf <--- auconv <--- auresamp <--- aucmock
```

It tests these combinations
| ausrc/auplay | codec |
| -------- | --------- |
| s16le | s16le |
| s16le | float |
| float | s16le |
| float | float |

resampler test:
```
auresamp: resample encoder 16000/1 --> 48000/2
auresamp: resample decoder 48000/2 --> 16000/1
```