### PR TITLE
webrtc_aec: Add support for extended filter option

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -298,3 +298,6 @@ video_selfview		window # {window,pip}
 
 # avformat
 #avformat_pass_through	yes
+
+# webrtc_aec
+# webrtc_aec_extended_filter		yes

--- a/modules/webrtc_aec/aec.cpp
+++ b/modules/webrtc_aec/aec.cpp
@@ -113,6 +113,7 @@ int webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
 			new webrtc::ExtendedFilter(true)
 		);
 	}
+
 	aec->inst->SetExtraOptions(config);
 
  out:

--- a/modules/webrtc_aec/aec.cpp
+++ b/modules/webrtc_aec/aec.cpp
@@ -109,8 +109,10 @@ int webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
 	aec->inst->gain_control()->Enable(true);
 
 	if (webrtc_aec_extended_filter) {
-		config.Set<webrtc::ExtendedFilter>(new webrtc::ExtendedFilter(true));
-      }
+		config.Set<webrtc::ExtendedFilter>(
+			new webrtc::ExtendedFilter(true)
+		);
+	}
 	aec->inst->SetExtraOptions(config);
 
  out:
@@ -140,7 +142,11 @@ static int module_init(void)
 	aufilt_register(baresip_aufiltl(), &webrtc_aec);
 
 	struct conf *conf = conf_cur();
-	conf_get_bool(conf, "webrtc_aec_extended_filter", &webrtc_aec_extended_filter);
+	conf_get_bool(
+		conf,
+		"webrtc_aec_extended_filter",
+		&webrtc_aec_extended_filter
+	);
 
 	return 0;
 }

--- a/modules/webrtc_aec/aec.cpp
+++ b/modules/webrtc_aec/aec.cpp
@@ -31,6 +31,7 @@
 
 using namespace webrtc;
 
+static bool webrtc_aec_extended_filter;
 
 static void aec_destructor(void *arg)
 {
@@ -47,6 +48,7 @@ int webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
 {
 	struct aec *aec;
 	int err = 0;
+	Config config;
 
 	if (!stp || !ctx || !prm)
 		return EINVAL;
@@ -106,6 +108,11 @@ int webrtc_aec_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
 
 	aec->inst->gain_control()->Enable(true);
 
+	if (webrtc_aec_extended_filter) {
+		config.Set<webrtc::ExtendedFilter>(new webrtc::ExtendedFilter(true));
+      }
+	aec->inst->SetExtraOptions(config);
+
  out:
 	if (err)
 		mem_deref(aec);
@@ -131,6 +138,10 @@ static struct aufilt webrtc_aec = {
 static int module_init(void)
 {
 	aufilt_register(baresip_aufiltl(), &webrtc_aec);
+
+	struct conf *conf = conf_cur();
+	conf_get_bool(conf, "webrtc_aec_extended_filter", &webrtc_aec_extended_filter);
+
 	return 0;
 }
 


### PR DESCRIPTION
The module currently contains a description for the `webrtc_aec_extended_filter` parameter, but didn't provide an implementation.

The PR implements the `webrtc_aec_extended_filter` option.