### PR TITLE
auresamp: fix size of sampv if aufmt conversion needed

### DIFF
--- a/modules/auresamp/auresamp.c
+++ b/modules/auresamp/auresamp.c
@@ -71,10 +71,17 @@ static void dec_destructor(void *arg)
 
 static int sampv_alloc(struct auresamp_st *st, struct auframe *af)
 {
+	size_t psize_out;
 	size_t psize;
 
-	psize = auframe_size(af);
-	st->sampv = mem_zalloc(psize, NULL);
+	/* s16le used internally */
+	psize = af->sampc * af->ch * 2;
+
+	/* output format == input format */
+	psize_out = aufmt_sample_size(af->fmt) * af->sampc *
+			st->oprm.srate * st->oprm.ch / (af->srate * af->ch);
+
+	st->sampv = mem_zalloc(max(psize, psize_out), NULL);
 
 	if (!st->sampv)
 		return ENOMEM;


### PR DESCRIPTION
Second "try". Now it should be correct.

The test is activated here in this draft: https://github.com/baresip/baresip/pull/3047

`st->sampv` is used for:
- audio format conversion from input format to s16le and for
- conversion from s16le to the output format (= input format)

The maximum size needs to be allocated.