### PR TITLE
aufile: ptime zero check for ausrc

### DIFF
--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -197,7 +197,7 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	struct aufile_prm fprm;
 	int err;
 
-	if (!stp || !as || !prm)
+	if (!stp || !as || !prm  || !prm->ptime)
 		return EINVAL;
 
 	if (prm->fmt != AUFMT_S16LE) {


### PR DESCRIPTION
Reading a WAV file as fast as possible can be done with `aufile_open()` from `re`.

So we simply could make `ptime==0` unsupported, and return EINVAL in such a case.