### PR TITLE
ua,uag: support SUBSCRIBE only if handler is set

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -405,6 +405,7 @@ struct uag {
 struct config_sip *uag_cfg(void);
 const char *uag_eprm(void);
 bool uag_delayed_close(void);
+sip_msg_h *uag_subh(void);
 int uag_raise(struct ua *ua, struct le *le);
 
 void u32mask_enable(uint32_t *mask, uint8_t bit, bool enable);

--- a/src/ua.c
+++ b/src/ua.c
@@ -1892,7 +1892,10 @@ int ua_print_allowed(struct re_printf *pf, const struct ua *ua)
 
 	err = re_hprintf(pf,
 			 "INVITE,ACK,BYE,CANCEL,OPTIONS,"
-			 "NOTIFY,SUBSCRIBE,INFO,MESSAGE,UPDATE");
+			 "NOTIFY,INFO,MESSAGE,UPDATE");
+
+	if (uag_subh())
+		err |= re_hprintf(pf, ",SUBSCRIBE");
 
 	if (ua->acc->rel100_mode)
 		err |= re_hprintf(pf, ",PRACK");

--- a/src/uag.c
+++ b/src/uag.c
@@ -476,6 +476,9 @@ static bool sub_handler(const struct sip_msg *msg, void *arg)
 
 	if (uag.subh)
 		uag.subh(msg, ua);
+	else
+		(void)sip_treply(NULL, uag_sip(), msg, 405,
+				 "Method Not Allowed");
 
 	return true;
 }
@@ -1267,3 +1270,13 @@ bool uag_delayed_close(void)
 	return uag.delayed_close;
 }
 
+
+/**
+ * Get the subscribe handler
+ *
+ * @return Subscribe handler
+ */
+sip_msg_h *uag_subh(void)
+{
+	return uag.subh;
+}


### PR DESCRIPTION
BareSIP always has the SUBSCRIBE method in its Allow header, so other UAs correctly assume that we will respond to those. However, if no `subh` is set, these SUBSCRIBE messages will not be responded to.

Now, only if `subh` is set, we add SUBSCRIBE to the Allow header and if it is not set, we respond with 405 Method Not Allowed (see [RFC 3261 section 8.2.1](https://www.rfc-editor.org/rfc/rfc3261#section-8.2.1)).