### PR TITLE
cmake/webrtc_aec: use PUBLIC stdc++ linking

### DIFF
--- a/modules/webrtc_aec/CMakeLists.txt
+++ b/modules/webrtc_aec/CMakeLists.txt
@@ -27,4 +27,4 @@ target_compile_options(${PROJECT_NAME} PRIVATE
   -Wno-missing-field-initializers
   -Wno-unused-parameter
 )
-target_link_options(${PROJECT_NAME} PRIVATE -lstdc++)
+target_link_options(${PROJECT_NAME} PUBLIC -lstdc++)


### PR DESCRIPTION
Fixes static build:

```
/usr/bin/ld: libbaresip.a(aec.cpp.o): undefined reference to symbol '_ZSt9terminatev@@GLIBCXX_3.4'                                                          
/usr/bin/ld: /usr/lib/libstdc++.so.6: error adding symbols: DSO missing from command line
```