### PR TITLE
test/ua: disable dns cache for reg_dns tests

### DIFF
--- a/test/ua.c
+++ b/test/ua.c
@@ -274,6 +274,8 @@ static int reg_dns(enum sip_transp tp)
 
 	memset(&t, 0, sizeof(t));
 
+	dnsc_cache_max(net_dnsc(net), 0);
+
 	/*
 	 * Setup server-side mocks:
 	 */


### PR DESCRIPTION
similar to c15b6e2a8d28ac74715f9d0cf141e337f5279ffd

Fixes: https://github.com/baresip/baresip/issues/3066
