### PR TITLE
srtp: Fix base64 key decoding for AEAD_AES_256_GCM

### DIFF
--- a/modules/srtp/srtp.c
+++ b/modules/srtp/srtp.c
@@ -321,7 +321,7 @@ static int start_crypto(struct menc_st *st, const struct pl *key_info)
 
 	len = get_master_keylen(resolve_suite(st->crypto_suite));
 
-	/* key-info is BASE64 encoded requiring a buffer larger than the key length */
+	/* key-info is BASE64 encoded requiring a larger buffer */
 	new_key = mem_zalloc(sizeof(st->key_rx), NULL);
 	if (!new_key)
 		return ENOMEM;

--- a/modules/srtp/srtp.c
+++ b/modules/srtp/srtp.c
@@ -321,12 +321,12 @@ static int start_crypto(struct menc_st *st, const struct pl *key_info)
 
 	len = get_master_keylen(resolve_suite(st->crypto_suite));
 
-	/* key-info is BASE64 encoded */
-	new_key = mem_zalloc(len, NULL);
+	/* key-info is BASE64 encoded requiring a buffer larger than the key length */
+	new_key = mem_zalloc(sizeof(st->key_rx), NULL);
 	if (!new_key)
 		return ENOMEM;
 
-	olen = len;
+	olen = sizeof(st->key_rx);
 	err = base64_decode(key_info->p, key_info->l, new_key, &olen);
 	if (err) {
 		mem_deref(new_key);


### PR DESCRIPTION
The base64 decode routine requires a buffer size that is somewhat larger than the expected key size by olen < 3 * (ilen/4). When given just the expected key size for AEAD_AES_256_GCM as the base64 output length, EOVERFLOW is returned.

This was previously discussed in https://github.com/baresip/baresip/pull/790 when AEAD_AES_256_GCM support was added, but has regressed due to #2975.

Found the issue and tested the fix by making calls both to other Baresip instances and to FreeSWITCH.