### PR TITLE
add filter_registrar option

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -15,6 +15,7 @@ sip_verify_server	yes
 #sip_verify_client	no
 #sip_tls_resumption	all		# none, ids, tickets
 sip_tos			160 # See TOS fields!
+#filter_registrar   udp,tcp
 
 ## TOS fields ##
 #    7     6     5     4     3     2     1     0

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -362,6 +362,7 @@ struct config_sip {
 	bool verify_client;     /**< Enable SIP TLS verify client   */
 	enum tls_resume_mode tls_resume; /** TLS resumption mode    */
 	uint8_t tos;            /**< Type-of-Service for SIP        */
+	uint32_t reg_filt;	/**< Registrar filter transport mask*/
 };
 
 /** Call config */
@@ -945,6 +946,7 @@ int ua_set_autoanswer_value(struct ua *ua, const char *value);
 void ua_add_extension(struct ua *ua, const char *extension);
 void ua_remove_extension(struct ua *ua, const char *extension);
 bool ua_req_allowed(const struct ua *ua, const struct sip_msg *msg);
+bool ua_req_check_origin(const struct ua *ua, const struct sip_msg *msg);
 
 
 /* One instance */

--- a/src/core.h
+++ b/src/core.h
@@ -239,6 +239,7 @@ int  reg_json_api(struct odict *od, const struct reg *reg);
 int  reg_status(struct re_printf *pf, const struct reg *reg);
 int  reg_af(const struct reg *reg);
 const struct sa *reg_laddr(const struct reg *reg);
+const struct sa *reg_paddr(const struct reg *reg);
 void reg_set_custom_hdrs(struct reg *reg, const struct list *hdrs);
 
 /*

--- a/src/message.c
+++ b/src/message.c
@@ -96,7 +96,7 @@ static bool request_handler(const struct sip_msg *msg, void *arg)
 		return true;
 	}
 
-	if (!ua_req_allowed(ua, msg)) {
+	if (!ua_req_check_origin(ua, msg) || !ua_req_allowed(ua, msg)) {
 		(void)sip_treply(NULL, uag_sip(), msg, 403, "Forbidden");
 		return true;
 	}

--- a/src/reg.c
+++ b/src/reg.c
@@ -15,6 +15,7 @@ struct reg {
 	struct sipreg *sipreg;       /**< SIP Register client                */
 	int id;                      /**< Registration ID (for SIP outbound) */
 	int regint;                  /**< Registration interval              */
+	struct sa paddr;             /**< Peer Address                       */
 
 	/* status: */
 	uint16_t scode;              /**< Registration status code           */
@@ -131,6 +132,8 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 	if (200 <= msg->scode && msg->scode <= 299) {
 
 		uint32_t n_bindings;
+
+		reg->paddr = msg->src;
 
 		n_bindings = sip_msg_hdr_count(msg, SIP_HDR_CONTACT);
 		reg->af    = sipmsg_af(msg);
@@ -421,4 +424,10 @@ const struct sa *reg_laddr(const struct reg *reg)
 		return NULL;
 
 	return sipreg_laddr(reg->sipreg);
+}
+
+
+const struct sa *reg_paddr(const struct reg *reg)
+{
+	return reg ? &reg->paddr : NULL;
 }


### PR DESCRIPTION
If the new config option `filter_registrar` is set to some transport (default: `""`), any incoming request of that transport is verified to have originated from a registered server's IP address (only makes sense for registered accounts `regint>0`). Further, no listening socket is opened for the connection-oriented transport protocols listed in `filter_registrar` (i.e. a UDP socket is always opened if UDP is configured). BareSIP's default behavior stays the exact same.

Requires:
- https://github.com/baresip/re/pull/1160