### PR TITLE
audiounit: remove deprecated iOS session handling

### DIFF
--- a/modules/audiounit/audiounit.c
+++ b/modules/audiounit/audiounit.c
@@ -134,38 +134,11 @@ uint32_t audiounit_aufmt_to_formatflags(enum aufmt fmt)
 }
 
 
-#if TARGET_OS_IPHONE
-static void interruptionListener(void *data, UInt32 inInterruptionState)
-{
-	(void)data;
-
-	if (inInterruptionState == kAudioSessionBeginInterruption) {
-		info("audiounit: interrupt Begin\n");
-		audiosess_interrupt(true);
-	}
-	else if (inInterruptionState == kAudioSessionEndInterruption) {
-		info("audiounit: interrupt End\n");
-		audiosess_interrupt(false);
-	}
-}
-#endif
-
-
 static int module_init(void)
 {
 	AudioComponentDescription desc;
 	CFStringRef name = NULL;
 	int err;
-
-#if TARGET_OS_IPHONE
-	OSStatus ret;
-
-	ret = AudioSessionInitialize(NULL, NULL, interruptionListener, 0);
-	if (ret && ret != kAudioSessionAlreadyInitialized) {
-		warning("audiounit: AudioSessionInitialize: %d\n", ret);
-		return ENODEV;
-	}
-#endif
 
 	desc.componentType = kAudioUnitType_Output;
 #if TARGET_OS_IPHONE

--- a/modules/audiounit/sess.c
+++ b/modules/audiounit/sess.c
@@ -26,7 +26,6 @@ struct audiosess_st {
 static struct audiosess *gas;
 
 
-
 static void sess_destructor(void *arg)
 {
 	struct audiosess_st *st = arg;

--- a/modules/audiounit/sess.c
+++ b/modules/audiounit/sess.c
@@ -4,7 +4,6 @@
  * Copyright (C) 2010 Alfred E. Heggestad
  */
 #include <AudioUnit/AudioUnit.h>
-#include <AudioToolbox/AudioToolbox.h>
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
@@ -27,32 +26,6 @@ struct audiosess_st {
 static struct audiosess *gas;
 
 
-#if TARGET_OS_IPHONE
-static void propListener(void *inClientData, AudioSessionPropertyID inID,
-			 UInt32 inDataSize, const void *inData)
-{
-	struct audiosess *sess = inClientData;
-	CFDictionaryRef dref = inData;
-	CFNumberRef nref;
-	SInt32 reason = 0;
-
-	(void)inDataSize;
-	(void)sess;
-
-	if (kAudioSessionProperty_AudioRouteChange != inID)
-		return;
-
-	nref = CFDictionaryGetValue(
-			dref,
-			CFSTR(kAudioSession_AudioRouteChangeKey_Reason)
-			);
-
-	CFNumberGetValue(nref, kCFNumberSInt32Type, &reason);
-
-	info("audiounit: AudioRouteChange - reason %d\n", reason);
-}
-#endif
-
 
 static void sess_destructor(void *arg)
 {
@@ -66,12 +39,6 @@ static void sess_destructor(void *arg)
 static void destructor(void *arg)
 {
 	struct audiosess *as = arg;
-#if TARGET_OS_IPHONE
-	AudioSessionPropertyID id = kAudioSessionProperty_AudioRouteChange;
-
-	AudioSessionRemovePropertyListenerWithUserData(id, propListener, as);
-	AudioSessionSetActive(false);
-#endif
 
 	list_flush(&as->sessl);
 
@@ -86,25 +53,10 @@ int audiosess_alloc(struct audiosess_st **stp,
 	struct audiosess *as = NULL;
 	int err = 0;
 	bool created = false;
-#if TARGET_OS_IPHONE
-	AudioSessionPropertyID id = kAudioSessionProperty_AudioRouteChange;
-	UInt32 category;
-	OSStatus ret;
-#endif
 
 	if (!stp)
 		return EINVAL;
 
-#if TARGET_OS_IPHONE
-	/* Must be done for all modules */
-	category = kAudioSessionCategory_PlayAndRecord;
-	ret = AudioSessionSetProperty(kAudioSessionProperty_AudioCategory,
-				      sizeof(category), &category);
-	if (ret) {
-		warning("audiounit: Audio Category: %d\n", ret);
-		return EINVAL;
-	}
-#endif
 
 	if (gas)
 		goto makesess;
@@ -112,23 +64,6 @@ int audiosess_alloc(struct audiosess_st **stp,
 	as = mem_zalloc(sizeof(*as), destructor);
 	if (!as)
 		return ENOMEM;
-
-#if TARGET_OS_IPHONE
-	ret = AudioSessionSetActive(true);
-	if (ret) {
-		warning("audiounit: AudioSessionSetActive: %d\n", ret);
-		err = ENOTSUP;
-		goto out;
-	}
-
-	ret = AudioSessionAddPropertyListener(id, propListener, as);
-	if (ret) {
-		warning("audiounit: AudioSessionAddPropertyListener: %d\n",
-			ret);
-		err = EINVAL;
-		goto out;
-	}
-#endif
 
 	gas = as;
 	created = true;


### PR DESCRIPTION
Since iOS 7, AudioSession is deprecated and should be handled by application, so CallKit handling is easier to integrate.