### PR TITLE
ice: fix crash during ICE on fast disconnect

### DIFF
--- a/modules/ice/ice.c
+++ b/modules/ice/ice.c
@@ -179,6 +179,9 @@ static void turnc_handler(int err, uint16_t scode, const char *reason,
 	struct ice_cand *lcand;
 	(void)msg;
 
+	if (m->terminated)
+		return;
+
 	--m->nstun;
 
 	/* TURN failed, so we destroy the client */
@@ -716,6 +719,9 @@ static void conncheck_handler(int err, bool update, void *arg)
 	struct mnat_media *m = arg;
 	struct mnat_sess *sess = m->sess;
 	bool sess_complete = false;
+
+	if (m->terminated)
+		return;
 
 	info("ice: %s: connectivity check is complete (update=%d)\n",
 	     sdp_media_name(m->sdpm), update);


### PR DESCRIPTION
When searching for ICE candidates is not completed, but the peerconnection is quickly closed (https://github.com/baresip/baresip/blob/main/webrtc/src/sess.c#L260) the WebRTC demo will crash. 

Adding there small checks analog to this one https://github.com/baresip/baresip/blob/main/modules/ice/ice.c#L112 fixes the issue for me. I am not sure if any of the other functions should also have this check added.