### PR TITLE
test/call: set global certificate again in SNI test

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -3273,9 +3273,8 @@ int test_call_sni(void)
 	char s[256];
 
 	/* Set wrong global certificate. */
-	/* TODO re-enable this once test is fixed
-	 *re_snprintf(conf_config()->sip.cert, sizeof(conf_config()->sip.cert),
-		    "%s/sni/other-cert.pem", dp); */
+	re_snprintf(conf_config()->sip.cert, sizeof(conf_config()->sip.cert),
+		    "%s/sni/other-cert.pem", dp);
 	conf_config()->sip.verify_server = true;
 
 	/* Setup Mocking DNS Server */


### PR DESCRIPTION
test/call: set global certificate again in SNI test