### PR TITLE
sip/transp: add client certificate to all TLS transports

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -55,6 +55,7 @@ static const struct test tests[] = {
 	TEST(test_call_srtp_tx_rekey),
 #ifdef USE_TLS
 	TEST(test_call_sni),
+	TEST(test_call_cert_select),
 #endif
 	TEST(test_cmd),
 	TEST(test_cmd_long),

--- a/test/test.h
+++ b/test/test.h
@@ -229,6 +229,7 @@ int test_call_hold_resume(void);
 int test_call_srtp_tx_rekey(void);
 #ifdef USE_TLS
 int test_call_sni(void);
+int test_call_cert_select(void);
 #endif
 int test_cmd(void);
 int test_cmd_long(void);


### PR DESCRIPTION
test/call: add account certificate selection test

Currently, the test fails (as expected). With the [fix in libre](https://github.com/baresip/re/pull/1173) the test is green.

Fix:

- https://github.com/baresip/re/pull/1173