### PR TITLE
uag: match transport and af when finding ua for msg

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -919,21 +919,19 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 		struct ua *ua = le->data;
 		struct account *acc = ua_account(ua);
 
-		if (!acc->regint) {
-			if (!uri_match_transport(&acc->luri, NULL, msg->tp))
-				continue;
+		if (!uri_match_transport(&acc->luri, NULL, msg->tp))
+			continue;
 
-			if (!uri_match_af(&acc->luri, &msg->uri))
-				continue;
-
-			if (!uaf && ua_catchall(ua))
-				uaf = ua;
-		}
+		if (!uri_match_af(&acc->luri, &msg->uri))
+			continue;
 
 		if (0 == pl_casecmp(cuser, &acc->luri.user)) {
 			ua_printf(ua, "account match for %r\n", cuser);
 			return ua;
 		}
+		if (!acc->regint && !uaf && ua_catchall(ua))
+			uaf = ua;
+
 	}
 
 	if (uaf)


### PR DESCRIPTION
Currently, when finding a UA for an incoming msg, the transport protocol and address family only had to match for registrarless (regint=0) accounts.

Consider the case where `sip_transports  udp,tls` and there is a server account configured with `<sip:vuln@sip.example.com;transport=TLS>;regint=60`. Now BareSIP receives an incoming INVITE via UDP addressed to the account `vuln`. The account would be matched even though it is configured to use TLS.

Now, the transport protocol of the account (if configured) and the address family has to match, even if it is a server account (regint>0), which is the same behavior as it has always been for registrarless accounts.