### PR TITLE
aufilt: add aufilt_enable

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -674,6 +674,7 @@ typedef int (aufilt_decode_h)(struct aufilt_dec_st *st,
 struct aufilt {
 	struct le le;
 	const char *name;
+	bool enabled;
 	aufilt_encupd_h *encupdh;
 	aufilt_encode_h *ench;
 	aufilt_decupd_h *decupdh;
@@ -682,6 +683,7 @@ struct aufilt {
 
 void aufilt_register(struct list *aufiltl, struct aufilt *af);
 void aufilt_unregister(struct aufilt *af);
+void aufilt_enable(struct list *aufiltl, const char *name, bool enable);
 
 
 /*

--- a/modules/auresamp/auresamp.c
+++ b/modules/auresamp/auresamp.c
@@ -280,9 +280,11 @@ static int decode(struct aufilt_dec_st *aufilt_dec_st, struct auframe *af)
 }
 
 
-static struct aufilt resample = {
-	LE_INIT, "auresamp", encode_update, encode, decode_update, decode
-};
+static struct aufilt resample = {.name	  = "auresamp",
+				 .encupdh = encode_update,
+				 .ench	  = encode,
+				 .decupdh = decode_update,
+				 .dech	  = decode};
 
 
 static int module_init(void)

--- a/modules/mixausrc/mixausrc.c
+++ b/modules/mixausrc/mixausrc.c
@@ -868,9 +868,11 @@ static int dec_mix_stop(struct re_printf *pf, void *unused)
 }
 
 
-static struct aufilt mixausrc = {
-	LE_INIT, "mixausrc", encode_update, encode, decode_update, decode
-};
+static struct aufilt mixausrc = {.name	  = "mixausrc",
+				 .encupdh = encode_update,
+				 .ench	  = encode,
+				 .decupdh = decode_update,
+				 .dech	  = decode};
 
 
 static int module_init(void)

--- a/modules/mixminus/mixminus.c
+++ b/modules/mixminus/mixminus.c
@@ -441,9 +441,11 @@ static int debug_conference(struct re_printf *pf, void *arg)
 }
 
 
-static struct aufilt mixminus = {
-	LE_INIT, "mixminus", encode_update, encode, decode_update, decode
-};
+static struct aufilt mixminus = {.name	  = "mixminus",
+				 .encupdh = encode_update,
+				 .ench	  = encode,
+				 .decupdh = decode_update,
+				 .dech	  = decode};
 
 
 static const struct cmd cmdv[] = {

--- a/modules/webrtc_aecm/aec.cpp
+++ b/modules/webrtc_aecm/aec.cpp
@@ -125,14 +125,11 @@ int webrtc_aecm_alloc(struct aec **stp, void **ctx, struct aufilt_prm *prm)
 }
 
 
-static struct aufilt webrtc_aec = {
-	LE_INIT,
-	"webrtc_aecm",
-	webrtc_aecm_encode_update,
-	webrtc_aecm_encode,
-	webrtc_aecm_decode_update,
-	webrtc_aecm_decode
-};
+static struct aufilt webrtc_aec = {.name    = "webrtc_aecm",
+				   .encupdh = webrtc_aecm_encode_update,
+				   .ench    = webrtc_aecm_encode,
+				   .decupdh = webrtc_aecm_decode_update,
+				   .dech    = webrtc_aecm_decode};
 
 
 static int module_init(void)

--- a/src/audio.c
+++ b/src/audio.c
@@ -994,6 +994,9 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 		struct aufilt_dec_st *decst = NULL;
 		void *ctx = NULL;
 
+		if (!af->enabled)
+			continue;
+
 		if (af->encupdh && update_enc) {
 			err = af->encupdh(&encst, &ctx, af, &encprm, a);
 			if (err) {

--- a/src/aufilt.c
+++ b/src/aufilt.c
@@ -19,9 +19,37 @@ void aufilt_register(struct list *aufiltl, struct aufilt *af)
 	if (!aufiltl || !af)
 		return;
 
+	af->enabled = true;
+
 	list_append(aufiltl, &af->le, af);
 
 	info("aufilt: %s\n", af->name);
+}
+
+
+/**
+ * Enable/Disable a Audio Filter
+ *
+ * @param aufiltl List of Audio Filters
+ * @param name    Audio Filter name
+ * @param enable  True for enable and False for disable
+ */
+void aufilt_enable(struct list *aufiltl, const char *name, bool enable)
+{
+	struct le *le;
+
+	if (!aufiltl || !name)
+		return;
+
+	LIST_FOREACH(aufiltl, le) {
+		struct aufilt *af = le->data;
+
+		if (str_casecmp(af->name, name) != 0)
+			continue;
+
+		af->enabled = enable;
+		break;
+	}
 }
 
 


### PR DESCRIPTION
Currently audio filters can not be disabled. Maybe a application want only record specific calls, so a filter like `sndfile` can be enabled/disabled at runtime now.