### PR TITLE
aufile: fixes for prm->duration

### DIFF
--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -197,7 +197,7 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	struct aufile_prm fprm;
 	int err;
 
-	if (!stp || !as || !prm  || !prm->ptime)
+	if (!stp || !as || !prm)
 		return EINVAL;
 
 	if (prm->fmt != AUFMT_S16LE) {
@@ -216,6 +216,8 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	st->errh  = errh;
 	st->arg   = arg;
 	st->ptime = prm->ptime;
+	if (!st->ptime)
+		st->ptime = 20;
 
 	err = aufile_open(&st->aufile, &fprm, dev, AUFILE_READ);
 	if (err) {
@@ -231,10 +233,8 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	prm->ch    = fprm.channels;
 	prm->duration = aufile_get_length(st->aufile, &fprm);
 
-	if (!rh) {
-		mem_deref(st);
-		return 0;
-	}
+	if (!rh)
+		goto out;
 
 	st->prm   = *prm;
 


### PR DESCRIPTION
In order to retrieve the duration a read handler or setting ptime
is not needed.

Compare with module gst!

config:
```
module_app		debug_cmd.so
module			aufile.so
file_ausrc		aufile
```

```
$ echo "/aufileinfo ring.wav" | nc -N localhost 5555
/aufileinfo ring.wav
aufile: loading input file '/usr/local/share/baresip/ring.wav'
aufile: /usr/local/share/baresip/ring.wav: 8000 Hz, 1 channels, PCMU
debug_cmd: length = 1.514 seconds
```