### PR TITLE
ausrc, aufile, gst: replace duration by callback handler

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -565,6 +565,7 @@ int message_encode_dict(struct odict *od, struct account *acc,
 
 struct ausrc;
 struct ausrc_st;
+typedef size_t (ausrc_duration_h)(struct ausrc_st *st);
 
 /** Audio Source parameters */
 struct ausrc_prm {
@@ -572,7 +573,7 @@ struct ausrc_prm {
 	uint8_t    ch;          /**< Number of channels         */
 	uint32_t   ptime;       /**< Wanted packet-time in [ms] */
 	int        fmt;         /**< Sample format (enum aufmt) */
-	size_t     duration;    /**< Duration in [ms], 0 for infinite        */
+	ausrc_duration_h *durationh;  /**< Handler returns duration in [ms]  */
 };
 
 typedef void (ausrc_read_h)(struct auframe *af, void *arg);

--- a/modules/debug_cmd/debug_cmd.c
+++ b/modules/debug_cmd/debug_cmd.c
@@ -185,9 +185,12 @@ static void fileinfo_destruct(void *arg)
 
 static void print_fileinfo(struct fileinfo_st *st)
 {
-	double s  = ((float) st->prm.duration) / 1000;
+	size_t duration = 0;
+	if (st->prm.durationh)
+		duration = st->prm.durationh(st->ausrc);
 
-	if (st->prm.duration) {
+	if (duration) {
+		double s  = ((float) duration) / 1000;
 		info("debug_cmd: length = %1.3lf seconds\n", s);
 		module_event("debug_cmd", "aufileinfo", NULL, NULL,
 			 "length = %lf seconds", s);

--- a/modules/gst/gst.c
+++ b/modules/gst/gst.c
@@ -411,6 +411,21 @@ static void timeout(void *arg)
 }
 
 
+static size_t gst_duration_handler(struct ausrc_st *st)
+{
+	if (!st)
+		return 0;
+
+	gst_element_get_state(st->pipeline, NULL, NULL, 500*1000*1000);
+	gint64 duration = 0;
+	gst_element_query_duration(st->pipeline,
+			    GST_FORMAT_TIME,
+			    &duration);
+
+	return duration / 1000000;
+}
+
+
 static int gst_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		     struct ausrc_prm *prm, const char *device,
 		     ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
@@ -487,12 +502,7 @@ static int gst_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		mem_deref(st);
 	else {
 		*stp = st;
-		gst_element_get_state(st->pipeline, NULL, NULL, 500*1000*1000);
-		gint64 duration = 0;
-		gst_element_query_duration(st->pipeline,
-				   	   GST_FORMAT_TIME,
-				   	   &duration);
-		prm->duration = duration / 1000000;
+		prm->durationh = gst_duration_handler;
 	}
 
 	return err;


### PR DESCRIPTION
Retrieving the duration of an audio file may lead to long blocking
delay. E.g. gst_element_query_duration()

The proposed solution meant for discussion.

A callback handler added to `struct ausrc_prm` can be called by the application only if needed.
