### PR TITLE
ausrc, aufile, gst, debug_cmd: rework on ausrc duration retrieval

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -582,6 +582,8 @@ typedef void (ausrc_error_h)(int err, const char *str, void *arg);
 typedef int  (ausrc_alloc_h)(struct ausrc_st **stp, const struct ausrc *ausrc,
 			     struct ausrc_prm *prm, const char *device,
 			     ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
+typedef int  (ausrc_info_h)(const struct ausrc *ausrc,
+			    struct ausrc_prm *prm, const char *device);
 
 /** Defines an Audio Source */
 struct ausrc {
@@ -589,6 +591,7 @@ struct ausrc {
 	const char      *name;
 	struct list      dev_list;
 	ausrc_alloc_h   *alloch;
+	ausrc_info_h    *infoh;
 };
 
 int ausrc_register(struct ausrc **asp, struct list *ausrcl, const char *name,
@@ -598,6 +601,8 @@ int ausrc_alloc(struct ausrc_st **stp, struct list *ausrcl,
 		const char *name,
 		struct ausrc_prm *prm, const char *device,
 		ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
+int ausrc_info(struct list *ausrcl,
+	       const char *name, struct ausrc_prm *prm, const char *device);
 
 
 /*

--- a/modules/aufile/aufile.c
+++ b/modules/aufile/aufile.c
@@ -32,6 +32,10 @@ static int module_init(void)
 			     aufile_src_alloc);
 	err |= auplay_register(&auplay, baresip_auplayl(), "aufile",
 			       aufile_play_alloc);
+	if (err)
+		return err;
+
+	ausrc->infoh = aufile_info_handler;
 	return err;
 }
 

--- a/modules/aufile/aufile.h
+++ b/modules/aufile/aufile.h
@@ -10,3 +10,5 @@ int aufile_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		     struct ausrc_prm *prm, const char *dev,
 		     ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
+int aufile_info_handler(const struct ausrc *as,
+			struct ausrc_prm *prm, const char *dev);

--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -231,7 +231,6 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	/* return wav format to caller */
 	prm->srate = fprm.srate;
 	prm->ch    = fprm.channels;
-	prm->duration = aufile_get_length(st->aufile, &fprm);
 
 	if (!rh)
 		goto out;
@@ -269,5 +268,32 @@ int aufile_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	else
 		*stp = st;
 
+	return err;
+}
+
+
+int aufile_info_handler(const struct ausrc *as,
+			struct ausrc_prm *prm, const char *dev)
+{
+	int err;
+	(void)as;
+
+	if (!prm || !str_isset(dev))
+		return EINVAL;
+
+	struct aufile *aufile;
+	struct aufile_prm fprm;
+	err = aufile_open(&aufile, &fprm, dev, AUFILE_READ);
+	if (err) {
+		warning("aufile: failed to open file '%s' (%m)\n", dev, err);
+		return err;
+	}
+
+	prm->srate    = fprm.srate;
+	prm->ch       = fprm.channels;
+	prm->fmt      = fprm.fmt;
+	prm->duration = aufile_get_length(aufile, &fprm);
+
+	mem_deref(aufile);
 	return err;
 }

--- a/src/ausrc.c
+++ b/src/ausrc.c
@@ -105,3 +105,29 @@ int ausrc_alloc(struct ausrc_st **stp, struct list *ausrcl,
 
 	return as->alloch(stp, as, prm, device, rh, errh, arg);
 }
+
+
+/**
+ * Retreive audio parameters of an audio source
+ *
+ * @param ausrcl List of Audio Sources
+ * @param name   Name of Audio Source
+ * @param prm    Audio Source parameters
+ * @param device Name of Audio Source device (driver specific)
+ *
+ * @return 0 if success, otherwise errorcode
+ */
+int ausrc_info(struct list *ausrcl,
+		const char *name, struct ausrc_prm *prm, const char *device)
+{
+	struct ausrc *as;
+
+	as = (struct ausrc *)ausrc_find(ausrcl, name);
+	if (!as)
+		return ENOENT;
+
+	if (!as->infoh)
+		return EINVAL;
+
+	return as->infoh(as, prm, device);
+}


### PR DESCRIPTION
replaces: https://github.com/baresip/baresip/pull/3103

Another solution for duration retrieval.

Retrieving the duration of an audio file may lead to long blocking
delay. E.g. gst_element_query_duration()
Now a callback handler can be called by the application only if
needed.

```c
int ausrc_info(struct list *ausrcl, const char *name, const char *device, struct ausrc_prm *prm);
```

- Sets the fields of given ausrc_prm.
- No need to alloc an ausrc_st.
