### PR TITLE
bevent: update function calls in src

### DIFF
--- a/src/bevent.c
+++ b/src/bevent.c
@@ -91,9 +91,9 @@ static enum bevent_class bevent_class(enum ua_event ev)
 	case UA_EVENT_CREATE:
 	case UA_EVENT_MWI_NOTIFY:
 	case UA_EVENT_CUSTOM:
+	case UA_EVENT_SHUTDOWN:
 		return BEVENT_CLASS_UA;
 
-	case UA_EVENT_SHUTDOWN:
 	case UA_EVENT_EXIT:
 		return BEVENT_CLASS_APP;
 

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -405,7 +405,7 @@ static int add_rtcp_stats(struct odict *od_parent, const struct rtcp_stats *rs)
  * @param call Call object (optional)
  * @param prm  Event parameters
  *
- * @deprecated Use odict_encode_event() instead
+ * @deprecated Use odict_encode_bevent() instead
  *
  * @return 0 if success, otherwise errorcode
  */
@@ -724,8 +724,8 @@ void ua_event(struct ua *ua, enum ua_event ev, struct call *call,
 		warning("Used deprecated ua_event() for %s. "
 			"Use one of event_xxx_emit() instead!\n",
 			uag_event_str(ev));
-	struct bevent event = {.ev = ev, .txt = buf};
 
+	struct bevent event = {.ev = ev, .txt = buf};
 	if (bevent_class(ev) == BEVENT_CLASS_CALL)
 		event.u.call = call;
 	else if (bevent_class(ev) == BEVENT_CLASS_UA)

--- a/src/call.c
+++ b/src/call.c
@@ -313,8 +313,8 @@ static int update_media(struct call *call)
 {
 	debug("call: update media\n");
 
-	ua_event(call->ua, UA_EVENT_CALL_REMOTE_SDP, call,
-		 call->got_offer ? "offer" : "answer");
+	bevent_call_emit(UA_EVENT_CALL_REMOTE_SDP, call,
+			 call->got_offer ? "offer" : "answer");
 
 	return call_update_media(call);
 }
@@ -384,8 +384,8 @@ static void audio_level_handler(bool tx, double lvl, void *arg)
 	struct call *call = arg;
 	MAGIC_CHECK(call);
 
-	ua_event(call->ua, tx ? UA_EVENT_VU_TX : UA_EVENT_VU_RX,
-		 call, "%.2f", lvl);
+	bevent_call_emit(tx ? UA_EVENT_VU_TX : UA_EVENT_VU_RX, call,
+			 "%.2f", lvl);
 }
 
 
@@ -397,14 +397,15 @@ static void audio_error_handler(int err, const char *str, void *arg)
 	if (err) {
 		warning("call: audio device error: %m (%s)\n", err, str);
 
-		ua_event(call->ua, UA_EVENT_AUDIO_ERROR, call, "%d,%s",
-			err, str);
+		bevent_call_emit(UA_EVENT_AUDIO_ERROR, call,
+				 "%d,%s", err, str);
+
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_CLOSED,
 			"%s", str);
 	}
 	else
-		ua_event(call->ua, UA_EVENT_END_OF_FILE, call, "");
+		bevent_call_emit(UA_EVENT_END_OF_FILE, call, "");
 }
 
 
@@ -525,8 +526,8 @@ static void stream_rtpestab_handler(struct stream *strm, void *arg)
 	struct call *call = arg;
 	MAGIC_CHECK(call);
 
-	ua_event(call->ua, UA_EVENT_CALL_RTPESTAB, call,
-		 "%s", sdp_media_name(stream_sdpmedia(strm)));
+	bevent_call_emit(UA_EVENT_CALL_RTPESTAB, call,
+			 "%s", sdp_media_name(stream_sdpmedia(strm)));
 }
 
 
@@ -543,13 +544,13 @@ static void stream_rtcp_handler(struct stream *strm,
 		if (call->config_avt.rtp_stats)
 			call_set_xrtpstat(call);
 
-		ua_event(call->ua, UA_EVENT_CALL_RTCP, call,
-			 "%s", sdp_media_name(stream_sdpmedia(strm)));
+		bevent_call_emit(UA_EVENT_CALL_RTCP, call,
+				 "%s", sdp_media_name(stream_sdpmedia(strm)));
 		break;
 
 	case RTCP_APP:
-		ua_event(call->ua, UA_EVENT_CALL_RTCP, call,
-			 "%s", sdp_media_name(stream_sdpmedia(strm)));
+		bevent_call_emit(UA_EVENT_CALL_RTCP, call,
+				 "%s", sdp_media_name(stream_sdpmedia(strm)));
 		break;
 	}
 }
@@ -1092,8 +1093,8 @@ int call_modify(struct call *call)
 	if (call_refresh_allowed(call)) {
 		err = call_sdp_get(call, &desc, true);
 		if (!err) {
-			ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call,
-				 "offer");
+			bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call,
+					 "offer");
 
 			err = sipsess_modify(call->sess, desc);
 			if (err)
@@ -1226,7 +1227,7 @@ int call_progress_dir(struct call *call, enum sdp_dir adir, enum sdp_dir vdir)
 		goto out;
 
 	if (call->got_offer) {
-		ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call, "answer");
+		bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "answer");
 		err = call_update_media(call);
 	}
 
@@ -1294,8 +1295,8 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 	if (call->got_offer)
 		err = call_apply_sdp(call);
 
-	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call,
-		 "%s", !call->got_offer ? "offer" : "answer");
+	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call,
+			 "%s", !call->got_offer ? "offer" : "answer");
 
 	err = sdp_encode(&desc, call->sdp, !call->got_offer);
 	if (err)
@@ -1749,9 +1750,9 @@ static int sipsess_offer_handler(struct mbuf **descp,
 		}
 
 		if (aurx && !(sdp_media_dir(m) & SDP_SENDONLY))
-			ua_event(call->ua, UA_EVENT_CALL_HOLD, call, "");
+			bevent_call_emit(UA_EVENT_CALL_HOLD, call, "");
 		else if (!aurx && sdp_media_dir(m) & SDP_SENDONLY)
-			ua_event(call->ua, UA_EVENT_CALL_RESUME, call, "");
+			bevent_call_emit(UA_EVENT_CALL_RESUME, call, "");
 
 		err = update_media(call);
 		if (err) {
@@ -2337,8 +2338,8 @@ static void redirect_handler(const struct sip_msg *msg, const char *uri,
 	struct call *call = arg;
 
 	info("call: redirect to %s\n", uri);
-	ua_event(call->ua, UA_EVENT_CALL_REDIRECT, call,
-		 "%d,%s", msg->scode, uri);
+	bevent_call_emit(UA_EVENT_CALL_REDIRECT, call,
+			 "%d,%s", msg->scode, uri);
 	return;
 }
 
@@ -2434,7 +2435,7 @@ static int send_invite(struct call *call)
 	/* save call setup timer */
 	call->time_conn = time(NULL);
 
-	ua_event(call->ua, UA_EVENT_CALL_LOCAL_SDP, call, "offer");
+	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "offer");
 
 	return 0;
 }

--- a/src/reg.c
+++ b/src/reg.c
@@ -119,7 +119,7 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 
 		reg->scode = 999;
 
-		ua_event(reg->ua, evfail, NULL, "%m", err);
+		bevent_ua_emit(evfail, reg->ua, "%m", err);
 		return;
 	}
 
@@ -162,8 +162,8 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 			}
 		}
 
-		ua_event(reg->ua, evok, NULL, "%u %r",
-			 msg->scode, &msg->reason);
+		bevent_ua_emit(evok, reg->ua,
+			       "%u %r", msg->scode, &msg->reason);
 	}
 	else if (msg->scode >= 300) {
 
@@ -172,8 +172,8 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 
 		reg->scode = msg->scode;
 
-		ua_event(reg->ua, evfail, NULL, "%u %r",
-			 msg->scode, &msg->reason);
+		bevent_ua_emit(evfail, reg->ua,
+			       "%u %r", msg->scode, &msg->reason);
 	}
 }
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -426,7 +426,7 @@ unsigned ua_destroy(struct ua *ua)
 	list_unlink(&ua->le);
 
 	/* send the shutdown event */
-	bevent_app_emit(UA_EVENT_SHUTDOWN, NULL, NULL);
+	bevent_ua_emit(UA_EVENT_SHUTDOWN, ua, NULL);
 
 	/* terminate all calls now */
 	list_flush(&ua->calls);

--- a/src/ua.c
+++ b/src/ua.c
@@ -46,11 +46,12 @@ static void ua_destructor(void *arg)
 	list_unlink(&ua->le);
 
 	if (!list_isempty(&ua->regl))
-		ua_event(ua, UA_EVENT_UNREGISTERING, NULL, NULL);
+		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
 
 	LIST_FOREACH(&ua->calls, le) {
 		struct call *call = le->data;
-		ua_event(ua, UA_EVENT_CALL_CLOSED, call, "User-Agent deleted");
+		bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+				 "User-Agent deleted");
 	}
 
 	list_flush(&ua->calls);
@@ -219,7 +220,7 @@ static int start_register(struct ua *ua, bool fallback)
 		create_register_clients(ua);
 
 	if (!fallback && !list_isempty(&ua->regl))
-		ua_event(ua, UA_EVENT_REGISTERING, NULL, NULL);
+		bevent_ua_emit(UA_EVENT_REGISTERING, ua, NULL);
 
 	for (le = ua->regl.head, i=0; le; le = le->next, i++) {
 		struct reg *reg = le->data;
@@ -234,10 +235,10 @@ static int start_register(struct ua *ua, bool fallback)
 			warning("ua: SIP%s register failed: %m\n",
 					fallback ? " fallback" : "", err);
 
-			ua_event(ua, fallback ?
-					UA_EVENT_FALLBACK_FAIL :
-					UA_EVENT_REGISTER_FAIL,
-					NULL, "%m", err);
+			bevent_ua_emit(fallback ?
+				       UA_EVENT_FALLBACK_FAIL :
+				       UA_EVENT_REGISTER_FAIL,
+				       ua, "%m", err);
 			goto out;
 		}
 	}
@@ -302,7 +303,7 @@ void ua_stop_register(struct ua *ua)
 		return;
 
 	if (!list_isempty(&ua->regl))
-		ua_event(ua, UA_EVENT_UNREGISTERING, NULL, NULL);
+		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
 
 	for (le = ua->regl.head; le; le = le->next) {
 		struct reg *reg = le->data;
@@ -325,7 +326,7 @@ void ua_unregister(struct ua *ua)
 		return;
 
 	if (!list_isempty(&ua->regl))
-		ua_event(ua, UA_EVENT_UNREGISTERING, NULL, NULL);
+		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
 
 	for (le = ua->regl.head; le; le = le->next) {
 		struct reg *reg = le->data;
@@ -425,7 +426,7 @@ unsigned ua_destroy(struct ua *ua)
 	list_unlink(&ua->le);
 
 	/* send the shutdown event */
-	ua_event(ua, UA_EVENT_SHUTDOWN, NULL, NULL);
+	bevent_app_emit(UA_EVENT_SHUTDOWN, NULL, NULL);
 
 	/* terminate all calls now */
 	list_flush(&ua->calls);
@@ -524,12 +525,13 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 			info("ua: blocked access: \"%s\"\n", peeruri);
 
-			ua_event(ua, UA_EVENT_CALL_CLOSED, call, "%s", str);
+			bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+					 "%s", str);
 			mem_deref(call);
 			break;
 		}
 
-		ua_event(ua, UA_EVENT_CALL_INCOMING, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_INCOMING, call, "%s", peeruri);
 		switch (ua->acc->answermode) {
 
 		case ANSWERMODE_EARLY:
@@ -553,43 +555,45 @@ static void call_event_handler(struct call *call, enum call_event ev,
 		break;
 
 	case CALL_EVENT_RINGING:
-		ua_event(ua, UA_EVENT_CALL_RINGING, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_RINGING, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_OUTGOING:
-		ua_event(ua, UA_EVENT_CALL_OUTGOING, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_OUTGOING, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_PROGRESS:
 		ua_printf(ua, "Call in-progress: %s\n", peeruri);
-		ua_event(ua, UA_EVENT_CALL_PROGRESS, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_PROGRESS, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_ANSWERED:
 		ua_printf(ua, "Call answered: %s\n", peeruri);
-		ua_event(ua, UA_EVENT_CALL_ANSWERED, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_ANSWERED, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_ESTABLISHED:
 		ua_printf(ua, "Call established: %s\n", peeruri);
-		ua_event(ua, UA_EVENT_CALL_ESTABLISHED, call, "%s", peeruri);
+		bevent_call_emit(UA_EVENT_CALL_ESTABLISHED, call,
+				"%s", peeruri);
 		break;
 
 	case CALL_EVENT_CLOSED:
-		ua_event(ua, UA_EVENT_CALL_CLOSED, call, "%s", str);
+		bevent_call_emit(UA_EVENT_CALL_CLOSED, call, "%s", str);
 		mem_deref(call);
 		break;
 
 	case CALL_EVENT_TRANSFER:
-		ua_event(ua, UA_EVENT_CALL_TRANSFER, call, "%s", str);
+		bevent_call_emit(UA_EVENT_CALL_TRANSFER, call, "%s", str);
 		break;
 
 	case CALL_EVENT_TRANSFER_FAILED:
-		ua_event(ua, UA_EVENT_CALL_TRANSFER_FAILED, call, "%s", str);
+		bevent_call_emit(UA_EVENT_CALL_TRANSFER_FAILED, call,
+				"%s", str);
 		break;
 
 	case CALL_EVENT_MENC:
-		ua_event(ua, UA_EVENT_CALL_MENC, call, "%s", str);
+		bevent_call_emit(UA_EVENT_CALL_MENC, call, "%s", str);
 		break;
 	}
 }
@@ -607,10 +611,11 @@ static void call_dtmf_handler(struct call *call, char key, void *arg)
 		key_str[0] = key;
 		key_str[1] = '\0';
 
-		ua_event(ua, UA_EVENT_CALL_DTMF_START, call, "%s", key_str);
+		bevent_call_emit(UA_EVENT_CALL_DTMF_START, call,
+				 "%s", key_str);
 	}
 	else {
-		ua_event(ua, UA_EVENT_CALL_DTMF_END, call, NULL);
+		bevent_call_emit(UA_EVENT_CALL_DTMF_END, call, NULL);
 	}
 }
 
@@ -1100,7 +1105,7 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 	}
 
 	debug("ua: REFER to %r\n", &hdr->val);
-	ua_event(ua, UA_EVENT_REFER, NULL, "%r", &hdr->val);
+	bevent_ua_emit(UA_EVENT_REFER, ua, "%r", &hdr->val);
 
 out:
 
@@ -1214,7 +1219,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 		goto out;
 
 	list_append(uag_list(), &ua->le, ua);
-	ua_event(ua, UA_EVENT_CREATE, NULL, "%s", aor);
+	bevent_ua_emit(UA_EVENT_CREATE, ua, "%s", aor);
 
  out:
 	mem_deref(host);
@@ -1414,8 +1419,8 @@ void ua_hangup(struct ua *ua, struct call *call,
 
 	call_hangup(call, scode, reason);
 
-	ua_event(ua, UA_EVENT_CALL_CLOSED, call,
-		 reason ? reason : "Connection reset by user");
+	bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+			 reason ? reason : "Connection reset by user");
 
 	mem_deref(call);
 }

--- a/src/uag.c
+++ b/src/uag.c
@@ -19,7 +19,7 @@ static void exit_handler(void *arg)
 {
 	(void)arg;
 
-	ua_event(NULL, UA_EVENT_EXIT, NULL, NULL);
+	bevent_app_emit(UA_EVENT_EXIT, NULL, NULL);
 
 	debug("ua: sip-stack exit\n");
 
@@ -734,9 +734,9 @@ int uag_reset_transp(bool reg, bool reinvite)
 				if (!call_refresh_allowed(call)) {
 					call_hangup(call, 500, "Transport of "
 						    "User Agent changed");
-					ua_event(ua, UA_EVENT_CALL_CLOSED,
-						 call, "Transport of "
-						 "User Agent changed");
+					bevent_call_emit(UA_EVENT_CALL_CLOSED,
+							 call, "Transport of "
+							 "User Agent changed");
 					mem_deref(call);
 					continue;
 				}


### PR DESCRIPTION
- core: use bevent API
- fix: `UA_EVENT_SHUTDOWN` moved to event class `BEVENT_CLASS_UA`


Step 3 of initial PR https://github.com/baresip/baresip/pull/3090

### Steps for bevent
- [x] add core bevent
- [x] ~~add event class filter mask to `bevent_register()`~~
- [x] add backwards wrapper
- [ ] update function calls
  - [x] use bevent API in core
  - [ ] use bevent API in test
  - [ ] use bevent API in module menu
  - [ ] module ctrl_dbus
  - [ ] module ctrl_tcp
  - [ ] module echo
  - [ ] module gtk
  - [ ] module mqtt
  - [ ] module mwi
  - [ ] module presence
  - [ ] module rtcpsummary
  - [ ] module serreg
  - [ ] module ebuacip
- [ ] provide alternative to https://github.com/baresip/baresip/pull/3088
- [ ] move DnD feature from core to menu
- [ ] move more of the 4xx replies from core to menu