### PR TITLE
menu: use new bevent API

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -652,17 +652,19 @@ static void process_module_event(struct call *call, const char *prm)
 }
 
 
-static void ua_event_handler(struct ua *ua, enum ua_event ev,
-			     struct call *call, const char *prm, void *arg)
+static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 {
 	struct call *call2 = NULL;
-	struct account *acc = ua_account(ua);
 	int32_t adelay = -1;
 	bool incall;
 	enum sdp_dir ardir, vrdir;
 	uint32_t count;
 	struct pl val;
 	char * uri;
+	const char           *prm  = bevent_get_text(event);
+	struct call          *call = bevent_get_call(event);
+	struct ua            *ua   = bevent_get_ua(event);
+	struct account       *acc  = ua_account(bevent_get_ua(event));
 	int err;
 	(void)arg;
 
@@ -1179,7 +1181,7 @@ static int module_init(void)
 	if (err)
 		return err;
 
-	err = uag_event_register(ua_event_handler, NULL);
+	err = bevent_register(event_handler, NULL);
 	if (err)
 		return err;
 
@@ -1199,7 +1201,7 @@ static int module_close(void)
 
 	message_unlisten(baresip_message(), message_handler);
 
-	uag_event_unregister(ua_event_handler);
+	bevent_unregister(event_handler);
 	static_menu_unregister();
 	dial_menu_unregister();
 	dynamic_menu_unregister();


### PR DESCRIPTION
core: use bevent API

Step 3 of initial PR https://github.com/baresip/baresip/pull/3090

### Steps for bevent
- [x] add core bevent
- [x] ~~add event class filter mask to `bevent_register()`~~
- [x] add backwards wrapper
- [ ] update function calls
  - [ ] use bevent API in core
  - [ ] use bevent API in test
  - [x] use bevent API in module menu
  - [ ] module ctrl_dbus
  - [ ] module ctrl_tcp
  - [ ] module echo
  - [ ] module gtk
  - [ ] module mqtt
  - [ ] module mwi
  - [ ] module presence
  - [ ] module rtcpsummary
  - [ ] module serreg
  - [ ] module ebuacip
- [ ] provide alternative to https://github.com/baresip/baresip/pull/3088
- [ ] move DnD feature from core to menu
- [ ] move more of the 4xx replies from core to menu