### PR TITLE
ua: remove all matching headers when calling ua_rm_custom_hdr

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -2052,7 +2052,6 @@ int ua_rm_custom_hdr(struct ua *ua, struct pl *name)
 		if (!pl_cmp(&h->name, name)) {
 			list_unlink(&h->le);
 			mem_deref(h);
-			break;
 		}
 	}
 


### PR DESCRIPTION
Currently, only the first matching header is removed when calling ua_rm_custom_hdr. Now, all matching headers are removed.