### PR TITLE
ua,menu: do not accept call by default

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -34,6 +34,7 @@ sip_tos			160 # See TOS fields!
 call_local_timeout	120
 call_max_calls		4
 call_hold_other_calls	yes
+call_accept		no
 
 # Audio
 #audio_path		/usr/local/share/baresip

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -372,6 +372,7 @@ struct config_call {
 	uint32_t local_timeout; /**< Incoming call timeout [sec] 0=off    */
 	uint32_t max_calls;     /**< Maximum number of calls, 0=unlimited */
 	bool hold_other_calls;  /**< Hold other calls */
+	bool accept;            /**< Accept call by baresip core          */
 };
 
 /** Audio */
@@ -909,6 +910,7 @@ int  ua_connect_dir(struct ua *ua, struct call **callp,
 		    enum vidmode vmode, enum sdp_dir adir, enum sdp_dir vdir);
 void ua_hangup(struct ua *ua, struct call *call,
 	       uint16_t scode, const char *reason);
+int  ua_accept(struct ua *ua, const struct sip_msg *msg);
 int  ua_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_options_send(struct ua *ua, const char *uri,

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -664,6 +664,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	const char           *prm  = bevent_get_text(event);
 	struct call          *call = bevent_get_call(event);
 	struct ua            *ua   = bevent_get_ua(event);
+	const struct sip_msg *msg  = bevent_get_msg(event);
 	struct account       *acc  = ua_account(bevent_get_ua(event));
 	int err;
 	(void)arg;
@@ -679,6 +680,17 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	count = uag_call_count();
 
 	switch (ev) {
+
+	case UA_EVENT_SIPSESS_CONN:
+		ua = uag_find_msg(msg);
+		err = ua_accept(ua, msg);
+		if (err) {
+			warning("menu: could not accept incoming call (%m)\n",
+				err);
+			return;
+		}
+
+		break;
 
 	case UA_EVENT_CALL_INCOMING:
 

--- a/src/config.c
+++ b/src/config.c
@@ -46,7 +46,8 @@ static struct config core_config = {
 	{
 		120,
 		4,
-		true
+		true,
+		false
 	},
 
 	/** Audio */
@@ -435,6 +436,8 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 			   &cfg->call.max_calls);
 	(void)conf_get_bool(conf, "call_hold_other_calls",
 			   &cfg->call.hold_other_calls);
+	(void)conf_get_bool(conf, "call_accept",
+			   &cfg->call.accept);
 
 	/* Audio */
 	(void)conf_get_str(conf, "audio_path", cfg->audio.audio_path,
@@ -614,6 +617,7 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 			 "call_local_timeout\t%u\n"
 			 "call_max_calls\t\t%u\n"
 			 "call_hold_other_calls\t%s\n"
+			 "call_accept\t\t%s\n"
 			 "\n",
 			 cfg->sip.local, cfg->sip.cert, cfg->sip.cafile,
 			 cfg->sip.capath, sip_transports_print,
@@ -627,7 +631,8 @@ int config_print(struct re_printf *pf, const struct config *cfg)
 
 			 cfg->call.local_timeout,
 			 cfg->call.max_calls,
-			 cfg->call.hold_other_calls ? "yes" : "no");
+			 cfg->call.hold_other_calls ? "yes" : "no",
+			 cfg->call.accept ? "yes" : "no");
 	if (err)
 		return err;
 
@@ -887,6 +892,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "call_local_timeout\t%u\n"
 			  "call_max_calls\t\t%u\n"
 			  "call_hold_other_calls\tyes\n"
+			  "call_accept\t\tno\n"
 			  "\n"
 			  ,
 			  cfg->call.local_timeout,

--- a/test/call.c
+++ b/test/call.c
@@ -628,6 +628,9 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	ASSERT_TRUE(f != NULL);
 	ASSERT_EQ(MAGIC, f->magic);
 
+	if (ev == UA_EVENT_CREATE)
+		return;
+
 	if (!ua)
 		ua = uag_find_msg(msg);
 
@@ -647,9 +650,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	else if (ua == f->c.ua)
 		ag = &f->c;
 	else {
-		if (ev != UA_EVENT_CREATE)
-			warning("test: could not find agent/ua\n");
-
+		warning("test: could not find agent/ua\n");
 		return;
 	}
 

--- a/test/call.c
+++ b/test/call.c
@@ -617,6 +617,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	const char    *prm  = bevent_get_text(event);
 	struct call   *call = bevent_get_call(event);
 	struct ua     *ua   = bevent_get_ua(event);
+	const struct sip_msg *msg  = bevent_get_msg(event);
 	int err = 0;
 
 #if 1
@@ -627,6 +628,18 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	ASSERT_TRUE(f != NULL);
 	ASSERT_EQ(MAGIC, f->magic);
 
+	if (!ua)
+		ua = uag_find_msg(msg);
+
+	if (ua && ev == UA_EVENT_SIPSESS_CONN) {
+		err = ua_accept(ua, msg);
+		if (err) {
+			warning("test: could not accept incoming call (%m)\n",
+				err);
+			return;
+		}
+	}
+
 	if (ua == f->a.ua)
 		ag = &f->a;
 	else if (ua == f->b.ua)
@@ -634,6 +647,9 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	else if (ua == f->c.ua)
 		ag = &f->c;
 	else {
+		if (ev != UA_EVENT_CREATE)
+			warning("test: could not find agent/ua\n");
+
 		return;
 	}
 
@@ -881,7 +897,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 }
 
 
-int test_call_answer(void)
+static int test_call_answer_priv(void)
 {
 	struct fixture fix, *f = &fix;
 	int err = 0;
@@ -910,8 +926,28 @@ int test_call_answer(void)
 
  out:
 	fixture_close(f);
-
 	return err;
+}
+
+
+int test_call_answer(void)
+{
+	int err;
+	conf_config()->call.accept = true;
+	err = test_call_answer_priv();
+	if (err) {
+		warning("call_accept true failed\n");
+		return err;
+	}
+
+	conf_config()->call.accept = false;
+	err = test_call_answer_priv();
+	if (err) {
+		warning("call_accept false failed\n");
+		return err;
+	}
+
+	return 0;
 }
 
 


### PR DESCRIPTION
Replaces https://github.com/baresip/baresip/pull/3088 "Moved 180 Ringing response from core to app (menu module)"

- The application decides when to send a 180 Ringing.
- A new config setting `call_accept` can be set to `yes` in order to let the baresip core reply with 180 Ringing, like before.

Note: As requested by @juha-h this changes the default behavior of the baresip core, because `call_accept` is `off` by default.

### Steps for bevent
- [x] add core bevent
- [x] ~~add event class filter mask to `bevent_register()`~~
- [x] add backwards wrapper
- [x] update function calls
  - [x] use bevent API in core
  - [x] use bevent API in test
  - [x] use bevent API in module menu
  - [x] module ctrl_dbus
  - [x] module ctrl_tcp
  - [x] module echo
  - [x] module gtk
  - [x] module mqtt
  - [x] module mwi
  - [x] module presence (forgot `publisher.c`)
  - [x] module rtcpsummary
  - [x] module serreg
  - [x ] module ebuacip
- [x] provide alternative to https://github.com/baresip/baresip/pull/3088
- [ ] move DnD feature from core to menu
- [ ] move more of the 4xx replies from core to menu
- [ ] let `menu` decide if 180 Ringing is sent or 183 Session Progress. Not both like it is done currently if `answermode` is `early`.