### PR TITLE
bevent: move dnd to menu

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -972,6 +972,7 @@ void ua_close(void);
 void ua_stop_all(bool forced);
 int  uag_hold_resume(struct call *call);
 int  uag_hold_others(struct call *call);
+int  uag_reject(const struct sip_msg *msg, uint16_t scode, const char *reason);
 void uag_set_nodial(bool nodial);
 bool uag_nodial(void);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -972,7 +972,6 @@ void ua_close(void);
 void ua_stop_all(bool forced);
 int  uag_hold_resume(struct call *call);
 int  uag_hold_others(struct call *call);
-int  uag_reject(const struct sip_msg *msg, uint16_t scode, const char *reason);
 void uag_set_nodial(bool nodial);
 bool uag_nodial(void);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -975,8 +975,6 @@ int  uag_hold_others(struct call *call);
 void uag_set_nodial(bool nodial);
 bool uag_nodial(void);
 void uag_set_exit_handler(ua_exit_h *exith, void *arg);
-void uag_set_dnd(bool dnd);
-bool uag_dnd(void);
 void uag_enable_sip_trace(bool enable);
 int  uag_reset_transp(bool reg, bool reinvite);
 void uag_set_sub_handler(sip_msg_h *subh);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -682,6 +682,13 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	switch (ev) {
 
 	case UA_EVENT_SIPSESS_CONN:
+
+		if (menu.dnd) {
+			(void)sip_treply(NULL, uag_sip(), msg, 480,
+					 "Temporarily Unavailable");
+			break;
+		}
+
 		ua = uag_find_msg(msg);
 		err = ua_accept(ua, msg);
 		if (err) {

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -684,8 +684,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	case UA_EVENT_SIPSESS_CONN:
 
 		if (menu.dnd) {
-			(void)sip_treply(NULL, uag_sip(), msg, 480,
-					 "Temporarily Unavailable");
+			uag_reject(msg, 480, "Temporarily Unavailable");
 			break;
 		}
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -686,6 +686,9 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 		if (menu.dnd) {
 			(void)sip_treply(NULL, uag_sip(), msg, 480,
 					 "Temporarily Unavailable");
+			info("menu: incoming call from %r <%r> rejected: "
+			     "480 Temporarily Unavailable\n",
+			     &msg->from.dname, &msg->from.auri);
 			break;
 		}
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -684,7 +684,8 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	case UA_EVENT_SIPSESS_CONN:
 
 		if (menu.dnd) {
-			uag_reject(msg, 480, "Temporarily Unavailable");
+			(void)sip_treply(NULL, uag_sip(), msg, 480,
+					 "Temporarily Unavailable");
 			break;
 		}
 

--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -36,6 +36,7 @@ struct menu{
 	struct odict *ovaufile;       /**< Override aufile dictionary     */
 	struct tmr tmr_play;          /**< Tones play timer               */
 	size_t outcnt;                /**< Outgoing call counter          */
+	bool dnd;                     /**< Do not disturb flag            */
 };
 
 /*Get menu object*/

--- a/modules/menu/static_menu.c
+++ b/modules/menu/static_menu.c
@@ -712,13 +712,14 @@ static int cmd_dnd(struct re_printf *pf, void *arg)
 {
 	int err = 0;
 	const struct cmd_arg *carg = arg;
+	struct menu *menu = menu_get();
 	bool en = false;
 
 	err = str_bool(&en, carg->prm);
 	if (err)
 		goto out;
 
-	uag_set_dnd(en);
+	menu->dnd = en;
 
  out:
 	if (err)

--- a/src/ua.c
+++ b/src/ua.c
@@ -722,12 +722,6 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 		return;
 	}
 
-	if (uag_dnd()) {
-		(void)sip_treply(NULL, uag_sip(), msg,
-			480,"Temporarily Unavailable");
-		return;
-	}
-
 	/* handle multiple calls */
 	if (config->call.max_calls &&
 	    uag_call_count() + 1 > config->call.max_calls) {

--- a/src/uag.c
+++ b/src/uag.c
@@ -1235,28 +1235,6 @@ const char *uag_eprm(void)
 
 
 /**
- * Set global Do not Disturb flag
- *
- * @param dnd DnD flag
- */
-void uag_set_dnd(bool dnd)
-{
-	uag.dnd = dnd;
-}
-
-
-/**
- * Get DnD status of uag
- *
- * @return True if DnD is active, False if not
- */
-bool uag_dnd(void)
-{
-	return uag.dnd;
-}
-
-
-/**
  * Enable/Disable a transport protocol
  *
  * @param tp  Transport protocol

--- a/src/uag.c
+++ b/src/uag.c
@@ -113,6 +113,16 @@ int uag_hold_others(struct call *call)
 }
 
 
+int uag_reject(const struct sip_msg *msg, uint16_t scode, const char *reason)
+{
+	if (!msg)
+		return EINVAL;
+
+	info("uag: incoming call rejected: %u %s\n", scode, reason);
+	return sip_treply(NULL, uag_sip(), msg, scode, reason);
+}
+
+
 /**
  * Find call with given id
  *

--- a/src/uag.c
+++ b/src/uag.c
@@ -113,16 +113,6 @@ int uag_hold_others(struct call *call)
 }
 
 
-int uag_reject(const struct sip_msg *msg, uint16_t scode, const char *reason)
-{
-	if (!msg)
-		return EINVAL;
-
-	info("uag: incoming call rejected: %u %s\n", scode, reason);
-	return sip_treply(NULL, uag_sip(), msg, scode, reason);
-}
-
-
 /**
  * Find call with given id
  *


### PR DESCRIPTION
- ua,menu: move DnD to menu
- uag: add uag_reject() with log info

### Steps for bevent
- [x] add core bevent
- [x] ~~add event class filter mask to `bevent_register()`~~
- [x] add backwards wrapper
- [x] update function calls
  - [x] use bevent API in core
  - [x] use bevent API in test
  - [x] use bevent API in module menu
  - [x] module ctrl_dbus
  - [x] module ctrl_tcp
  - [x] module echo
  - [x] module gtk
  - [x] module mqtt
  - [x] module mwi
  - [x] module presence (forgot `publisher.c`)
  - [x] module rtcpsummary
  - [x] module serreg
  - [x] module ebuacip
- [x] provide alternative to https://github.com/baresip/baresip/pull/3088
- [x] move DnD feature from core to menu
- [ ] move more of the 4xx replies from core to menu
- [ ] let `menu` decide if 180 Ringing is sent or 183 Session Progress. Not both like it is done currently if `answermode` is `early`.