### PR TITLE
jack: add jack_server_name config

### DIFF
--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -176,7 +176,7 @@ static int start_jack(struct auplay_st *st)
 	const char *client_name = "baresip";
 	char server_name[32] = "default";
 	char *conf_name;
-	jack_options_t options = JackNullOption;
+	jack_options_t options = JackServerName;
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;

--- a/modules/jack/jack_play.c
+++ b/modules/jack/jack_play.c
@@ -174,7 +174,7 @@ static int start_jack(struct auplay_st *st)
 	struct conf *conf = conf_cur();
 	const char **ports;
 	const char *client_name = "baresip";
-	const char *server_name = NULL;
+	char server_name[32] = "default";
 	char *conf_name;
 	jack_options_t options = JackNullOption;
 	jack_status_t status;
@@ -189,6 +189,9 @@ static int start_jack(struct auplay_st *st)
 	/* open a client connection to the JACK server */
 	len = jack_client_name_size();
 	conf_name = mem_alloc(len+1, NULL);
+
+	conf_get_str(conf, "jack_server_name", server_name,
+		     sizeof(server_name));
 
 	if (!conf_get_str(conf, "jack_client_name",
 			conf_name, len)) {

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -82,7 +82,7 @@ static int start_jack(struct ausrc_st *st)
 	const char *client_name = "baresip";
 	char server_name[32] = "default";
 	char *conf_name;
-	jack_options_t options = JackNullOption;
+	jack_options_t options = JackServerName;
 	jack_status_t status;
 	unsigned ch;
 	jack_nframes_t engine_srate;

--- a/modules/jack/jack_src.c
+++ b/modules/jack/jack_src.c
@@ -80,7 +80,7 @@ static int start_jack(struct ausrc_st *st)
 	struct conf *conf = conf_cur();
 	const char **ports;
 	const char *client_name = "baresip";
-	const char *server_name = NULL;
+	char server_name[32] = "default";
 	char *conf_name;
 	jack_options_t options = JackNullOption;
 	jack_status_t status;
@@ -95,6 +95,9 @@ static int start_jack(struct ausrc_st *st)
 	/* open a client connection to the JACK server */
 	len = jack_client_name_size();
 	conf_name = mem_alloc(len+1, NULL);
+
+	conf_get_str(conf, "jack_server_name", server_name,
+		     sizeof(server_name));
 
 	if (!conf_get_str(conf, "jack_client_name",
 			conf_name, len)) {


### PR DESCRIPTION
With multiple jack instances it's useful to configure server name.