### PR TITLE
call: a getter for local media directions

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -270,6 +270,7 @@ const struct list *call_get_custom_hdrs(const struct call *call);
 void call_set_media_direction(struct call *call, enum sdp_dir a,
 			     enum sdp_dir v);
 void call_set_mdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
+void call_get_mdir(struct call *call, enum sdp_dir *ap, enum sdp_dir *vp);
 void call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);

--- a/src/call.c
+++ b/src/call.c
@@ -1186,6 +1186,11 @@ int call_progress(struct call *call)
 	vdir = m == ANSWERMODE_EARLY ? SDP_SENDRECV :
 			    m == ANSWERMODE_EARLY_VIDEO ? SDP_RECVONLY :
 			    SDP_INACTIVE;
+	enum sdp_dir ladir = SDP_SENDRECV;
+	enum sdp_dir lvdir = SDP_SENDRECV;
+	call_get_mdir(call, &ladir, &lvdir);
+	adir &= ladir;
+	vdir &= lvdir;
 
 	return call_progress_dir(call, adir, vdir);
 }

--- a/src/call.c
+++ b/src/call.c
@@ -3051,6 +3051,30 @@ void call_set_mdir(struct call *call, enum sdp_dir a, enum sdp_dir v)
 
 
 /**
+ * Returns local audio and video directions
+ *
+ * @param call Call object
+ * @param ap   Pointer for returning local audio direction
+ * @param vp   Pointer for returning local video direction
+ */
+void call_get_mdir(struct call *call, enum sdp_dir *ap, enum sdp_dir *vp)
+{
+	struct stream *strm;
+
+	if (!call)
+		return;
+
+	strm = audio_strm(call_audio(call));
+	if (strm && ap)
+		*ap = stream_ldir(strm);
+
+	strm = video_strm(call_video(call));
+	if (strm && vp)
+		*vp = stream_ldir(strm);
+}
+
+
+/**
  * Set audio/video direction during pre-established for the established state
  *
  * @param call Call object


### PR DESCRIPTION
- call: add a getter for local stream directions
- call: respect local media direction on incoming call

The new getter allows an application to query the current local media direction. It is possible that other application modules change the local media direction e.g. with `call_set_mdir()`.

```c
	case UA_EVENT_CALL_INCOMING:

		call_set_mdir(call, SDP_SENDRECV, SDP_SENDONLY);
		break;
```
