### PR TITLE
conf: use str_dup for conf_path_set

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -66,3 +66,6 @@ jobs:
 
     - name: run selftest
       run: ./build/test/selftest
+
+    - name: run quit/config test
+      run: ./build/baresip -t 1 -f /tmp/baresip_config

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -310,7 +310,7 @@ typedef int (confline_h)(const struct pl *addr, void *arg);
 int  conf_configure(void);
 int  conf_configure_buf(const uint8_t *buf, size_t sz);
 int  conf_modules(void);
-void conf_path_set(const char *path);
+int  conf_path_set(const char *path);
 int  conf_path_get(char *path, size_t sz);
 int  conf_parse(const char *filename, confline_h *ch, void *arg);
 int  conf_get_range(const struct conf *conf, const char *name,

--- a/src/conf.c
+++ b/src/conf.c
@@ -40,7 +40,7 @@
 #endif
 
 
-static const char *conf_path = NULL;
+static char *conf_path = NULL;
 static struct conf *conf_obj;
 
 
@@ -143,10 +143,13 @@ int conf_parse(const char *filename, confline_h *ch, void *arg)
  * Set the path to configuration files
  *
  * @param path Configuration path
+ *
+ * @return 0 if success, otherwise errorcode
  */
-void conf_path_set(const char *path)
+int conf_path_set(const char *path)
 {
-	conf_path = path;
+	mem_deref(conf_path);
+	return str_dup(&conf_path, path);
 }
 
 
@@ -478,6 +481,7 @@ struct conf *conf_cur(void)
 void conf_close(void)
 {
 	conf_obj = mem_deref(conf_obj);
+	conf_path = mem_deref(conf_path);
 }
 
 


### PR DESCRIPTION
Fixes #3146 