### PR TITLE
menu: fix early audio limit for video less call

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -145,10 +145,14 @@ static void limit_earlymedia(struct call* call, void *arg)
 		update = true;
 	}
 
-	/* video */
-	if (!call_video(call))
-		return;
+	if (!call_video(call)) {
+		if (update)
+			call_update_media(call);
 
+		return;
+	}
+
+	/* video */
 	ldir = sdp_media_ldir(stream_sdpmedia(video_strm(call_video(call))));
 	ndir = ldir;
 


### PR DESCRIPTION
The media direction was never updated if the early audio limit was
reached and the call has no video stream.
