### PR TITLE
wasapi: Add WASAPI Audio module

### DIFF
--- a/cmake/modules.cmake
+++ b/cmake/modules.cmake
@@ -80,6 +80,7 @@ set(MODULES
   vp8
   vp9
   vumeter
+  wasapi
   webrtc_aec
   webrtc_aecm
   wincons

--- a/modules/wasapi/CMakeLists.txt
+++ b/modules/wasapi/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 list(APPEND MODULES_DETECTED ${PROJECT_NAME})
 set(MODULES_DETECTED ${MODULES_DETECTED} PARENT_SCOPE)
 
-set(SRCS wasapi.c play.c src.c)
+set(SRCS wasapi.c play.c src.c util.c)
 
 if(STATIC)
   add_library(${PROJECT_NAME} OBJECT ${SRCS})

--- a/modules/wasapi/CMakeLists.txt
+++ b/modules/wasapi/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(wasapi)
+
+if(NOT WIN32)
+  return()
+endif()
+
+list(APPEND MODULES_DETECTED ${PROJECT_NAME})
+set(MODULES_DETECTED ${MODULES_DETECTED} PARENT_SCOPE)
+
+set(SRCS wasapi.c play.c src.c)
+
+if(STATIC)
+  add_library(${PROJECT_NAME} OBJECT ${SRCS})
+else()
+  add_library(${PROJECT_NAME} MODULE ${SRCS})
+endif()

--- a/modules/wasapi/play.c
+++ b/modules/wasapi/play.c
@@ -1,0 +1,187 @@
+/**
+ * @file wasapi/play.c Windows Audio Session API (WASAPI)
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ * Copyright (C) 2024 AGFEO GmbH & Co. KG
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <re_atomic.h>
+
+#include "wasapi.h"
+
+
+struct auplay_st {
+	thrd_t thread;
+	RE_ATOMIC bool run;
+	struct auplay_prm prm;
+	auplay_write_h *wh;
+	void *sampv;
+	size_t sampc;
+	void *arg;
+};
+
+
+static void auplay_destructor(void *arg)
+{
+	struct auplay_st *st = arg;
+	/* Wait for termination of other thread */
+	if (re_atomic_rlx(&st->run)) {
+		re_atomic_rlx_set(&st->run, false);
+		thrd_join(st->thread, NULL);
+	}
+
+	mem_deref(st->sampv);
+}
+
+static int play_thread(void *arg)
+{
+	struct auplay_st *st = arg;
+	bool started = false;
+	HRESULT hr;
+	IMMDevice *renderer		= NULL;
+	IMMDeviceEnumerator *enumerator = NULL;
+	IAudioClient *client		= NULL;
+	IAudioRenderClient *service	= NULL;
+	WAVEFORMATEX *format		= NULL;
+	uint32_t num_frames_buffer  = 0;
+	uint32_t num_frames_padding = 0;
+	void *sampv		    = NULL;
+	int err = 0;
+
+	uint32_t num_frames = st->prm.srate * st->prm.ptime / 1000;
+
+	struct auframe af;
+	auframe_init(&af, st->prm.fmt, st->sampv, st->sampc, st->prm.srate,
+		     st->prm.ch);
+
+	hr = CoInitializeEx(NULL, COINIT_MULTITHREADED |
+					  COINIT_DISABLE_OLE1DDE |
+					  COINIT_SPEED_OVER_MEMORY);
+	CHECK_HR(hr, "wasapi/play: CoInitializeEx failed");
+
+	hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+			      &IID_IMMDeviceEnumerator, (void **)&enumerator);
+	CHECK_HR(hr, "wasapi/play: CoCreateInstance failed");
+
+	hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(
+		enumerator, eRender, eMultimedia, &renderer);
+	CHECK_HR(hr, "wasapi/play: GetDefaultAudioEndpoint failed");
+
+	hr = IMMDevice_Activate(renderer, &IID_IAudioClient, CLSCTX_ALL,
+				NULL, (void **)&client);
+	CHECK_HR(hr, "wasapi/play: IMMDevice_Activate failed");
+
+	hr = IAudioClient_GetMixFormat(client, &format);
+	CHECK_HR(hr, "wasapi/play: GetMixFormat failed");
+
+	format->wFormatTag = WAVE_FORMAT_PCM;
+	format->nChannels = st->prm.ch;
+	format->nSamplesPerSec = st->prm.srate;
+	format->wBitsPerSample = (WORD)aufmt_sample_size(st->prm.fmt) * 8;
+	format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
+	format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;
+	format->cbSize = 0;
+
+	hr = IAudioClient_Initialize(
+		client, AUDCLNT_SHAREMODE_SHARED,
+		AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+			AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+		(st->prm.ptime * REF_PER_MS * 2), 0, format, NULL);
+	CHECK_HR(hr, "wasapi/play: IAudioClient_Initialize failed");
+
+	hr = IAudioClient_GetService(client, &IID_IAudioRenderClient,
+				     (void **)&service);
+	CHECK_HR(hr, "wasapi/play: IAudioClient_GetService failed");
+
+	hr = IAudioClient_GetBufferSize(client, &num_frames_buffer);
+	CHECK_HR(hr, "wasapi/play: IAudioClient_GetBufferSize failed");
+
+	hr = IAudioClient_Start(client);
+	CHECK_HR(hr, "wasapi/play: IAudioClient_Start failed");
+
+	started = true;
+
+	while (re_atomic_rlx(&st->run)) {
+		hr = IAudioClient_GetCurrentPadding(client,
+						    &num_frames_padding);
+		CHECK_HR(hr, "wasapi/play: GetCurrentPadding failed");
+
+		if ((num_frames_buffer - num_frames_padding) < num_frames) {
+			sys_msleep(5);
+			continue;
+		}
+
+		st->wh(&af, st->arg);
+
+		hr = IAudioRenderClient_GetBuffer(service, num_frames,
+						  (BYTE **)&sampv);
+		CHECK_HR(hr, "wasapi/play: GetBuffer failed");
+
+		memcpy(sampv, af.sampv, format->nBlockAlign * num_frames);
+
+		hr = IAudioRenderClient_ReleaseBuffer(service, num_frames, 0);
+		CHECK_HR(hr, "wasapi/play: ReleaseBuffer failed");
+	}
+
+
+out:
+	if (started)
+		IAudioClient_Stop(client);
+	if (service)
+		IAudioRenderClient_Release(service);
+	if (client)
+		IAudioClient_Release(client);
+	if (enumerator)
+		IMMDeviceEnumerator_Release(enumerator);
+
+	CoTaskMemFree(format);
+	CoUninitialize();
+
+	return err;
+}
+
+
+int wasapi_play_alloc(struct auplay_st **stp, const struct auplay *ap,
+		      struct auplay_prm *prm, const char *device,
+		      auplay_write_h *wh, void *arg)
+{
+	struct auplay_st *st;
+	int err = 0;
+	(void)device;
+
+	if (!stp || !ap || !prm)
+		return EINVAL;
+
+	st = mem_zalloc(sizeof(*st), auplay_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->wh	= wh;
+	st->arg = arg;
+	st->prm = *prm;
+
+	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
+	st->sampv = mem_alloc(aufmt_sample_size(prm->fmt) * st->sampc, NULL);
+	if (!st->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	re_atomic_rlx_set(&st->run, true);
+	err = thread_create_name(&st->thread, "wasapi_play", play_thread, st);
+	if (err) {
+		re_atomic_rlx_set(&st->run, false);
+		goto out;
+	}
+
+out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}

--- a/modules/wasapi/play.c
+++ b/modules/wasapi/play.c
@@ -67,7 +67,7 @@ static int play_thread(void *arg)
 	CHECK_HR(hr, "wasapi/play: CoCreateInstance failed");
 
 	hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(
-		enumerator, eRender, eMultimedia, &renderer);
+		enumerator, eRender, eCommunications, &renderer);
 	CHECK_HR(hr, "wasapi/play: GetDefaultAudioEndpoint failed");
 
 	hr = IMMDevice_Activate(renderer, &IID_IAudioClient, CLSCTX_ALL,

--- a/modules/wasapi/src.c
+++ b/modules/wasapi/src.c
@@ -1,0 +1,195 @@
+/**
+ * @file wasapi/src.c Windows Audio Session API (WASAPI)
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ * Copyright (C) 2024 AGFEO GmbH & Co. KG
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <re_atomic.h>
+
+#include "wasapi.h"
+
+
+struct ausrc_st {
+	thrd_t thread;
+	RE_ATOMIC bool run;
+	struct ausrc_prm prm;
+	ausrc_read_h *rh;
+	void *sampv;
+	size_t sampc;
+	void *arg;
+};
+
+
+static void ausrc_destructor(void *arg)
+{
+	struct ausrc_st *st = arg;
+	/* Wait for termination of other thread */
+	if (re_atomic_rlx(&st->run)) {
+		re_atomic_rlx_set(&st->run, false);
+		thrd_join(st->thread, NULL);
+	}
+
+
+	mem_deref(st->sampv);
+
+}
+
+
+static int src_thread(void *arg)
+{
+	struct ausrc_st *st = arg;
+	bool started = false;
+	HRESULT hr;
+	IMMDevice *capturer             = NULL;
+	IMMDeviceEnumerator *enumerator = NULL;
+	IAudioClient *client		= NULL;
+	IAudioCaptureClient *service	= NULL;
+	WAVEFORMATEX *format		= NULL;
+	uint32_t num_frames_buffer	= 0;
+	uint32_t packet_sz = 0;
+	DWORD flags;
+	uint32_t num_frames = st->prm.srate * st->prm.ptime / 1000;
+	int err = 0;
+
+	struct auframe af;
+	auframe_init(&af, st->prm.fmt, st->sampv, st->sampc, st->prm.srate,
+		     st->prm.ch);
+
+	hr = CoInitializeEx(NULL, COINIT_MULTITHREADED |
+					  COINIT_DISABLE_OLE1DDE |
+					  COINIT_SPEED_OVER_MEMORY);
+	CHECK_HR(hr, "wasapi/src: CoInitializeEx failed");
+
+	hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+			      &IID_IMMDeviceEnumerator, (void **)&enumerator);
+	CHECK_HR(hr, "wasapi/src: CoCreateInstance failed");
+
+	hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(
+		enumerator, eCapture, eMultimedia, &capturer);
+	CHECK_HR(hr, "wasapi/src: GetDefaultAudioEndpoint failed");
+
+
+	hr = IMMDevice_Activate(capturer, &IID_IAudioClient, CLSCTX_ALL,
+				NULL, (void **)&client);
+	CHECK_HR(hr, "wasapi/src: IMMDevice_Activate failed");
+
+	hr = IAudioClient_GetMixFormat(client, &format);
+	CHECK_HR(hr, "wasapi/src: GetMixFormat failed");
+
+	format->wFormatTag = WAVE_FORMAT_PCM;
+	format->nChannels = st->prm.ch;
+	format->nSamplesPerSec = st->prm.srate;
+	format->wBitsPerSample = (WORD)aufmt_sample_size(st->prm.fmt) * 8;
+	format->nBlockAlign = (format->wBitsPerSample / 8) * format->nChannels;
+	format->nAvgBytesPerSec = format->nSamplesPerSec * format->nBlockAlign;
+	format->cbSize = 0;
+
+	hr = IAudioClient_Initialize(
+		client, AUDCLNT_SHAREMODE_SHARED,
+		AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+			AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY,
+		(st->prm.ptime * REF_PER_MS), 0, format, NULL);
+	CHECK_HR(hr, "wasapi/src: IAudioClient_Initialize failed");
+
+	hr = IAudioClient_GetService(client, &IID_IAudioCaptureClient,
+				     (void **)&service);
+	CHECK_HR(hr, "wasapi/src: IAudioClient_GetService failed");
+
+	hr = IAudioClient_GetBufferSize(client, &num_frames_buffer);
+	CHECK_HR(hr, "wasapi/src: IAudioClient_GetBufferSize failed");
+
+	hr = IAudioClient_Start(client);
+	CHECK_HR(hr, "wasapi/src: IAudioClient_Start failed");
+
+	started = true;
+
+	while (re_atomic_rlx(&st->run)) {
+		hr = IAudioCaptureClient_GetNextPacketSize(service,
+						    &packet_sz);
+		CHECK_HR(hr, "wasapi/src: GetNextPacketSize failed");
+
+		if (packet_sz == 0) {
+			sys_msleep(5);
+			continue;
+		}
+
+		hr = IAudioCaptureClient_GetBuffer(service, (BYTE **)&af.sampv,
+						   &num_frames, &flags, NULL,
+						   NULL);
+		CHECK_HR(hr, "wasapi/src: GetBuffer failed");
+
+		af.timestamp = tmr_jiffies_usec();
+		af.sampc = num_frames * format->nChannels;
+
+		st->rh(&af, st->arg);
+
+		hr = IAudioCaptureClient_ReleaseBuffer(service, num_frames);
+		CHECK_HR(hr, "wasapi/src: ReleaseBuffer failed");
+	}
+
+out:
+	if (started)
+		IAudioClient_Stop(client);
+	if (service)
+		IAudioCaptureClient_Release(service);
+	if (client)
+		IAudioClient_Release(client);
+	if (capturer)
+		IMMDevice_Release(capturer);
+	if (enumerator)
+		IMMDeviceEnumerator_Release(enumerator);
+
+	CoTaskMemFree(format);
+	CoUninitialize();
+
+	return err;
+}
+
+
+int wasapi_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
+		      struct ausrc_prm *prm, const char *device,
+		      ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
+{
+	struct ausrc_st *st;
+	int err;
+
+	(void)device;
+	(void)errh;
+
+	if (!stp || !as || !prm)
+		return EINVAL;
+
+	st = mem_zalloc(sizeof(*st), ausrc_destructor);
+	if (!st)
+		return ENOMEM;
+
+	st->rh  = rh;
+	st->arg = arg;
+	st->prm = *prm;
+
+	st->sampc = prm->srate * prm->ch * prm->ptime / 1000;
+	st->sampv = mem_alloc(aufmt_sample_size(prm->fmt) * st->sampc, NULL);
+	if (!st->sampv) {
+		err = ENOMEM;
+		goto out;
+	}
+
+	re_atomic_rlx_set(&st->run, true);
+	err = thread_create_name(&st->thread, "wasapi_src", src_thread, st);
+	if (err) {
+		re_atomic_rlx_set(&st->run, false);
+		goto out;
+	}
+
+out:
+	if (err)
+		mem_deref(st);
+	else
+		*stp = st;
+
+	return err;
+}

--- a/modules/wasapi/src.c
+++ b/modules/wasapi/src.c
@@ -69,7 +69,7 @@ static int src_thread(void *arg)
 	CHECK_HR(hr, "wasapi/src: CoCreateInstance failed");
 
 	hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(
-		enumerator, eCapture, eMultimedia, &capturer);
+		enumerator, eCapture, eCommunications, &capturer);
 	CHECK_HR(hr, "wasapi/src: GetDefaultAudioEndpoint failed");
 
 

--- a/modules/wasapi/util.c
+++ b/modules/wasapi/util.c
@@ -1,0 +1,56 @@
+/**
+ * @file wasapi/util.c Windows Audio Session API (WASAPI)
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ * Copyright (C) 2024 AGFEO GmbH & Co. KG
+ */
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
+#include <re_atomic.h>
+
+#include "wasapi.h"
+
+
+int wasapi_wc_to_utf8(char **dst, LPCWSTR src)
+{
+	int bufsz =
+		WideCharToMultiByte(CP_UTF8, 0, src, -1, NULL, 0, NULL, NULL);
+
+	if (!bufsz || !dst)
+		return EINVAL;
+
+	char *buf = mem_zalloc(bufsz, NULL);
+	if (!buf)
+		return ENOMEM;
+
+	WideCharToMultiByte(CP_UTF8, 0, src, -1, buf, bufsz, NULL, NULL);
+
+	*dst = buf;
+
+	return 0;
+}
+
+
+int wasapi_wc_from_utf8(LPWSTR *dst, const struct pl *src)
+{
+	if (!src || !dst)
+		return EINVAL;
+
+	int wclen =
+		MultiByteToWideChar(CP_UTF8, 0, src->p, (int)src->l, NULL, 0);
+
+	if (wclen <= 0)
+		return EMSGSIZE;
+
+	LPWSTR buf = mem_zalloc(sizeof(wchar_t) * (wclen + 1), NULL);
+	if (!buf)
+		return ENOMEM;
+
+	MultiByteToWideChar(CP_UTF8, 0, src->p, (int)src->l, buf, wclen);
+
+	*dst = buf;
+
+	return 0;
+}

--- a/modules/wasapi/wasapi.c
+++ b/modules/wasapi/wasapi.c
@@ -1,0 +1,46 @@
+/**
+ * @file wasapi/wasapi.c Windows Audio Session API (WASAPI)
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ * Copyright (C) 2024 AGFEO GmbH & Co. KG
+ */
+
+#include <re.h>
+#include <baresip.h>
+#include "wasapi.h"
+
+
+static struct auplay *auplay;
+static struct ausrc *ausrc;
+
+
+static int wasapi_init(void)
+{
+	int err;
+
+	err = ausrc_register(&ausrc, baresip_ausrcl(), "wasapi",
+			     wasapi_src_alloc);
+	err |= auplay_register(&auplay, baresip_auplayl(), "wasapi",
+			       wasapi_play_alloc);
+	if (err)
+		return err;
+
+	return err;
+}
+
+
+static int wasapi_close(void)
+{
+	ausrc = mem_deref(ausrc);
+	auplay = mem_deref(auplay);
+
+	return 0;
+}
+
+
+EXPORT_SYM const struct mod_export DECL_EXPORTS(wasapi) = {
+	"wasapi",
+	"sound",
+	wasapi_init,
+	wasapi_close
+};

--- a/modules/wasapi/wasapi.c
+++ b/modules/wasapi/wasapi.c
@@ -14,9 +14,149 @@ static struct auplay *auplay;
 static struct ausrc *ausrc;
 
 
+static int device_thread(void *arg)
+{
+	HRESULT hr;
+	IMMDeviceEnumerator *enumerator = NULL;
+	IMMDeviceCollection *devices	= NULL;
+	char *dev_id_utf8		= NULL;
+	char *name_utf8			= NULL;
+	UINT play_dev_count		= 0;
+	UINT src_dev_count		= 0;
+	int err				= 0;
+	(void)arg;
+
+	hr = CoInitializeEx(NULL, COINIT_MULTITHREADED);
+	CHECK_HR(hr, "wasapi/devices: CoInitializeEx failed");
+
+	hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL, CLSCTX_ALL,
+			      &IID_IMMDeviceEnumerator, (void **)&enumerator);
+	CHECK_HR(hr, "wasapi/devices: CoCreateInstance failed");
+
+	hr = IMMDeviceEnumerator_EnumAudioEndpoints(
+		enumerator, eRender, DEVICE_STATE_ACTIVE, &devices);
+	CHECK_HR(hr, "wasapi/devices: EnumAudioEndpoints failed");
+
+	hr = IMMDeviceCollection_GetCount(devices, &play_dev_count);
+	CHECK_HR(hr, "wasapi/devices: GetCount failed");
+
+	for (UINT i = 0; i < play_dev_count; i++) {
+		IMMDevice *device     = NULL;
+		LPWSTR dev_id	      = NULL;
+		IPropertyStore *store = NULL;
+		PROPVARIANT name;
+
+		hr = IMMDeviceCollection_Item(devices, i, &device);
+		CHECK_HR(hr, "wasapi/devices: Item failed");
+
+		hr = IMMDevice_GetId(device, &dev_id);
+		CHECK_HR(hr, "wasapi/devices: GetId failed");
+
+		hr = IMMDevice_OpenPropertyStore(device, STGM_READ, &store);
+		CHECK_HR(hr, "wasapi/devices: OpenPropertyStore failed");
+
+		PropVariantInit(&name);
+		hr = IPropertyStore_GetValue(store, &PKEY_Device_FriendlyName,
+					     &name);
+		CHECK_HR(hr, "wasapi/devices: Store GetValue failed");
+
+		err = wasapi_wc_to_utf8(&dev_id_utf8, dev_id);
+		if (err)
+			goto out;
+
+		err = wasapi_wc_to_utf8(&name_utf8, name.pwszVal);
+		if (err)
+			goto out;
+
+		info("wasapi/device/play: %s (%s)\n", name_utf8, dev_id_utf8);
+
+		PropVariantClear(&name);
+		IPropertyStore_Release(store);
+		CoTaskMemFree(dev_id);
+		IMMDevice_Release(device);
+
+		err = mediadev_add(&auplay->dev_list, dev_id_utf8);
+		if (err)
+			goto out;
+
+		dev_id_utf8 = mem_deref(dev_id_utf8);
+		name_utf8 = mem_deref(name_utf8);
+	}
+
+	if (devices)
+		IMMDeviceCollection_Release(devices);
+
+	hr = IMMDeviceEnumerator_EnumAudioEndpoints(
+		enumerator, eCapture, DEVICE_STATE_ACTIVE, &devices);
+	CHECK_HR(hr, "wasapi/devices: EnumAudioEndpoints failed");
+
+	hr = IMMDeviceCollection_GetCount(devices, &src_dev_count);
+	CHECK_HR(hr, "wasapi/devices: GetCount failed");
+
+	for (UINT i = 0; i < src_dev_count; i++) {
+		IMMDevice *device     = NULL;
+		LPWSTR dev_id	      = NULL;
+		IPropertyStore *store = NULL;
+		PROPVARIANT name;
+
+		hr = IMMDeviceCollection_Item(devices, i, &device);
+		CHECK_HR(hr, "wasapi/devices: Item failed");
+
+		hr = IMMDevice_GetId(device, &dev_id);
+		CHECK_HR(hr, "wasapi/devices: GetId failed");
+
+		hr = IMMDevice_OpenPropertyStore(device, STGM_READ, &store);
+		CHECK_HR(hr, "wasapi/devices: OpenPropertyStore failed");
+
+		PropVariantInit(&name);
+		hr = IPropertyStore_GetValue(store, &PKEY_Device_FriendlyName,
+					     &name);
+		CHECK_HR(hr, "wasapi/devices: Store GetValue failed");
+
+		err = wasapi_wc_to_utf8(&dev_id_utf8, dev_id);
+		if (err)
+			goto out;
+
+		err = wasapi_wc_to_utf8(&name_utf8, name.pwszVal);
+		if (err)
+			goto out;
+
+		info("wasapi/device/src: %s (%s)\n", name_utf8, dev_id_utf8);
+
+		PropVariantClear(&name);
+		IPropertyStore_Release(store);
+		CoTaskMemFree(dev_id);
+		IMMDevice_Release(device);
+
+		err = mediadev_add(&ausrc->dev_list, dev_id_utf8);
+		if (err)
+			goto out;
+
+		dev_id_utf8 = mem_deref(dev_id_utf8);
+		name_utf8 = mem_deref(name_utf8);
+	}
+
+	info("wasapi: output devices: %d, input devices: %d\n", play_dev_count,
+	     src_dev_count);
+
+out:
+	dev_id_utf8 = mem_deref(dev_id_utf8);
+	name_utf8 = mem_deref(name_utf8);
+
+	if (devices)
+		IMMDeviceCollection_Release(devices);
+	if (enumerator)
+		IMMDeviceEnumerator_Release(enumerator);
+	CoUninitialize();
+
+	return err;
+}
+
+
 static int wasapi_init(void)
 {
 	int err;
+	thrd_t thread;
 
 	err = ausrc_register(&ausrc, baresip_ausrcl(), "wasapi",
 			     wasapi_src_alloc);
@@ -25,13 +165,17 @@ static int wasapi_init(void)
 	if (err)
 		return err;
 
+	err = thread_create_name(&thread, "wasapi_devices", device_thread,
+				 NULL);
+	thrd_join(thread, &err);
+
 	return err;
 }
 
 
 static int wasapi_close(void)
 {
-	ausrc = mem_deref(ausrc);
+	ausrc  = mem_deref(ausrc);
 	auplay = mem_deref(auplay);
 
 	return 0;
@@ -39,8 +183,4 @@ static int wasapi_close(void)
 
 
 EXPORT_SYM const struct mod_export DECL_EXPORTS(wasapi) = {
-	"wasapi",
-	"sound",
-	wasapi_init,
-	wasapi_close
-};
+	"wasapi", "sound", wasapi_init, wasapi_close};

--- a/modules/wasapi/wasapi.h
+++ b/modules/wasapi/wasapi.h
@@ -17,6 +17,7 @@
 #include <audioclient.h>
 #include <audiosessiontypes.h>
 #include <audiopolicy.h>
+#include <functiondiscoverykeys_devpkey.h>
 
 #define REF_PER_MS 10000LL
 #define CHECK_HR(hr, msg)                                                     \
@@ -68,3 +69,5 @@ int wasapi_play_alloc(struct auplay_st **stp, const struct auplay *ap,
 int wasapi_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		      struct ausrc_prm *prm, const char *device,
 		      ausrc_read_h *rh, ausrc_error_h *errh, void *arg);
+int wasapi_wc_to_utf8(char **dst, LPCWSTR src);
+int wasapi_wc_from_utf8(LPWSTR *dst, const struct pl *src);

--- a/modules/wasapi/wasapi.h
+++ b/modules/wasapi/wasapi.h
@@ -1,0 +1,70 @@
+/**
+ * @file wasapi/wasapi.h Windows Audio Session API (WASAPI)
+ *
+ * Copyright (C) 2024 Sebastian Reimers
+ * Copyright (C) 2024 AGFEO GmbH & Co. KG
+ */
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#define CINTERFACE
+#define COBJMACROS
+#define CONST_VTABLE
+#include <initguid.h>
+#include <windows.h>
+#include <mmdeviceapi.h>
+#include <audioclient.h>
+#include <audiosessiontypes.h>
+#include <audiopolicy.h>
+
+#define REF_PER_MS 10000LL
+#define CHECK_HR(hr, msg)                                                     \
+	if (FAILED((hr))) {                                                   \
+		warning("%s: 0x%08x\n", (msg), (hr));                         \
+		err = ENODATA;                                                \
+		goto out;                                                     \
+	}
+
+#ifndef __MINGW32__
+static const CLSID CLSID_MMDeviceEnumerator = {
+	0xbcde0395,
+	0xe52f,
+	0x467c,
+	{0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e}};
+
+static const IID IID_IMMDeviceEnumerator = {
+	/* MIDL_INTERFACE("A95664D2-9614-4F35-A746-DE8DB63617E6") */
+	0xa95664d2,
+	0x9614,
+	0x4f35,
+	{0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6}};
+
+static const IID IID_IAudioClient = {
+	/* MIDL_INTERFACE("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2") */
+	0x1cb9ad4c,
+	0xdbfa,
+	0x4c32,
+	{0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2}};
+
+static const IID IID_IAudioRenderClient = {
+	/* MIDL_INTERFACE("F294ACFC-3146-4483-A7BF-ADDCA7C260E2") */
+	0xf294acfc,
+	0x3146,
+	0x4483,
+	{0xa7, 0xbf, 0xad, 0xdc, 0xa7, 0xc2, 0x60, 0xe2}};
+
+static const IID IID_IAudioCaptureClient = {
+	//MIDL_INTERFACE("C8ADBD64-E71E-48a0-A4DE-185C395CD317")
+	0xc8adbd64,
+	0xe71e,
+	0x48a0,
+	{0xa4, 0xde, 0x18, 0x5c, 0x39, 0x5c, 0xd3, 0x17}};
+#endif
+
+int wasapi_play_alloc(struct auplay_st **stp, const struct auplay *ap,
+		      struct auplay_prm *prm, const char *device,
+		      auplay_write_h *wh, void *arg);
+int wasapi_src_alloc(struct ausrc_st **stp, const struct ausrc *as,
+		      struct ausrc_prm *prm, const char *device,
+		      ausrc_read_h *rh, ausrc_error_h *errh, void *arg);


### PR DESCRIPTION
This is a replacement for the winwave module, since Windows 7 there are newer improved Core Audio APIs.