### PR TITLE
ci/fedora: Use Fedora 40 until CI is updated for Fedora 41

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -35,7 +35,7 @@ jobs:
   build:
     needs: dependency
     runs-on: ubuntu-latest
-    container: fedora
+    container: fedora:40
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Important: This is just a workaround, *not* a solution for #3183. The real solution is to perform the changes related to the newer RPM version in Fedora 41, but this will happen on my side *at earliest* at the end of next week.