### PR TITLE
menu dnd event

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -688,11 +688,16 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	case UA_EVENT_SIPSESS_CONN:
 
 		if (menu.dnd) {
-			(void)sip_treply(NULL, uag_sip(), msg, 480,
-					 "Temporarily Unavailable");
+			const uint16_t scode = 480;
+			const char *reason = "Temporarily Unavailable";
+
+			(void)sip_treply(NULL, uag_sip(), msg, scode, reason);
+
 			info("menu: incoming call from %r <%r> rejected: "
-			     "480 Temporarily Unavailable\n",
-			     &msg->from.dname, &msg->from.auri);
+			     "%u %s\n",
+			     &msg->from.dname, &msg->from.auri, scode, reason);
+			bevent_sip_msg_emit(UA_EVENT_MODULE, msg,
+				"menu,rejected,%u %s", scode, reason);
 			bevent_stop(event);
 			break;
 		}

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -482,20 +482,6 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 }
 
 
-static int odict_pl_add(struct odict *od, const char *key,
-			const struct pl *val)
-{
-	char *str;
-	int err = pl_strdup(&str, val);
-	if (err)
-		return err;
-
-	err = odict_entry_add(od, key, ODICT_STRING, str);
-	mem_deref(str);
-	return err;
-}
-
-
 int odict_encode_bevent(struct odict *od, struct bevent *event)
 {
 	struct ua *ua     = bevent_get_ua(event);


### PR DESCRIPTION
This adds an enum `bevent_class` field to `struct bevent` because it should not be derived from the `enum ua_event`. This does not always give wanted results. The second commit gives an example how the fixed API can be used.

- **bevent: add enum bevent_class to struct**
- **menu: emit bevent for dnd reject**
