### PR TITLE
cmake: install logo.png and *.wav files again (fixes #3191)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,10 @@ install(TARGETS baresip
     COMPONENT Development
 )
 
-file(GLOB SHARE_FILES "${PROJECT_SOURCE_DIR}/share/!(*.desktop)")
+file(GLOB SHARE_FILES
+  "${PROJECT_SOURCE_DIR}/share/*.png"
+  "${PROJECT_SOURCE_DIR}/share/*.wav"
+)
 file(GLOB DESKTOP_FILES "${PROJECT_SOURCE_DIR}/share/*.desktop")
 
 install(FILES ${SHARE_FILES}


### PR DESCRIPTION
Fixes #3191, a regression related to cmake globbing of `*.desktop` introduced with commit 085e86f (#3127).