### PR TITLE
mixausrc: reset mixstatus ptime if ptime changes

### DIFF
--- a/modules/mixausrc/mixausrc.c
+++ b/modules/mixausrc/mixausrc.c
@@ -561,6 +561,7 @@ static int process(struct mixstatus *st, struct auframe *af)
 		warning("mixausrc: ptime changed %u --> %u.\n",
 			st->ptime, ptime);
 		stop_ausrc(st);
+		st->ptime = 0;
 		st->nextmode = FM_FADEIN;
 		return EINVAL;
 	}


### PR DESCRIPTION
Currently, if the `ptime` of an audio stream changes, `mixausrc` gets stuck in a loop where it keeps printing a warning "mixausrc: ptime changed" and no more audio is processed. This is fixed by resetting the `ptime` of `mixstatus` if a `ptime` change is detected. 