### PR TITLE
bevent: Add local URI information to events

### DIFF
--- a/src/bevent.c
+++ b/src/bevent.c
@@ -403,6 +403,8 @@ int event_encode_dict(struct odict *od, struct ua *ua, enum ua_event ev,
 		err |= odict_entry_add(od, "direction", ODICT_STRING, dir);
 		err |= odict_entry_add(od, "peeruri",
 				       ODICT_STRING, call_peeruri(call));
+		err |= odict_entry_add(od, "localuri",
+				       ODICT_STRING, call_localuri(call));
 		peerdisplayname = call_peername(call);
 		if (peerdisplayname){
 				err |= odict_entry_add(od, "peerdisplayname",


### PR DESCRIPTION
Let this information be readily available for example in JSON events as emitted by the ctrl_tcp module.