### PR TITLE
video: add picture update bool to vidpacket

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1096,6 +1096,7 @@ struct vidpacket {
 	size_t size;         /**< Size of buffer                    */
 	uint64_t timestamp;  /**< Timestamp in VIDEO_TIMEBASE units */
 	bool keyframe;       /**< True=keyframe, False=deltaframe   */
+	bool picup;          /**< Picture update requested          */
 };
 
 /* Declare function pointer */

--- a/src/video.c
+++ b/src/video.c
@@ -392,6 +392,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 		mtx_lock(vtx->lock_enc);
 
 		if (vtx->vc && vtx->vc->packetizeh) {
+			packet->picup = vtx->picup;
 			err = vtx->vc->packetizeh(vtx->enc, packet);
 			if (err)
 				goto out;


### PR DESCRIPTION
Currently, video encoders only receive picture update information (i.e. new keyframe request) when the encoder's frame handler is called. When the encoder's packetize handler is called, this information is not passed on. Some videosrc/vidcodec combinations only work in this "pass-through" mode where *only* the packetize handler is called, and the encoder will never receive picture update information. However, some encoders can still act on picture update requests even when operated in "pass-through" mode, so now the `update` bool is also passed to the packetize handler.