### PR TITLE
ua,call: add API for rejecting incoming call

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -222,6 +222,8 @@ int  call_progress_dir(struct call *call,
 		       enum sdp_dir adir, enum sdp_dir vdir);
 int  call_progress(struct call *call);
 void call_hangup(struct call *call, uint16_t scode, const char *reason);
+void call_hangupf(struct call *call, uint16_t scode, const char *reason,
+		  const char *fmt, ...);
 int  call_modify(struct call *call);
 int  call_hold(struct call *call, bool hold);
 void call_set_audio_ldir(struct call *call, enum sdp_dir dir);
@@ -916,6 +918,8 @@ int  ua_connect_dir(struct ua *ua, struct call **callp,
 		    enum vidmode vmode, enum sdp_dir adir, enum sdp_dir vdir);
 void ua_hangup(struct ua *ua, struct call *call,
 	       uint16_t scode, const char *reason);
+void ua_hangupf(struct ua *ua, struct call *call,
+		uint16_t scode, const char *reason, const char *fmt, ...);
 int  ua_accept(struct ua *ua, const struct sip_msg *msg);
 int  ua_answer(struct ua *ua, struct call *call, enum vidmode vmode);
 int  ua_hold_answer(struct ua *ua, struct call *call, enum vidmode vmode);

--- a/src/call.c
+++ b/src/call.c
@@ -1117,8 +1117,11 @@ int call_modify(struct call *call)
  * @param call   Call to hangup
  * @param scode  Optional status code
  * @param reason Optional reason
+ * @param fmt    Formatted headers
+ * @param ...    Variable arguments
  */
-void call_hangup(struct call *call, uint16_t scode, const char *reason)
+void call_hangupf(struct call *call, uint16_t scode, const char *reason,
+		 const char *fmt, ...)
 {
 	if (!call)
 		return;
@@ -1142,7 +1145,11 @@ void call_hangup(struct call *call, uint16_t scode, const char *reason)
 
 			info("call: rejecting incoming call from %s (%u %s)\n",
 			     call->peer_uri, scode, reason);
-			(void)sipsess_reject(call->sess, scode, reason, NULL);
+			va_list ap;
+			va_start(ap, fmt);
+			(void)sipsess_reject(call->sess, scode, reason,
+					     fmt ? "%v" : NULL, fmt, &ap);
+			va_end(ap);
 		}
 	}
 	else {
@@ -1159,6 +1166,19 @@ void call_hangup(struct call *call, uint16_t scode, const char *reason)
 	set_state(call, CALL_STATE_TERMINATED);
 
 	call_stream_stop(call);
+}
+
+
+/**
+ * Hangup the call
+ *
+ * @param call   Call to hangup
+ * @param scode  Optional status code
+ * @param reason Optional reason
+ */
+void call_hangup(struct call *call, uint16_t scode, const char *reason)
+{
+	call_hangupf(call, scode, reason, NULL);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1428,21 +1428,7 @@ int ua_connect(struct ua *ua, struct call **callp,
 void ua_hangup(struct ua *ua, struct call *call,
 	       uint16_t scode, const char *reason)
 {
-	if (!ua)
-		return;
-
-	if (!call) {
-		call = ua_call(ua);
-		if (!call)
-			return;
-	}
-
-	call_hangup(call, scode, reason);
-
-	bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
-			 reason ? reason : "Connection reset by user");
-
-	mem_deref(call);
+	ua_hangupf(ua, call, scode, reason, NULL);
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -1447,6 +1447,40 @@ void ua_hangup(struct ua *ua, struct call *call,
 
 
 /**
+ * Hangup the current call
+ *
+ * @param ua     User-Agent
+ * @param call   Call to reject, or NULL for current call
+ * @param scode  Optional status code
+ * @param reason Optional reason
+ * @param fmt    Formatted headers
+ * @param ...    Variable arguments
+ */
+void ua_hangupf(struct ua *ua, struct call *call,
+		uint16_t scode, const char *reason, const char *fmt, ...)
+{
+	if (!ua)
+		return;
+
+	if (!call) {
+		call = ua_call(ua);
+		if (!call)
+			return;
+	}
+
+	va_list ap;
+	va_start(ap, fmt);
+	call_hangupf(call, scode, reason, fmt ? "%v" : NULL, fmt, &ap);
+	va_end(ap);
+
+	bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+			 reason ? reason : "Rejected by user");
+
+	mem_deref(call);
+}
+
+
+/**
  * Answer an incoming call
  *
  * @param ua    User-Agent


### PR DESCRIPTION
This adds a more general version of `ua_hangup()` to the API which allows to add custom headers. E.g. `Contact:` and `Diversion:` for a 302 Moved Temporarily.

```c
void ua_hangupf(struct ua *ua, struct call *call,
                uint16_t scode, const char *reason, const char *fmt, ...);
```

related application: https://github.com/baresip/baresip-apps/pull/57
related discussion: https://github.com/baresip/baresip/discussions/3207