### PR TITLE
video: allow RTCP FIR packets as payload-specific feedback

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -968,13 +968,18 @@ static void rtcp_handler(struct stream *strm, struct rtcp_msg *msg, void *arg)
 
 	case RTCP_FIR:
 		mtx_lock(vtx->lock_enc);
+		debug("video: recv Full Intra Request (FIR)\n");
 		vtx->picup = true;
 		mtx_unlock(vtx->lock_enc);
 		break;
 
 	case RTCP_PSFB:
-		if (msg->hdr.count == RTCP_PSFB_PLI) {
-			debug("video: recv Picture Loss Indication (PLI)\n");
+		if (msg->hdr.count == RTCP_PSFB_PLI ||
+		    msg->hdr.count == RTCP_PSFB_FIR) {
+			const char *s = msg->hdr.count == RTCP_PSFB_PLI ?
+				"Picture Loss Indication (PLI)" :
+				"Full Intra Request (FIR)";
+			debug("video: recv %s\n", s);
 			mtx_lock(vtx->lock_enc);
 			vtx->picup = true;
 			mtx_unlock(vtx->lock_enc);


### PR DESCRIPTION
The RTCP FIR messages of [RFC 2032](https://www.rfc-editor.org/rfc/rfc2032) have been obsoleted in [RFC 4587](https://www.rfc-editor.org/rfc/rfc4587) (see section 5) and instead the feedback mechanism of [RFC 4585](https://www.rfc-editor.org/rfc/rfc4585) should be used which has been extended to include FIR messages in [RFC 5104](https://www.rfc-editor.org/rfc/rfc5104).

With this change, the FIR messages of RFC 5104, which are payload-specific feedback messages (PSFB), are also interpreted as picture update requests.