### PR TITLE
ua prevent double call accept

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -236,6 +236,7 @@ bool call_has_video(const struct call *call);
 bool call_early_video_available(const struct call *call);
 bool call_refresh_allowed(const struct call *call);
 bool call_ack_pending(const struct call *call);
+bool call_sess_cmp(const struct call *call, const struct sip_msg *msg);
 int  call_transfer(struct call *call, const char *uri);
 int  call_replace_transfer(struct call *target_call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);
@@ -963,6 +964,7 @@ int  ua_call_alloc(struct call **callp, struct ua *ua,
 		   struct call *xcall, const char *local_uri,
 		   bool use_rtp);
 struct call *ua_find_call_state(const struct ua *ua, enum call_state st);
+struct call *ua_find_call_msg(struct ua *ua, const struct sip_msg *msg);
 int ua_raise(struct ua *ua);
 int ua_set_autoanswer_value(struct ua *ua, const char *value);
 void ua_add_extension(struct ua *ua, const char *extension);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -710,6 +710,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 			return;
 		}
 
+		bevent_stop(event);
 		break;
 
 	case UA_EVENT_CALL_INCOMING:

--- a/src/call.c
+++ b/src/call.c
@@ -2294,6 +2294,12 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 }
 
 
+bool call_sess_cmp(const struct call *call, const struct sip_msg *msg)
+{
+	return sipsess_msg_equal(call->sess, msg);
+}
+
+
 static void delayed_answer_handler(void *arg)
 {
 	struct call *call = arg;

--- a/src/call.c
+++ b/src/call.c
@@ -2296,6 +2296,9 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 
 bool call_sess_cmp(const struct call *call, const struct sip_msg *msg)
 {
+	if (!call || !msg)
+		return false;
+
 	return sipsess_msg_equal(call->sess, msg);
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -2299,7 +2299,7 @@ bool call_sess_cmp(const struct call *call, const struct sip_msg *msg)
 	if (!call || !msg)
 		return false;
 
-	return sipsess_msg_equal(call->sess, msg);
+	return sipsess_msg(call->sess) == msg;
 }
 
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -803,7 +803,7 @@ int ua_accept(struct ua *ua, const struct sip_msg *msg)
 		return EINVAL;
 
 	if (ua_find_call_msg(ua, msg)) {
-		warning("ua: call was already accepted\n");
+		warning("ua: call was already created\n");
 		return EINVAL;
 	}
 

--- a/test/call.c
+++ b/test/call.c
@@ -659,6 +659,8 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 				err);
 			return;
 		}
+
+		bevent_stop(event);
 	}
 
 	if (ua == f->a.ua)


### PR DESCRIPTION
- **ua,call: prevent double ua_accept**
  - API function ua_accept() can be called by multiple modules which handle
    the shortly added UA_EVENT_SIPSESS_CONN. This commit prevents that
    multiple call/sipsess/sip_dialog objects are created for a single SIP
    INVITE message.
- **menu,test: bevent_stop after ua_accept**
  -  After accepting a call the bevent should not be handled by following
     event handlers.

