### PR TITLE
menu: add scode and reason arguments to hangup command

### DIFF
--- a/modules/menu/menu.h
+++ b/modules/menu/menu.h
@@ -67,6 +67,8 @@ void dial_menu_unregister(void);
 /*Generic menu funtions*/
 void menu_update_callstatus(bool incall);
 int  menu_param_decode(const char *prm, const char *name, struct pl *val);
+int menu_get_call_ua(struct re_printf *pf, const struct cmd_arg *carg,
+		     struct ua **uap, struct call **callp);
 struct call *menu_find_call(call_match_h *matchh, const struct call *exclude);
 struct call *menu_find_call_state(enum call_state st);
 enum sdp_dir decode_sdp_enum(const struct pl *pl);


### PR DESCRIPTION
This can be useful for replying for example with "603 Decline" which indicates that the user does not want to answer the call at all. From [RFC 3261 section 21.6.2](https://www.rfc-editor.org/rfc/rfc3261#section-21.6.2):

```
21.6.2 603 Decline

   The callee's machine was successfully contacted but the user
   explicitly does not wish to or cannot participate.  The response MAY
   indicate a better time to call in the Retry-After header field.  This
   status response is returned only if the client knows that no other
   end point will answer the request.
```