### PR TITLE
bevent: fix encode bevent without display name

### DIFF
--- a/src/bevent.c
+++ b/src/bevent.c
@@ -507,7 +507,7 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 			err = odict_pl_add(od, "contact", &hdr->val);
 
 		if (pl_isset(&msg->from.dname))
-			err = odict_pl_add(od, "display", &msg->from.dname);
+			err |= odict_pl_add(od, "display", &msg->from.dname);
 
 		err |= re_sdprintf(&buf, "%H", uri_encode, &msg->from.uri);
 		err |= odict_entry_add(od, "from", ODICT_STRING, buf);

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -507,9 +507,9 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 			err = odict_pl_add(od, "contact", &hdr->val);
 
 		if (pl_isset(&msg->from.dname))
-			odict_pl_add(od, "display", &msg->from.dname);
+			err = odict_pl_add(od, "display", &msg->from.dname);
 
-		err  = re_sdprintf(&buf, "%H", uri_encode, &msg->from.uri);
+		err |= re_sdprintf(&buf, "%H", uri_encode, &msg->from.uri);
 		err |= odict_entry_add(od, "from", ODICT_STRING, buf);
 		mem_deref(buf);
 		if (err)

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -506,8 +506,10 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 		if (hdr)
 			err = odict_pl_add(od, "contact", &hdr->val);
 
-		err |= odict_pl_add(od, "display", &msg->from.dname);
-		err |= re_sdprintf(&buf, "%H", uri_encode, &msg->from.uri);
+		if (pl_isset(&msg->from.dname))
+			odict_pl_add(od, "display", &msg->from.dname);
+
+		err  = re_sdprintf(&buf, "%H", uri_encode, &msg->from.uri);
 		err |= odict_entry_add(od, "from", ODICT_STRING, buf);
 		mem_deref(buf);
 		if (err)


### PR DESCRIPTION
This fixes serialization of `BEVENT_CLASS_SIP` events. If display name is not set `odict_encode_bevent()` failed and the event was not sent e.g. via dbus.