### PR TITLE
Static code analysis fixes

### DIFF
--- a/modules/httpreq/httpreq.c
+++ b/modules/httpreq/httpreq.c
@@ -264,7 +264,7 @@ static int cmd_setbody(struct re_printf *pf, void *arg)
 	(void)pf;
 
 	err = pl_opt_arg(&plp, arg);
-	if (err)
+	if (err || !plp)
 		return err;
 
 	mb = mbuf_alloc(plp->l);

--- a/modules/pipewire/capture.c
+++ b/modules/pipewire/capture.c
@@ -148,8 +148,10 @@ static void on_process(void *arg)
 	size_t sampc;
 
 	b = pw_stream_dequeue_buffer(st->stream);
-	if (!b)
+	if (!b) {
 		warning("pipewire: out of buffers (%m)\n", errno);
+		return;
+	}
 
 	buf = b->buffer;
 	d = &buf->datas[0];

--- a/modules/pipewire/playback.c
+++ b/modules/pipewire/playback.c
@@ -141,8 +141,10 @@ static void on_process(void *arg)
 	void *sampv;
 
 	b = pw_stream_dequeue_buffer(st->stream);
-	if (!b)
+	if (!b) {
 		warning("pipewire: out of buffers (%m)\n", errno);
+		return;
+	}
 
 	buf = b->buffer;
 	d = &buf->datas[0];

--- a/src/video.c
+++ b/src/video.c
@@ -911,7 +911,7 @@ static void rtcp_nack_handler(struct vtx *vtx, struct rtcp_msg *msg)
 {
 	uint16_t nack_pid;
 	uint16_t nack_blp;
-	uint16_t pids[NACK_BLPSZ + 1];
+	uint16_t pids[NACK_BLPSZ + 1] = {0};
 	struct le *le;
 
 	if (!msg || msg->hdr.count != RTCP_RTPFB_GNACK ||


### PR DESCRIPTION
Small fixes which were reported by running the [clang static code analyzer](https://clang-analyzer.llvm.org/) against the BareSIP repo.