### PR TITLE
ci/coverage: use ubuntu-22.04

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
I need to investigate why ubuntu 24.04 fails, for now let's stick with 22.04