### PR TITLE
fix vidframe xoffs yoffs init value to 0

### DIFF
--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -195,6 +195,8 @@ void avformat_video_decode(struct shared *st, AVPacket *pkt)
 
 	vf.size.w = st->vid.ctx->width;
 	vf.size.h = st->vid.ctx->height;
+	vf.xoffs = 0;
+	vf.yoffs = 0;
 
 	for (i=0; i<4; i++) {
 		vf.data[i]     = frame->data[i];


### PR DESCRIPTION
https://github.com/baresip/baresip/blob/0e8e45c7c0e8ea2de1ff3f43b29c210c9c6f4b77/modules/avformat/video.c#L140

not init properly.  xoffs, yoffs may get random number, and cause crash.

