### PR TITLE
Add OCSP Stapling

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -14,6 +14,7 @@ sip_capath		/etc/ssl/certs
 sip_verify_server	yes
 #sip_verify_client	no
 #sip_tls_resumption	all		# none, ids, tickets
+#sip_ocsp_stapling  no		# yes, required
 sip_tos			160 # See TOS fields!
 #filter_registrar   udp,tcp
 

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -357,18 +357,19 @@ const char *rtp_receive_mode_str(enum rtp_receive_mode rxmode);
 
 /** SIP User-Agent */
 struct config_sip {
-	char uuid[64];          /**< Universally Unique Identifier  */
-	char local[64];         /**< Local SIP Address              */
-	char cert[256];         /**< SIP Certificate                */
-	char cafile[256];       /**< SIP CA-file                    */
-	char capath[256];       /**< SIP CA-path                    */
-	uint32_t transports;    /**< Supported transports mask      */
+	char uuid[64];          /**< Universally Unique Identifier           */
+	char local[64];         /**< Local SIP Address                       */
+	char cert[256];         /**< SIP Certificate                         */
+	char cafile[256];       /**< SIP CA-file                             */
+	char capath[256];       /**< SIP CA-path                             */
+	uint32_t transports;    /**< Supported transports mask               */
 	enum sip_transp transp; /**< Default outgoing SIP transport protocol */
-	bool verify_server;     /**< Enable SIP TLS verify server   */
-	bool verify_client;     /**< Enable SIP TLS verify client   */
-	enum tls_resume_mode tls_resume; /** TLS resumption mode    */
-	uint8_t tos;            /**< Type-of-Service for SIP        */
-	uint32_t reg_filt;	/**< Registrar filter transport mask*/
+	bool verify_server;     /**< Enable SIP TLS verify server            */
+	bool verify_client;     /**< Enable SIP TLS verify client            */
+	enum tls_resume_mode tls_resume; /** TLS resumption mode             */
+	enum tls_ocsp_stapling ocsp_stapling; /** TLS OCSP stapling mode     */
+	uint8_t tos;            /**< Type-of-Service for SIP                 */
+	uint32_t reg_filt;	/**< Registrar filter transport mask         */
 };
 
 /** Call config */

--- a/src/uag.c
+++ b/src/uag.c
@@ -368,6 +368,7 @@ static int uag_transp_add(const struct sa *laddr)
 				tls_enable_verify_client(uag.tls, true);
 
 			tls_set_resumption(uag.tls, uag.cfg->tls_resume);
+			tls_set_ocsp_stapling(uag.tls, uag.cfg->ocsp_stapling);
 		}
 
 		if (sa_isset(&local, SA_PORT))


### PR DESCRIPTION
config,uag: add `sip_ocsp_stapling` setting

See [RFC 6066](https://datatracker.ietf.org/doc/html/rfc6066) (for the `status_request` extension) and [RFC 2560](https://datatracker.ietf.org/doc/html/rfc2560) (for the Online Certificate Status Protocol - OCSP definition).