### PR TITLE
video: do not request keyframe immediately if a packet is lost

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -889,12 +889,9 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	(void)extv;
 	(void)extc;
 	(void)ignore;
+	(void)lostc;
 
 	MAGIC_CHECK(v);
-
-	/* in case of packet loss, we need to receive a new keyframe */
-	if (lostc)
-		request_picture_update(&v->vrx);
 
 	(void)video_stream_decode(&v->vrx, hdr, mb);
 }


### PR DESCRIPTION
The video decoder is in a much better position to decide if a new keyframe is needed, and decoders already indicate that by returning an error in the decode handler.

For example see `avcodec/decode.c`. A lost fragment does not immediately mean that a new keyframe is needed, while other errors can not be recovered and a new keyframe must be requested.