### PR TITLE
menu: return on UA_EVENT_SIPSESS_CONN

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -731,7 +731,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 		}
 
 		bevent_stop(event);
-		break;
+		return;
 
 	case UA_EVENT_CALL_INCOMING:
 


### PR DESCRIPTION
Otherwise, when `UA_EVENT_SIPSESS_CONN` is done processing in the menu event_handler, `menu_set_incall` and `menu_update_callstatus` will be incorrect, leading to the `dynamic_menu` being broken.