### PR TITLE
pulse: add NULL checks for paconn_get

### DIFF
--- a/modules/pulse/player.c
+++ b/modules/pulse/player.c
@@ -158,5 +158,6 @@ void stream_write_cb(pa_stream *s, size_t len, void *arg)
 	}
 
 out:
-	pa_threaded_mainloop_signal(c->mainloop, 0);
+	if (c)
+		pa_threaded_mainloop_signal(c->mainloop, 0);
 }

--- a/modules/pulse/recorder.c
+++ b/modules/pulse/recorder.c
@@ -203,5 +203,6 @@ void stream_read_cb(pa_stream *s, size_t len, void *arg)
 	st->rh(&af, st->arg);
 
 out:
-	pa_threaded_mainloop_signal(c->mainloop, 0);
+	if (c)
+		pa_threaded_mainloop_signal(c->mainloop, 0);
 }


### PR DESCRIPTION
This fixes SEGVs when pulse is restarted during a call.