### PR TITLE
call: fix cppcheck warning

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1812,7 +1812,7 @@ static int sipsess_offer_handler(struct mbuf **descp,
 	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "%s",
 			 got_offer ? "answer" : "offer");
 
-	return err;
+	return 0;
 }
 
 


### PR DESCRIPTION
src/call.c:1815:9: warning: Identical condition and return expression 'err', return value is always 0 [identicalConditionAfterEarlyExit]
 return err;
        ^
src/call.c:1809:6: note: If condition 'err' is true, the function will return/exit
 if (err)
     ^
src/call.c:1815:9: note: Returning identical expression 'err'
 return err;
        ^
