### PR TITLE
menu fix contact media direction

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -275,6 +275,8 @@ void call_set_media_direction(struct call *call, enum sdp_dir a,
 void call_set_mdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
 void call_get_mdir(struct call *call, enum sdp_dir *ap, enum sdp_dir *vp);
 void call_set_media_estdir(struct call *call, enum sdp_dir a, enum sdp_dir v);
+void call_get_media_estdir(struct call *call,
+			   enum sdp_dir *ap, enum sdp_dir *vp);
 void call_start_answtmr(struct call *call, uint32_t ms);
 bool          call_supported(struct call *call, uint16_t tags);
 const char   *call_user_data(const struct call *call);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -667,9 +667,19 @@ static void apply_contact_mediadir(struct call *call)
 	if (!con)
 		return;
 
-	enum sdp_dir audir  = SDP_SENDRECV;
-	enum sdp_dir viddir = SDP_SENDRECV;
-	contact_get_ldir(con, &audir, &viddir);
+	enum sdp_dir caudir  = SDP_SENDRECV;
+	enum sdp_dir cviddir = SDP_SENDRECV;
+	contact_get_ldir(con, &caudir, &cviddir);
+
+	enum sdp_dir estaudir  = SDP_SENDRECV;
+	enum sdp_dir estviddir = SDP_SENDRECV;
+	call_get_media_estdir(call, &estaudir, &estviddir);
+
+	enum sdp_dir audir  = estaudir & caudir;
+	enum sdp_dir viddir = estviddir & cviddir;
+	if (audir == estaudir && viddir == estviddir)
+		return;
+
 	debug("menu: apply contact media direction audio=%s video=%s\n",
 	      sdp_dir_name(audir), sdp_dir_name(viddir));
 	call_set_media_direction(call, audir, viddir);

--- a/src/call.c
+++ b/src/call.c
@@ -3175,6 +3175,27 @@ void call_get_mdir(struct call *call, enum sdp_dir *ap, enum sdp_dir *vp)
 
 
 /**
+ * Returns audio and video directions for the established state
+ *
+ * @param call Call object
+ * @param ap   Pointer for returning audio direction
+ * @param vp   Pointer for returning video direction
+ */
+void call_get_media_estdir(struct call *call,
+			   enum sdp_dir *ap, enum sdp_dir *vp)
+{
+	if (!call)
+		return;
+
+	if (ap)
+		*ap = call->estadir;
+
+	if (vp)
+		*vp = call->estvdir;
+}
+
+
+/**
  * Set audio/video direction during pre-established for the established state
  *
  * @param call Call object


### PR DESCRIPTION
Fixes #3324 

I suggest to set the logical `&` of contact and the "established" media direction (`estadir`, `estvdir`).

For both `SDP_SENDRECV` is the default. The user should have the chance to switch any direction off
- permanently for the contact (e.g. for security reasons) or
- for one call via `dialdir`.

This fixes the issue #3324 and works also in combination with 183 Session Progress. Whereas commands like
- `medialdir` override the media direction for the specified call and
- `videodir` override the mdir temporarily for the current call state (early media, resp. established).

Commits:
- **call: a getter for the established media direction**
- **menu: contact media direction vs dialdir (#3324)**
