### PR TITLE
In aaudio recorder, use InputPreset VOICE_COMMUNICATION instead of VOICE_RECOGNITION

### DIFF
--- a/modules/aaudio/recorder.c
+++ b/modules/aaudio/recorder.c
@@ -150,7 +150,7 @@ static int open_recorder_stream(struct ausrc_st *st) {
 	AAudioStreamBuilder_setPerformanceMode(builder,
 		AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
 	AAudioStreamBuilder_setInputPreset(builder,
-		AAUDIO_INPUT_PRESET_VOICE_RECOGNITION);
+		AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION);
 	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, st);
 	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, st);
 


### PR DESCRIPTION
In aaudio module recorder, use VOICE_COMMUNICATION instead of VOICE_RECOGNITION.  From API document:
```
AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION  Use this preset when doing telephony or voice messaging. 
```
Turned out that audio effects, e.g. echo canceler, need AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION.