### PR TITLE
aac: fix formatting arguments to %w

### DIFF
--- a/modules/aac/aac.c
+++ b/modules/aac/aac.c
@@ -289,7 +289,7 @@ static int module_init(void)
 	     enc_info.frameLength, enc_info.inputChannels);
 
 	re_snprintf(prm.config, sizeof(prm.config), "%w",
-			enc_info.confBuf, enc_info.confSize);
+			enc_info.confBuf, (size_t)enc_info.confSize);
 
 	aacEncClose(&enc);
 


### PR DESCRIPTION
Caused a crash on Debug build on Linux ...