### PR TITLE
cmake/FindOPUS: align include path names

### DIFF
--- a/cmake/FindOPUS.cmake
+++ b/cmake/FindOPUS.cmake
@@ -10,7 +10,7 @@ if(NOT WIN32)
 endif()
 
 find_path(OPUS_INCLUDE_DIR
-  NAMES opus/opus.h opus.h
+  NAMES opus/opus.h
   HINTS
     "${OPUS_INCLUDE_DIRS}"
     "${OPUS_HINTS}/include"


### PR DESCRIPTION
remove standalone `opus.h`, we always include `<opus/opus.h>`