### PR TITLE
ctrl_tcp preload: allow preloading of ctrl_tcp module on baresip command line

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1686,7 +1686,7 @@ int sip_req_send(struct ua *ua, const char *method, const char *uri,
 #endif
 
 
-int  module_preload(const char *module, const struct conf *cfg);
+int  module_preload(const char *module);
 int  module_load(const char *path, const char *name);
 void module_unload(const char *name);
 void module_app_unload(void);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1686,7 +1686,7 @@ int sip_req_send(struct ua *ua, const char *method, const char *uri,
 #endif
 
 
-int  module_preload(const char *module);
+int  module_preload(const char *module, const struct conf *cfg);
 int  module_load(const char *path, const char *name);
 void module_unload(const char *name);
 void module_app_unload(void);

--- a/src/main.c
+++ b/src/main.c
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
 
 		for (i=0; i<modc; i++) {
 
-			err = module_preload(modv[i]);
+			err = module_preload(modv[i], conf_cur());
 			if (err) {
 				re_fprintf(stderr,
 					   "could not pre-load module"

--- a/src/main.c
+++ b/src/main.c
@@ -267,7 +267,14 @@ int main(int argc, char *argv[])
 			      conf_config()->audio.audio_path);
 	}
 
-	/* NOTE: must be done after all arguments are processed */
+    /* Initialise User Agents */
+    err = ua_init(software, true, true, true);
+    if (err)
+        goto out;
+
+    /* NOTE: must be done after all arguments are processed and UA is
+       initialized; some modules (eg, ctrl_tcp) can only be preloaded
+       when the UA is available */
 	if (modc) {
 
 		info("pre-loading modules: %zu\n", modc);
@@ -282,11 +289,6 @@ int main(int argc, char *argv[])
 			}
 		}
 	}
-
-	/* Initialise User Agents */
-	err = ua_init(software, true, true, true);
-	if (err)
-		goto out;
 
 	uag_set_exit_handler(ua_exit_handler, NULL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -267,14 +267,14 @@ int main(int argc, char *argv[])
 			      conf_config()->audio.audio_path);
 	}
 
-    /* Initialise User Agents */
-    err = ua_init(software, true, true, true);
-    if (err)
-        goto out;
+	/* Initialise User Agents */
+	err = ua_init(software, true, true, true);
+	if (err)
+		goto out;
 
-    /* NOTE: must be done after all arguments are processed and UA is
-       initialized; some modules (eg, ctrl_tcp) can only be preloaded
-       when the UA is available */
+	/* NOTE: must be done after all arguments are processed and UA is
+		initialized; some modules (eg, ctrl_tcp) can only be preloaded
+		when the UA is available */
 	if (modc) {
 
 		info("pre-loading modules: %zu\n", modc);

--- a/src/main.c
+++ b/src/main.c
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
 
 		for (i=0; i<modc; i++) {
 
-			err = module_preload(modv[i], conf_cur());
+			err = module_preload(modv[i]);
 			if (err) {
 				re_fprintf(stderr,
 					   "could not pre-load module"

--- a/src/module.c
+++ b/src/module.c
@@ -190,6 +190,7 @@ void module_app_unload(void)
 int module_preload(const char *module)
 {
 	struct pl path, name;
+	int err;
 
 	if (!module)
 		return EINVAL;
@@ -197,15 +198,17 @@ int module_preload(const char *module)
 	pl_set_str(&path, ".");
 	pl_set_str(&name, module);
 
-	char file[FS_PATH_MAX];
-	if (re_snprintf(file, sizeof(file), "%r/%r", &path, &name) < 0) {
-		return ENOMEM;
-	}
+	char *file = NULL;
+	err = re_sdprintf(&file, "%r/%r", &path, &name);
+	if (err)
+		return err;
 
 	if (! fs_isfile(file)) {
 		const struct conf *conf = conf_cur();
 		conf_get(conf, "module_path", &path);
 	}
+
+	mem_deref(file);
 
 	return load_module(NULL, &path, &name);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -65,9 +65,10 @@ static int load_module(struct mod **modp, const struct pl *modpath,
 		return EINVAL;
 
 #ifdef STATIC
-	/* Try static first; if a static module is available assume that it
-		is "sound" and the call to mod_add (which initializes the module)
-		should succeed */
+	/* Try static first; if a static module is available
+		assume that it is "sound" and that the call to
+		mod_add (which initializes the module) should
+		succeed */
 	pl_strcpy(name, namestr, sizeof(namestr));
 
 	if (mod_find(namestr)) {
@@ -178,8 +179,8 @@ void module_app_unload(void)
 
 
 /**
- * Pre-load a module. First check the current working directory 
- * then fall back to the configured module path 
+ * Pre-load a module. First check the current working directory
+ * then fall back to the configured module path
  *
  * @param module Module name including extension
  * @param conf Config from which to obtain module path

--- a/src/module.c
+++ b/src/module.c
@@ -178,13 +178,15 @@ void module_app_unload(void)
 
 
 /**
- * Pre-load a module from the current working directory
+ * Pre-load a module. First check the current working directory 
+ * then fall back to the configured module path 
  *
  * @param module Module name including extension
+ * @param conf Config from which to obtain module path
  *
  * @return 0 if success, otherwise errorcode
  */
-int module_preload(const char *module)
+int module_preload(const char *module, const struct conf *conf)
 {
 	struct pl path, name;
 
@@ -193,6 +195,15 @@ int module_preload(const char *module)
 
 	pl_set_str(&path, ".");
 	pl_set_str(&name, module);
+
+	char file[FS_PATH_MAX];
+	if (re_snprintf(file, sizeof(file), "%r/%r", &path, &name) < 0) {
+		return ENOMEM;
+	}
+
+	if (! fs_isfile(file)) {
+		conf_get(conf, "module_path", &path);
+	}
 
 	return load_module(NULL, &path, &name);
 }

--- a/src/module.c
+++ b/src/module.c
@@ -187,7 +187,7 @@ void module_app_unload(void)
  *
  * @return 0 if success, otherwise errorcode
  */
-int module_preload(const char *module, const struct conf *conf)
+int module_preload(const char *module)
 {
 	struct pl path, name;
 
@@ -203,6 +203,7 @@ int module_preload(const char *module, const struct conf *conf)
 	}
 
 	if (! fs_isfile(file)) {
+		const struct conf *conf = conf_cur();
 		conf_get(conf, "module_path", &path);
 	}
 

--- a/src/module.c
+++ b/src/module.c
@@ -65,7 +65,9 @@ static int load_module(struct mod **modp, const struct pl *modpath,
 		return EINVAL;
 
 #ifdef STATIC
-	/* Try static first */
+    /* Try static first; if a static module is available assume that it
+       is "sound" and the call to mod_add (which initializes the module)
+       should succeed */
 	pl_strcpy(name, namestr, sizeof(namestr));
 
 	if (mod_find(namestr)) {
@@ -73,9 +75,11 @@ static int load_module(struct mod **modp, const struct pl *modpath,
 		return EALREADY;
 	}
 
-	err = mod_add(&m, lookup_static_module(name));
-	if (!err)
-		goto out;
+    const struct mod_export* mex = lookup_static_module(name);
+    if (mex) {
+        err = mod_add(&m, mex);
+        goto out;
+    }
 #else
 	(void)namestr;
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -65,9 +65,9 @@ static int load_module(struct mod **modp, const struct pl *modpath,
 		return EINVAL;
 
 #ifdef STATIC
-    /* Try static first; if a static module is available assume that it
-       is "sound" and the call to mod_add (which initializes the module)
-       should succeed */
+	/* Try static first; if a static module is available assume that it
+		is "sound" and the call to mod_add (which initializes the module)
+		should succeed */
 	pl_strcpy(name, namestr, sizeof(namestr));
 
 	if (mod_find(namestr)) {
@@ -75,11 +75,11 @@ static int load_module(struct mod **modp, const struct pl *modpath,
 		return EALREADY;
 	}
 
-    const struct mod_export* mex = lookup_static_module(name);
-    if (mex) {
-        err = mod_add(&m, mex);
-        goto out;
-    }
+	const struct mod_export* mex = lookup_static_module(name);
+	if (mex) {
+		err = mod_add(&m, mex);
+		goto out;
+	}
 #else
 	(void)namestr;
 #endif

--- a/src/module.c
+++ b/src/module.c
@@ -183,7 +183,6 @@ void module_app_unload(void)
  * then fall back to the configured module path
  *
  * @param module Module name including extension
- * @param conf Config from which to obtain module path
  *
  * @return 0 if success, otherwise errorcode
  */


### PR DESCRIPTION
The `ctrl_tcp` module fails to initialize when attempting to preload it with `baresip -m`. This MR addresses this issue with the following changes:

1. Update main to initialize the UA before preloading modules - makes the UA available to the initialization routine of  `ctrl_tcp` (and any other modules like it).
2. Update `load_module` to skip dynamic loading for static modules. If a static module is found an attempt is made to load/initialize it, and the result returned to the caller immediately. Previously, a static module that failed to initialize would fall through to the dynamic case which leads to misleading errors (in the `ctrl_tcp` case) or confusing behavior.
3. Update `module_preload` to allow pre-loading modules from the current working directory or from the configured module path. This allows preloading standard modules in the same way whether they're compiled as separate libs or statically.