### PR TITLE
conf: initialize conf_obj

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -39,7 +39,7 @@
 
 
 static char *conf_path = NULL;
-static struct conf *conf_obj;
+static struct conf *conf_obj = NULL;
 
 
 static void print_populated(const char *what, uint32_t n)


### PR DESCRIPTION
When first beed accessed from `conf_obj = mem_deref(conf_obj);` around line `conf.c:372`, `conf_obj` is not a initialized value.
