### PR TITLE
avcapture: add macOS screen capture

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1359,7 +1359,7 @@ int video_start_source(struct video *v)
 
 	struct vtx *vtx = &v->vtx;
 
-	debug("video: start source\n");
+	debug("video: start source %s,%s\n", vtx->module, vtx->device);
 
 	if (vidsrc_find(baresip_vidsrcl(), NULL)) {
 		struct vidsrc *vs;


### PR DESCRIPTION
According to macOS doc: https://developer.apple.com/documentation/avfoundation/avcapturescreeninput?language=objc

_Starting in macOS 12.3, use the [ScreenCaptureKit](https://developer.apple.com/documentation/ScreenCaptureKit?language=objc) framework for screen recording instead._

However, this feature is still useful with minimum change.
