### PR TITLE
100rel improvements

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2419,7 +2419,8 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	switch (msg->scode) {
 
 	case 180:
-		set_state(call, CALL_STATE_RINGING);
+		if (call_state(call) != CALL_STATE_EARLY)
+			set_state(call, CALL_STATE_RINGING);
 		break;
 
 	case 183:
@@ -2434,7 +2435,7 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
                                    call->peer_uri);
 		mem_deref(call);
 	}
-	else {
+	else if (call_state(call) != CALL_STATE_EARLY) {
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_RINGING, "%s",
                                    call->peer_uri);


### PR DESCRIPTION
* [call: do not go back to RINGING state if already in EARLY](https://github.com/baresip/baresip/pull/3402/commits/c0eb101d78c03432849cd3ad257a27df9cdd88dc)
The function call_progress may fail with EAGAIN (e.g. if awaiting
PRACK). In that case, try again if a PRACK was received.
* [call: do not go back to RINGING state if already in EARLY](https://github.com/maximilianfridrich/baresip/commit/c0eb101d78c03432849cd3ad257a27df9cdd88dc)
In some cases, for example when 100rel is used, 1XX responses may arrive
out of order (e.g. due to re-transmissions with 100rel). If a 180
Ringing response arrives after a 183 response has already been
processed, it does not make much sense to stop the early media streams
and go back to ringing. So now, once in the EARLY state, the call will
not go back to the RINGING state.

Related:
- https://github.com/baresip/re/pull/1333