### PR TITLE
call: added from-tag and to-tag to Refer-To header in call_replace_transfer

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -238,7 +238,7 @@ bool call_refresh_allowed(const struct call *call);
 bool call_ack_pending(const struct call *call);
 bool call_sess_cmp(const struct call *call, const struct sip_msg *msg);
 int  call_transfer(struct call *call, const char *uri);
-int  call_replace_transfer(struct call *target_call, struct call *source_call);
+int  call_replace_transfer(struct call *call, struct call *source_call);
 int  call_status(struct re_printf *pf, const struct call *call);
 int  call_debug(struct re_printf *pf, const struct call *call);
 int  call_notify_sipfrag(struct call *call, uint16_t scode,

--- a/src/call.c
+++ b/src/call.c
@@ -2872,20 +2872,27 @@ int call_transfer(struct call *call, const char *uri)
  */
 int call_replace_transfer(struct call *call, struct call *source_call)
 {
-	int err;
+    int err;
+
+	if (!call || !source_call)
+		return EINVAL;
 
 	info("transferring call to %s\n", source_call->peer_uri);
 
 	call->sub = mem_deref(call->sub);
 
 	err = sipevent_drefer(&call->sub, uag_sipevent_sock(),
-			      sipsess_dialog(call->sess), ua_cuser(call->ua),
-			      auth_handler, call->acc, true,
-			      sipsub_notify_handler, sipsub_close_handler,
-                              call,
-			 "Refer-To: <%s?Replaces=%s>\r\nReferred-by: %s\r\n",
-                              source_call->peer_uri, source_call->id,
-		              account_aor(ua_account(call->ua)));
+		sipsess_dialog(call->sess), ua_cuser(call->ua),
+		auth_handler, call->acc, true,
+		sipsub_notify_handler, sipsub_close_handler, call,
+	    "Refer-To: <%s?Replaces=%s%%3Bto-tag%%3D%s%%3Bfrom-tag%%3D%s>\r\n"
+	    "Referred-By: %s\r\n",
+	    source_call->peer_uri,
+	    source_call->id,
+	    sip_dialog_rtag(sipsess_dialog(source_call->sess)),
+        sip_dialog_ltag(sipsess_dialog(source_call->sess)),
+	    account_aor(ua_account(call->ua)));
+
 	if (err) {
 		warning("call: sipevent_drefer: %m\n", err);
 	}

--- a/src/call.c
+++ b/src/call.c
@@ -2882,7 +2882,7 @@ int call_replace_transfer(struct call *call, struct call *source_call)
 	call->sub = mem_deref(call->sub);
 
 	err = sipevent_drefer(&call->sub, uag_sipevent_sock(),
-	    sipsess_dialog(call->sess), ua_cuser(call->ua),
+		sipsess_dialog(call->sess), ua_cuser(call->ua),
 		auth_handler, call->acc, true,
 		sipsub_notify_handler, sipsub_close_handler, call,
 	"Refer-To: <%s?Replaces=%s%%3Bto-tag%%3D%s%%3Bfrom-tag%%3D%s>\r\n"

--- a/src/call.c
+++ b/src/call.c
@@ -2872,7 +2872,7 @@ int call_transfer(struct call *call, const char *uri)
  */
 int call_replace_transfer(struct call *call, struct call *source_call)
 {
-    int err;
+	int err;
 
 	if (!call || !source_call)
 		return EINVAL;
@@ -2882,16 +2882,16 @@ int call_replace_transfer(struct call *call, struct call *source_call)
 	call->sub = mem_deref(call->sub);
 
 	err = sipevent_drefer(&call->sub, uag_sipevent_sock(),
-		sipsess_dialog(call->sess), ua_cuser(call->ua),
+	    sipsess_dialog(call->sess), ua_cuser(call->ua),
 		auth_handler, call->acc, true,
 		sipsub_notify_handler, sipsub_close_handler, call,
-	    "Refer-To: <%s?Replaces=%s%%3Bto-tag%%3D%s%%3Bfrom-tag%%3D%s>\r\n"
-	    "Referred-By: %s\r\n",
-	    source_call->peer_uri,
-	    source_call->id,
-	    sip_dialog_rtag(sipsess_dialog(source_call->sess)),
-        sip_dialog_ltag(sipsess_dialog(source_call->sess)),
-	    account_aor(ua_account(call->ua)));
+	"Refer-To: <%s?Replaces=%s%%3Bto-tag%%3D%s%%3Bfrom-tag%%3D%s>\r\n"
+		"Referred-By: %s\r\n",
+		source_call->peer_uri,
+		source_call->id,
+		sip_dialog_rtag(sipsess_dialog(source_call->sess)),
+		sip_dialog_ltag(sipsess_dialog(source_call->sess)),
+		account_aor(ua_account(call->ua)));
 
 	if (err) {
 		warning("call: sipevent_drefer: %m\n", err);


### PR DESCRIPTION
Commit targeting #3367.

Indentation updated to not exceed 79 columns. Some indentation is being pushed during the commit, let me know should there be any feedback re style etc or pls feel free to make any edits as you deem necessary. 

test_call_attended_transfer passing

```log
./build/test/selftest -r main -v test_call_attended_transfer
running baresip selftest version 3.22.0 with 1 tests
Local network addresses:
        lo0:  fe80::1
      utun0:  fe80::2ba4:8a12:d9de:58d2
        en0:  fe80::18f0:a2eb:e1dc:3cfd
        en0:  fd47:2d2a:e27b:d848:188a:b882:90dc:7738
        en0:  192.168.0.32
      awdl0:  fe80::706b:5bff:fee5:dea5
      utun1:  fe80::d5a1:760f:cdf5:79fd
      utun2:  fe80::c67d:14cb:c784:832
      utun3:  fe80::ce81:b1c:bd2c:69e
      utun5:  fe80::9865:8ec3:7587:dc88
      utun6:  fe80::ee4f:eddb:d14b:780b
      utun7:  fe80::332b:88f6:6bdb:e0bf
      utun8:  fe80::8639:8b16:c65d:2aa8
      utun9:  fe80::612d:4b7b:e6eb:80d
[ RUN      ] test_call_attended_transfer (rx main)
aucodec: PCMU/8000/1
aucodec: PCMA/8000/1
test: [ sip:c@127.0.0.1 ] event: CREATE (sip:c@127.0.0.1)
call: connecting to 'sip:b@127.0.0.1:62422'..
test: [ sip:a@127.0.0.1 ] event: CALL_OUTGOING (sip:b@127.0.0.1:62422)
test: [ sip:a@127.0.0.1 ] event: CALL_LOCAL_SDP (offer)
b@127.0.0.1: account match for b
test: [  ] event: SIPSESS_CONN (incoming call)
b@127.0.0.1: account match for b
ua: using connection-address 127.0.0.1 of SDP offer
test: [ sip:b@127.0.0.1 ] event: CALL_REMOTE_SDP (offer)
test: [ sip:b@127.0.0.1 ] event: CALL_INCOMING (sip:a@127.0.0.1)
call: answering call on line 1 from sip:a@127.0.0.1 with 200
stream: update 'audio'
test: [ sip:b@127.0.0.1 ] event: CALL_LOCAL_SDP (answer)
call: SIP Progress: 180 Ringing (/)
test: [ sip:a@127.0.0.1 ] event: CALL_RINGING (sip:b@127.0.0.1:62422)
a@127.0.0.1: Call answered: sip:b@127.0.0.1:62422
test: [ sip:a@127.0.0.1 ] event: CALL_ANSWERED (sip:b@127.0.0.1:62422)
test: [ sip:a@127.0.0.1 ] event: CALL_REMOTE_SDP (answer)
stream: update 'audio'
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
a@127.0.0.1: Call established: sip:b@127.0.0.1:62422
test: [ sip:a@127.0.0.1 ] event: CALL_ESTABLISHED (sip:b@127.0.0.1:62422)
test: [ sip:b@127.0.0.1 ] event: CALL_RTCP (audio)
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
b@127.0.0.1: Call established: sip:a@127.0.0.1
test: [ sip:b@127.0.0.1 ] event: CALL_ESTABLISHED (sip:a@127.0.0.1)
call: hold sip:a@127.0.0.1
test: [ sip:b@127.0.0.1 ] event: CALL_LOCAL_SDP (offer)
stream: update 'audio'
call: connecting to 'sip:c@127.0.0.1:62422'..
test: [ sip:b@127.0.0.1 ] event: CALL_OUTGOING (sip:c@127.0.0.1:62422)
test: [ sip:b@127.0.0.1 ] event: CALL_LOCAL_SDP (offer)
test: [ sip:a@127.0.0.1 ] event: CALL_HOLD ()
test: [ sip:a@127.0.0.1 ] event: CALL_REMOTE_SDP (offer)
stream: update 'audio'
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
call: got INVITE (SDP Offer) audio-video: recvonly-inactive
test: [ sip:a@127.0.0.1 ] event: CALL_LOCAL_SDP (answer)
test: [ sip:a@127.0.0.1 ] event: CALL_RTCP (audio)
c@127.0.0.1: account match for c
test: [  ] event: SIPSESS_CONN (incoming call)
c@127.0.0.1: account match for c
ua: using connection-address 127.0.0.1 of SDP offer
test: [ sip:c@127.0.0.1 ] event: CALL_REMOTE_SDP (offer)
test: [ sip:c@127.0.0.1 ] event: CALL_INCOMING (sip:b@127.0.0.1)
call: answering call on line 1 from sip:b@127.0.0.1 with 200
stream: update 'audio'
test: [ sip:c@127.0.0.1 ] event: CALL_LOCAL_SDP (answer)
test: [ sip:b@127.0.0.1 ] event: CALL_REMOTE_SDP (answer)
stream: update 'audio'
call: SIP Progress: 180 Ringing (/)
test: [ sip:b@127.0.0.1 ] event: CALL_RINGING (sip:c@127.0.0.1:62422)
test: [ sip:a@127.0.0.1 ] event: CALL_RTCP (audio)
b@127.0.0.1: Call answered: sip:c@127.0.0.1:62422
test: [ sip:b@127.0.0.1 ] event: CALL_ANSWERED (sip:c@127.0.0.1:62422)
test: [ sip:b@127.0.0.1 ] event: CALL_REMOTE_SDP (answer)
stream: update 'audio'
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
b@127.0.0.1: Call established: sip:c@127.0.0.1:62422
test: [ sip:b@127.0.0.1 ] event: CALL_ESTABLISHED (sip:c@127.0.0.1:62422)
call: hold sip:c@127.0.0.1:62422
test: [ sip:b@127.0.0.1 ] event: CALL_LOCAL_SDP (offer)
stream: update 'audio'
transferring call to sip:c@127.0.0.1:62422
test: [ sip:c@127.0.0.1 ] event: CALL_RTCP (audio)
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
c@127.0.0.1: Call established: sip:b@127.0.0.1
test: [ sip:c@127.0.0.1 ] event: CALL_ESTABLISHED (sip:b@127.0.0.1)
test: [ sip:c@127.0.0.1 ] event: CALL_RTCP (audio)
test: [ sip:c@127.0.0.1 ] event: CALL_HOLD ()
test: [ sip:c@127.0.0.1 ] event: CALL_REMOTE_SDP (offer)
stream: update 'audio'
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
call: got INVITE (SDP Offer) audio-video: recvonly-inactive
test: [ sip:c@127.0.0.1 ] event: CALL_LOCAL_SDP (answer)
a@127.0.0.1: selected for a-0x15c006ff0
test: [ sip:a@127.0.0.1 ] event: TRANSFER (<sip:c@127.0.0.1:62422?Replaces=5ce2ce7c70c08ece%3Bto-tag%3D79a7798616aa2fed%3Bfrom-tag%3D6b1773038057cb98>)
call: connecting to '<sip:c@127.0.0.1:62422?Replaces=5ce2ce7c70c08ece%3Bto-tag%3D79a7798616aa2fed%3Bfrom-tag%3D6b1773038057cb98>'..
test: [ sip:a@127.0.0.1 ] event: CALL_OUTGOING (sip:c@127.0.0.1:62422)
test: [ sip:a@127.0.0.1 ] event: CALL_LOCAL_SDP (offer)
test: [ sip:b@127.0.0.1 ] event: CALL_REMOTE_SDP (answer)
stream: update 'audio'
test: [ sip:c@127.0.0.1 ] event: CALL_RTCP (audio)
c@127.0.0.1: account match for c
test: [  ] event: SIPSESS_CONN (incoming call)
c@127.0.0.1: account match for c
ua: using connection-address 127.0.0.1 of SDP offer
test: [ sip:c@127.0.0.1 ] event: CALL_REMOTE_SDP (offer)
test: [ sip:c@127.0.0.1 ] event: CALL_CLOSED (5ce2ce7c70c08ece;to-tag=79a7798616aa2fed;from-tag=6b1773038057cb98 replaced)
test: [ sip:c@127.0.0.1 ] event: CALL_INCOMING (sip:a@127.0.0.1)
call: answering call on line 2 from sip:a@127.0.0.1 with 200
stream: update 'audio'
test: [ sip:c@127.0.0.1 ] event: CALL_LOCAL_SDP (answer)
call: SIP Progress: 180 Ringing (/)
test: [ sip:a@127.0.0.1 ] event: CALL_RINGING (sip:c@127.0.0.1:62422)
a@127.0.0.1: Call answered: sip:c@127.0.0.1:62422
test: [ sip:a@127.0.0.1 ] event: CALL_ANSWERED (sip:c@127.0.0.1:62422)
test: [ sip:a@127.0.0.1 ] event: CALL_REMOTE_SDP (answer)
stream: update 'audio'
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
a@127.0.0.1: Call established: sip:c@127.0.0.1:62422
test: [ sip:a@127.0.0.1 ] event: CALL_ESTABLISHED (sip:c@127.0.0.1:62422)
sip:c@127.0.0.1:62422: session closed: Connection reset by peer [54]
test: [ sip:b@127.0.0.1 ] event: CALL_CLOSED (Connection reset by peer [54])
test: [ sip:c@127.0.0.1 ] event: CALL_RTCP (audio)
audio_recv: Set audio decoder: PCMU 8000Hz 1ch
audio: Set audio encoder: PCMU 8000Hz 1ch
audio tx pipeline:       (src) ---> aubuf ---> PCMU
audio rx pipeline:      (play) <--- aubuf <--- PCMU
c@127.0.0.1: Call established: sip:a@127.0.0.1
test: [ sip:c@127.0.0.1 ] event: CALL_ESTABLISHED (sip:a@127.0.0.1)
test: [ sip:b@127.0.0.1 ] event: CALL_CLOSED (Call transfered)
sip:b@127.0.0.1:62422: session closed: Connection reset by peer [54]
test: [ sip:a@127.0.0.1 ] event: CALL_CLOSED (Connection reset by peer [54])
test: [ sip:c@127.0.0.1 ] event: CALL_CLOSED (User-Agent deleted)
test: [ sip:a@127.0.0.1 ] event: CALL_CLOSED (User-Agent deleted)
unloading module: g711.so
ua: stop all (forced=1)
[       OK ]
ua: stop all (forced=1)
OK. 1 tests passed successfully
ua: stop all (forced=1)
```

Thanks again for the support. 
