### PR TITLE
call: Get cancel reason from close message

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2104,19 +2104,17 @@ static void sipsess_close_handler(int err, const struct sip_msg *msg,
 
 	call_stream_stop(call);
 
-	if (msg) {
+	if (msg)
 		reason_hdr = sip_msg_hdr(msg, SIP_HDR_REASON);
-	}
 
 	if (reason_hdr) {
 		info("Cancel reason: %r\n", &reason_hdr->val);
-		call_event_handler(call, CALL_EVENT_CLOSED, "%s | %r",
+		call_event_handler(call, CALL_EVENT_CLOSED, "%s,%r",
 						   reason, &reason_hdr->val);
 	}
 	else {
 		call_event_handler(call, CALL_EVENT_CLOSED, "%s", reason);
 	}
-
 }
 
 


### PR DESCRIPTION
Lib-re now passes a close message when the call has been canceled which means we can pass the reason line via the reason string with the `CALL_EVENT_CLOSED`

This goes towards the goal of providing better UI when a call gets cancelled