### PR TITLE
ci: update mingw.yml

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -69,7 +69,7 @@ jobs:
         retention-days: 1
 
   wintest:
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: MinGW-w64-build
 
     steps:


### PR DESCRIPTION
Breaking changes

We will soon start the deprecation process for Windows 2019. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-06-01 and the image will be fully unsupported by 2025-06-30.