### PR TITLE
Add new configuration parameter 'play-after-estab' 

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -404,6 +404,9 @@ struct config_audio {
 	bool adaptive;          /**< Enable adaptive audio buffer   */
 	double silence;         /**< Silence volume in [dB]         */
 	uint32_t telev_pt;      /**< Payload type for tel.-event    */
+
+	// NOTE for reviewer: should the config param actually go inside "config_call"?
+	bool play_after_estab;  /**< Ignore early media scenario and start audio playback only after call estabilishment */
 };
 
 /** Video */

--- a/modules/aufile/aufile_src.c
+++ b/modules/aufile/aufile_src.c
@@ -140,7 +140,7 @@ static int read_file(struct ausrc_st *st)
 			break;
 
 		if (mb->end == 0) {
-			info("aufile: read end of file\n");
+			info("aufile: reached end of file\n");
 			break;
 		}
 

--- a/src/config.c
+++ b/src/config.c
@@ -53,7 +53,8 @@ static struct config core_config = {
 		.buffer = {20, 160},
 		.adaptive = false,
 		.silence = -35.0,
-		.telev_pt = 101
+		.telev_pt = 101,
+		.play_after_estab = false
 	},
 
 	/** Video */
@@ -468,6 +469,7 @@ int config_parse_conf(struct config *cfg, const struct conf *conf)
 
 	(void)conf_get_float(conf, "audio_silence", &cfg->audio.silence);
 	(void)conf_get_u32(conf, "audio_telev_pt", &cfg->audio.telev_pt);
+	(void)conf_get_bool(conf, "audio_play_after_estab", &cfg->audio.play_after_estab);
 
 	/* Video */
 	(void)conf_get_csv(conf, "video_source",


### PR DESCRIPTION
Ths PR allows to skip playing audio files for early-media scenarios via a new config option.

See https://github.com/baresip/baresip/issues/2882