### PR TITLE
menu: Add hangup sound on closed calls

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -248,6 +248,7 @@ video_selfview		window # {window,pip}
 #ring_aufile		ring.wav
 #callwaiting_aufile	callwaiting.wav
 #ringback_aufile	ringback.wav
+#hangup_aufile		none
 #notfound_aufile	notfound.wav
 #busy_aufile		busy.wav
 #error_aufile		error.wav

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -551,6 +551,9 @@ static void menu_play_closed(struct call *call)
 
 		menu_play(call, key, fb, 1, DEVICE_ALERT);
 	}
+	else {
+		menu_play(call, "hangup_aufile", "none", 0, DEVICE_PLAYER);
+	}
 }
 
 

--- a/src/config.c
+++ b/src/config.c
@@ -1306,6 +1306,7 @@ int config_write_template(const char *file, const struct config *cfg)
 			"#sip_autoanswer_method\trfc5373 "
 			"# {rfc5373,call-info,alert-info}\n"
 			"#ring_aufile\t\tring.wav\n"
+			"#hangup_aufile\t\tnone\n"
 			"#callwaiting_aufile\tcallwaiting.wav\n"
 			"#ringback_aufile\tringback.wav\n"
 			"#notfound_aufile\tnotfound.wav\n"


### PR DESCRIPTION
Gives the user the option to play an audio file when the call closes. This is a common way in many phones to provide the user an additional audio feedback when a call is terminated.

The new config option is called 'hangup_aufile' and is set to 'none' per default. Meaning there is no playback on hangup unless the user specifies a file.