### PR TITLE
enum ua event rename

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1704,7 +1704,7 @@ int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
 			const char *fmt, ...);
 void module_event(const char *module, const char *event, struct ua *ua,
 		struct call *call, const char *fmt, ...);
-const char  *uag_event_str(enum bevent_id ev);
+const char  *bevent_id_str(enum bevent_id ev);
 struct call    *bevent_get_call(const struct bevent *event);
 struct ua      *bevent_get_ua(const struct bevent *event);
 const struct sip_msg *bevent_get_msg(const struct bevent *event);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1709,7 +1709,7 @@ struct call    *bevent_get_call(const struct bevent *event);
 struct ua      *bevent_get_ua(const struct bevent *event);
 const struct sip_msg *bevent_get_msg(const struct bevent *event);
 void *bevent_get_apparg(const struct bevent *event);
-enum bevent_id bevent_get_type(const struct bevent *event);
+enum bevent_id bevent_get_id(const struct bevent *event);
 const char *bevent_get_text(const struct bevent *event);
 void bevent_set_error(struct bevent *event, int err);
 void bevent_stop(struct bevent *event);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -858,8 +858,8 @@ void play_set_path(struct player *player, const char *path);
 
 struct ua;
 
-/** Baresip event identifiers */
-enum bevent_id {
+/** Baresip event value */
+enum bevent_ev {
 	BEVENT_REGISTERING = 0,
 	BEVENT_REGISTER_OK,
 	BEVENT_REGISTER_FAIL,
@@ -915,7 +915,7 @@ enum answer_method {
 };
 
 /** Defines the Baresip event handler */
-typedef void (bevent_h)(enum bevent_id ev, struct bevent *event, void *arg);
+typedef void (bevent_h)(enum bevent_ev ev, struct bevent *event, void *arg);
 typedef void (options_resp_h)(int err, const struct sip_msg *msg, void *arg);
 typedef void (refer_resp_h)(int err, const struct sip_msg *msg, void *arg);
 
@@ -1696,20 +1696,20 @@ int odict_encode_bevent(struct odict *od, struct bevent *event);
 int event_add_au_jb_stat(struct odict *od_parent, const struct call *call);
 int  bevent_register(bevent_h *eh, void *arg);
 void bevent_unregister(bevent_h *eh);
-int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...);
-int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...);
-int bevent_call_emit(enum bevent_id ev, struct call *call,
+int bevent_app_emit(enum bevent_ev ev, void *arg, const char *fmt, ...);
+int bevent_ua_emit(enum bevent_ev ev, struct ua *ua, const char *fmt, ...);
+int bevent_call_emit(enum bevent_ev ev, struct call *call,
 		     const char *fmt, ...);
-int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
+int bevent_sip_msg_emit(enum bevent_ev ev, const struct sip_msg *msg,
 			const char *fmt, ...);
 void module_event(const char *module, const char *event, struct ua *ua,
 		struct call *call, const char *fmt, ...);
-const char  *bevent_id_str(enum bevent_id ev);
+const char  *bevent_str(enum bevent_ev ev);
 struct call    *bevent_get_call(const struct bevent *event);
 struct ua      *bevent_get_ua(const struct bevent *event);
 const struct sip_msg *bevent_get_msg(const struct bevent *event);
 void *bevent_get_apparg(const struct bevent *event);
-enum bevent_id bevent_get_id(const struct bevent *event);
+enum bevent_ev bevent_get_value(const struct bevent *event);
 const char *bevent_get_text(const struct bevent *event);
 void bevent_set_error(struct bevent *event, int err);
 void bevent_stop(struct bevent *event);

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -858,49 +858,96 @@ void play_set_path(struct player *player, const char *path);
 
 struct ua;
 
-/** Events from User-Agent */
-enum ua_event {
-	UA_EVENT_REGISTERING = 0,
-	UA_EVENT_REGISTER_OK,
-	UA_EVENT_REGISTER_FAIL,
-	UA_EVENT_UNREGISTERING,
-	UA_EVENT_FALLBACK_OK,
-	UA_EVENT_FALLBACK_FAIL,
-	UA_EVENT_MWI_NOTIFY,
-	UA_EVENT_CREATE,
-	UA_EVENT_SHUTDOWN,
-	UA_EVENT_EXIT,
+/** Baresip event identifiers */
+enum bevent_id {
+	BEVENT_REGISTERING = 0,
+	BEVENT_REGISTER_OK,
+	BEVENT_REGISTER_FAIL,
+	BEVENT_UNREGISTERING,
+	BEVENT_FALLBACK_OK,
+	BEVENT_FALLBACK_FAIL,
+	BEVENT_MWI_NOTIFY,
+	BEVENT_CREATE,
+	BEVENT_SHUTDOWN,
+	BEVENT_EXIT,
 
-	UA_EVENT_CALL_INCOMING,
-	UA_EVENT_CALL_OUTGOING,
-	UA_EVENT_CALL_RINGING,
-	UA_EVENT_CALL_PROGRESS,
-	UA_EVENT_CALL_ANSWERED,
-	UA_EVENT_CALL_ESTABLISHED,
-	UA_EVENT_CALL_CLOSED,
-	UA_EVENT_CALL_TRANSFER,
-	UA_EVENT_CALL_REDIRECT,
-	UA_EVENT_CALL_TRANSFER_FAILED,
-	UA_EVENT_CALL_DTMF_START,
-	UA_EVENT_CALL_DTMF_END,
-	UA_EVENT_CALL_RTPESTAB,
-	UA_EVENT_CALL_RTCP,
-	UA_EVENT_CALL_MENC,
-	UA_EVENT_VU_TX,
-	UA_EVENT_VU_RX,
-	UA_EVENT_AUDIO_ERROR,
-	UA_EVENT_CALL_LOCAL_SDP,      /**< param: offer or answer */
-	UA_EVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
-	UA_EVENT_CALL_HOLD,           /**< Call put on-hold by peer          */
-	UA_EVENT_CALL_RESUME,         /**< Call resumed by peer              */
-	UA_EVENT_REFER,
-	UA_EVENT_MODULE,
-	UA_EVENT_END_OF_FILE,
-	UA_EVENT_CUSTOM,
-	UA_EVENT_SIPSESS_CONN,
+	BEVENT_CALL_INCOMING,
+	BEVENT_CALL_OUTGOING,
+	BEVENT_CALL_RINGING,
+	BEVENT_CALL_PROGRESS,
+	BEVENT_CALL_ANSWERED,
+	BEVENT_CALL_ESTABLISHED,
+	BEVENT_CALL_CLOSED,
+	BEVENT_CALL_TRANSFER,
+	BEVENT_CALL_REDIRECT,
+	BEVENT_CALL_TRANSFER_FAILED,
+	BEVENT_CALL_DTMF_START,
+	BEVENT_CALL_DTMF_END,
+	BEVENT_CALL_RTPESTAB,
+	BEVENT_CALL_RTCP,
+	BEVENT_CALL_MENC,
+	BEVENT_VU_TX,
+	BEVENT_VU_RX,
+	BEVENT_AUDIO_ERROR,
+	BEVENT_CALL_LOCAL_SDP,      /**< param: offer or answer */
+	BEVENT_CALL_REMOTE_SDP,     /**< param: offer or answer */
+	BEVENT_CALL_HOLD,           /**< Call put on-hold by peer          */
+	BEVENT_CALL_RESUME,         /**< Call resumed by peer              */
+	BEVENT_REFER,
+	BEVENT_MODULE,
+	BEVENT_END_OF_FILE,
+	BEVENT_CUSTOM,
+	BEVENT_SIPSESS_CONN,
 
-	UA_EVENT_MAX,
+	BEVENT_MAX,
 };
+
+/** Backward compatibility to UA events */
+enum ua_event {
+	UA_EVENT_OLD1 = 0,
+};
+
+
+#define UA_EVENT_REGISTERING     BEVENT_REGISTERING
+#define UA_EVENT_REGISTER_OK     BEVENT_REGISTER_OK
+#define UA_EVENT_REGISTER_FAIL   BEVENT_REGISTER_FAIL
+#define UA_EVENT_UNREGISTERING   BEVENT_UNREGISTERING
+#define UA_EVENT_FALLBACK_OK     BEVENT_FALLBACK_OK
+#define UA_EVENT_FALLBACK_FAIL   BEVENT_FALLBACK_FAIL
+#define UA_EVENT_MWI_NOTIFY      BEVENT_MWI_NOTIFY
+#define UA_EVENT_CREATE          BEVENT_CREATE
+#define UA_EVENT_SHUTDOWN        BEVENT_SHUTDOWN
+#define UA_EVENT_EXIT            BEVENT_EXIT
+
+#define UA_EVENT_CALL_INCOMING   BEVENT_CALL_INCOMING
+#define UA_EVENT_CALL_OUTGOING   BEVENT_CALL_OUTGOING
+#define UA_EVENT_CALL_RINGING    BEVENT_CALL_RINGING
+#define UA_EVENT_CALL_PROGRESS   BEVENT_CALL_PROGRESS
+#define UA_EVENT_CALL_ANSWERED   BEVENT_CALL_ANSWERED
+#define UA_EVENT_CALL_ESTABLISHED BEVENT_CALL_ESTABLISHED
+#define UA_EVENT_CALL_CLOSED     BEVENT_CALL_CLOSED
+#define UA_EVENT_CALL_TRANSFER   BEVENT_CALL_TRANSFER
+#define UA_EVENT_CALL_REDIRECT   BEVENT_CALL_REDIRECT
+#define UA_EVENT_CALL_TRANSFER_FAILED BEVENT_CALL_TRANSFER_FAILED
+#define UA_EVENT_CALL_DTMF_START BEVENT_CALL_DTMF_START
+#define UA_EVENT_CALL_DTMF_END   BEVENT_CALL_DTMF_END
+#define UA_EVENT_CALL_RTPESTAB   BEVENT_CALL_RTPESTAB
+#define UA_EVENT_CALL_RTCP       BEVENT_CALL_RTCP
+#define UA_EVENT_CALL_MENC       BEVENT_CALL_MENC
+#define UA_EVENT_VU_TX           BEVENT_VU_TX
+#define UA_EVENT_VU_RX           BEVENT_VU_RX
+#define UA_EVENT_AUDIO_ERROR     BEVENT_AUDIO_ERROR
+#define UA_EVENT_CALL_LOCAL_SDP  BEVENT_CALL_LOCAL_SDP
+#define UA_EVENT_CALL_REMOTE_SDP BEVENT_CALL_REMOTE_SDP
+#define UA_EVENT_CALL_HOLD       BEVENT_CALL_HOLD
+#define UA_EVENT_CALL_RESUME     BEVENT_CALL_RESUME
+#define UA_EVENT_REFER           BEVENT_REFER
+#define UA_EVENT_MODULE          BEVENT_MODULE
+#define UA_EVENT_END_OF_FILE     BEVENT_END_OF_FILE
+#define UA_EVENT_CUSTOM          BEVENT_CUSTOM
+#define UA_EVENT_SIPSESS_CONN    BEVENT_SIPSESS_CONN
+
+#define UA_EVENT_MAX             BEVENT_MAX
 
 
 struct bevent;
@@ -914,10 +961,9 @@ enum answer_method {
 	ANSM_ALERTINFO,
 };
 
-/** Defines the User-Agent event handler */
-typedef void (ua_event_h)(struct ua *ua, enum ua_event ev,
-			  struct call *call, const char *prm, void *arg);
-typedef void (bevent_h)(enum ua_event ev, struct bevent *event, void *arg);
+/** Defines the Baresip event handler */
+typedef void (bevent_h)(enum bevent_id ev, struct bevent *event, void *arg);
+typedef void (old_bevent_h)(enum ua_event ev, struct bevent *event, void *arg);
 typedef void (options_resp_h)(int err, const struct sip_msg *msg, void *arg);
 typedef void (refer_resp_h)(int err, const struct sip_msg *msg, void *arg);
 
@@ -1696,27 +1742,49 @@ void module_app_unload(void);
 
 int odict_encode_bevent(struct odict *od, struct bevent *event);
 int event_add_au_jb_stat(struct odict *od_parent, const struct call *call);
-int  bevent_register(bevent_h *eh, void *arg);
-void bevent_unregister(bevent_h *eh);
-int bevent_app_emit(enum ua_event ev, void *arg, const char *fmt, ...);
-int bevent_ua_emit(enum ua_event ev, struct ua *ua, const char *fmt, ...);
-int bevent_call_emit(enum ua_event ev, struct call *call,
+int  bevent_register_new(bevent_h *eh, void *arg);
+int  bevent_register_old(old_bevent_h *eh, void *arg)
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((deprecated("Use enum bevent_id instead of enum ua_event")));
+#else
+;
+#endif
+void bevent_unregister_new(bevent_h *eh);
+void bevent_unregister_old(old_bevent_h *eh);
+int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...);
+int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...);
+int bevent_call_emit(enum bevent_id ev, struct call *call,
 		     const char *fmt, ...);
-int bevent_sip_msg_emit(enum ua_event ev, const struct sip_msg *msg,
+int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
 			const char *fmt, ...);
 void module_event(const char *module, const char *event, struct ua *ua,
 		struct call *call, const char *fmt, ...);
-const char  *uag_event_str(enum ua_event ev);
+const char  *uag_event_str(enum bevent_id ev);
 struct call    *bevent_get_call(const struct bevent *event);
 struct ua      *bevent_get_ua(const struct bevent *event);
 const struct sip_msg *bevent_get_msg(const struct bevent *event);
 void *bevent_get_apparg(const struct bevent *event);
-enum ua_event bevent_get_type(const struct bevent *event);
+enum bevent_id bevent_get_type(const struct bevent *event);
 const char *bevent_get_text(const struct bevent *event);
 void bevent_set_error(struct bevent *event, int err);
 void bevent_stop(struct bevent *event);
 
+#if __STDC_VERSION__ >= 201112L
+#define bevent_register(handler, arg) \
+	_Generic((handler), \
+		 bevent_h *: bevent_register_new, \
+		 old_bevent_h *: bevent_register_old \
+		 )(handler, arg)
 
+#define bevent_unregister(handler) \
+	_Generic((handler), \
+		 bevent_h *: bevent_unregister_new, \
+		 old_bevent_h *: bevent_unregister_old \
+		 )(handler)
+#else
+#error "C11 or later is required for _Generic support."
+// Pre-C11: must cast manually in old code
+#endif
 /*
  * Baresip instance
  */

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -902,53 +902,6 @@ enum bevent_id {
 	BEVENT_MAX,
 };
 
-/** Backward compatibility to UA events */
-enum ua_event {
-	UA_EVENT_OLD1 = 0,
-};
-
-
-#define UA_EVENT_REGISTERING     BEVENT_REGISTERING
-#define UA_EVENT_REGISTER_OK     BEVENT_REGISTER_OK
-#define UA_EVENT_REGISTER_FAIL   BEVENT_REGISTER_FAIL
-#define UA_EVENT_UNREGISTERING   BEVENT_UNREGISTERING
-#define UA_EVENT_FALLBACK_OK     BEVENT_FALLBACK_OK
-#define UA_EVENT_FALLBACK_FAIL   BEVENT_FALLBACK_FAIL
-#define UA_EVENT_MWI_NOTIFY      BEVENT_MWI_NOTIFY
-#define UA_EVENT_CREATE          BEVENT_CREATE
-#define UA_EVENT_SHUTDOWN        BEVENT_SHUTDOWN
-#define UA_EVENT_EXIT            BEVENT_EXIT
-
-#define UA_EVENT_CALL_INCOMING   BEVENT_CALL_INCOMING
-#define UA_EVENT_CALL_OUTGOING   BEVENT_CALL_OUTGOING
-#define UA_EVENT_CALL_RINGING    BEVENT_CALL_RINGING
-#define UA_EVENT_CALL_PROGRESS   BEVENT_CALL_PROGRESS
-#define UA_EVENT_CALL_ANSWERED   BEVENT_CALL_ANSWERED
-#define UA_EVENT_CALL_ESTABLISHED BEVENT_CALL_ESTABLISHED
-#define UA_EVENT_CALL_CLOSED     BEVENT_CALL_CLOSED
-#define UA_EVENT_CALL_TRANSFER   BEVENT_CALL_TRANSFER
-#define UA_EVENT_CALL_REDIRECT   BEVENT_CALL_REDIRECT
-#define UA_EVENT_CALL_TRANSFER_FAILED BEVENT_CALL_TRANSFER_FAILED
-#define UA_EVENT_CALL_DTMF_START BEVENT_CALL_DTMF_START
-#define UA_EVENT_CALL_DTMF_END   BEVENT_CALL_DTMF_END
-#define UA_EVENT_CALL_RTPESTAB   BEVENT_CALL_RTPESTAB
-#define UA_EVENT_CALL_RTCP       BEVENT_CALL_RTCP
-#define UA_EVENT_CALL_MENC       BEVENT_CALL_MENC
-#define UA_EVENT_VU_TX           BEVENT_VU_TX
-#define UA_EVENT_VU_RX           BEVENT_VU_RX
-#define UA_EVENT_AUDIO_ERROR     BEVENT_AUDIO_ERROR
-#define UA_EVENT_CALL_LOCAL_SDP  BEVENT_CALL_LOCAL_SDP
-#define UA_EVENT_CALL_REMOTE_SDP BEVENT_CALL_REMOTE_SDP
-#define UA_EVENT_CALL_HOLD       BEVENT_CALL_HOLD
-#define UA_EVENT_CALL_RESUME     BEVENT_CALL_RESUME
-#define UA_EVENT_REFER           BEVENT_REFER
-#define UA_EVENT_MODULE          BEVENT_MODULE
-#define UA_EVENT_END_OF_FILE     BEVENT_END_OF_FILE
-#define UA_EVENT_CUSTOM          BEVENT_CUSTOM
-#define UA_EVENT_SIPSESS_CONN    BEVENT_SIPSESS_CONN
-
-#define UA_EVENT_MAX             BEVENT_MAX
-
 
 struct bevent;
 
@@ -963,7 +916,6 @@ enum answer_method {
 
 /** Defines the Baresip event handler */
 typedef void (bevent_h)(enum bevent_id ev, struct bevent *event, void *arg);
-typedef void (old_bevent_h)(enum ua_event ev, struct bevent *event, void *arg);
 typedef void (options_resp_h)(int err, const struct sip_msg *msg, void *arg);
 typedef void (refer_resp_h)(int err, const struct sip_msg *msg, void *arg);
 
@@ -1742,15 +1694,8 @@ void module_app_unload(void);
 
 int odict_encode_bevent(struct odict *od, struct bevent *event);
 int event_add_au_jb_stat(struct odict *od_parent, const struct call *call);
-int  bevent_register_new(bevent_h *eh, void *arg);
-int  bevent_register_old(old_bevent_h *eh, void *arg)
-#if defined(__GNUC__) || defined(__clang__)
-__attribute__((deprecated("Use enum bevent_id instead of enum ua_event")));
-#else
-;
-#endif
-void bevent_unregister_new(bevent_h *eh);
-void bevent_unregister_old(old_bevent_h *eh);
+int  bevent_register(bevent_h *eh, void *arg);
+void bevent_unregister(bevent_h *eh);
 int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...);
 int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...);
 int bevent_call_emit(enum bevent_id ev, struct call *call,
@@ -1769,22 +1714,6 @@ const char *bevent_get_text(const struct bevent *event);
 void bevent_set_error(struct bevent *event, int err);
 void bevent_stop(struct bevent *event);
 
-#if __STDC_VERSION__ >= 201112L
-#define bevent_register(handler, arg) \
-	_Generic((handler), \
-		 bevent_h *: bevent_register_new, \
-		 old_bevent_h *: bevent_register_old \
-		 )(handler, arg)
-
-#define bevent_unregister(handler) \
-	_Generic((handler), \
-		 bevent_h *: bevent_unregister_new, \
-		 old_bevent_h *: bevent_unregister_old \
-		 )(handler)
-#else
-#error "C11 or later is required for _Generic support."
-// Pre-C11: must cast manually in old code
-#endif
 /*
  * Baresip instance
  */

--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -239,7 +239,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 	struct odict *od = NULL;
 	int err = 0;
 	const char *class;
-	const char *etype = uag_event_str(ev);
+	const char *etype = bevent_id_str(ev);
 
 	if (!st->interface)
 		return;

--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -231,7 +231,7 @@ on_handle_invoke(DBusBaresip *interface,
 /*
  * Relay UA events
  */
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct ctrl_st *st = arg;
 	struct mbuf *buf;

--- a/modules/ctrl_dbus/ctrl_dbus.c
+++ b/modules/ctrl_dbus/ctrl_dbus.c
@@ -231,7 +231,7 @@ on_handle_invoke(DBusBaresip *interface,
 /*
  * Relay UA events
  */
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ctrl_st *st = arg;
 	struct mbuf *buf;
@@ -239,7 +239,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 	struct odict *od = NULL;
 	int err = 0;
 	const char *class;
-	const char *etype = bevent_id_str(ev);
+	const char *etype = bevent_str(ev);
 
 	if (!st->interface)
 		return;

--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -252,7 +252,7 @@ static void tcp_conn_handler(const struct sa *peer, void *arg)
 /*
  * Relay UA events
  */
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ctrl_st *st = arg;
 	struct mbuf *buf = mbuf_alloc(1024);

--- a/modules/ctrl_tcp/ctrl_tcp.c
+++ b/modules/ctrl_tcp/ctrl_tcp.c
@@ -252,7 +252,7 @@ static void tcp_conn_handler(const struct sa *peer, void *arg)
 /*
  * Relay UA events
  */
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct ctrl_st *st = arg;
 	struct mbuf *buf = mbuf_alloc(1024);

--- a/modules/echo/echo.c
+++ b/modules/echo/echo.c
@@ -92,7 +92,7 @@ static int new_session(struct ua *ua, struct call *call)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	int err;
 	struct ua   *ua   = bevent_get_ua(event);

--- a/modules/echo/echo.c
+++ b/modules/echo/echo.c
@@ -92,7 +92,7 @@ static int new_session(struct ua *ua, struct call *call)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	int err;
 	struct ua   *ua   = bevent_get_ua(event);
@@ -101,7 +101,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 	switch (ev) {
 
-	case UA_EVENT_CALL_INCOMING:
+	case BEVENT_CALL_INCOMING:
 		info("echo: CALL_INCOMING: peer=%s  -->  local=%s\n",
 				call_peeruri(call),
 				call_localuri(call));

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -390,7 +390,7 @@ static void update_ua_presence(struct gtk_mod *mod)
 }
 
 
-static const char *ua_event_reg_str(enum bevent_id ev)
+static const char *ua_event_reg_str(enum bevent_ev ev)
 {
 	switch (ev) {
 
@@ -404,7 +404,7 @@ static const char *ua_event_reg_str(enum bevent_id ev)
 
 
 static void accounts_menu_set_status(struct gtk_mod *mod,
-					struct ua *ua, enum bevent_id ev)
+					struct ua *ua, enum bevent_ev ev)
 {
 	GtkMenuItem *item = accounts_menu_get_item(mod, ua);
 	char buf[256];
@@ -614,7 +614,7 @@ void gtk_mod_call_window_closed(struct gtk_mod *mod, struct call_window *win)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct gtk_mod *mod = arg;
 	struct call_window *win;

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -390,21 +390,21 @@ static void update_ua_presence(struct gtk_mod *mod)
 }
 
 
-static const char *ua_event_reg_str(enum ua_event ev)
+static const char *ua_event_reg_str(enum bevent_id ev)
 {
 	switch (ev) {
 
-	case UA_EVENT_REGISTERING:      return "registering";
-	case UA_EVENT_REGISTER_OK:      return "OK";
-	case UA_EVENT_REGISTER_FAIL:    return "ERR";
-	case UA_EVENT_UNREGISTERING:    return "unregistering";
+	case BEVENT_REGISTERING:      return "registering";
+	case BEVENT_REGISTER_OK:      return "OK";
+	case BEVENT_REGISTER_FAIL:    return "ERR";
+	case BEVENT_UNREGISTERING:    return "unregistering";
 	default: return "?";
 	}
 }
 
 
 static void accounts_menu_set_status(struct gtk_mod *mod,
-					struct ua *ua, enum ua_event ev)
+					struct ua *ua, enum bevent_id ev)
 {
 	GtkMenuItem *item = accounts_menu_get_item(mod, ua);
 	char buf[256];
@@ -614,7 +614,7 @@ void gtk_mod_call_window_closed(struct gtk_mod *mod, struct call_window *win)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct gtk_mod *mod = arg;
 	struct call_window *win;
@@ -626,20 +626,20 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 	switch (ev) {
 
-	case UA_EVENT_REGISTERING:
-	case UA_EVENT_UNREGISTERING:
-	case UA_EVENT_REGISTER_OK:
-	case UA_EVENT_REGISTER_FAIL:
+	case BEVENT_REGISTERING:
+	case BEVENT_UNREGISTERING:
+	case BEVENT_REGISTER_OK:
+	case BEVENT_REGISTER_FAIL:
 		accounts_menu_set_status(mod, ua, ev);
 		break;
 
 #ifdef USE_NOTIFICATIONS
-	case UA_EVENT_CALL_INCOMING:
+	case BEVENT_CALL_INCOMING:
 		notify_incoming_call(mod, call);
 		break;
 #endif
 
-	case UA_EVENT_CALL_CLOSED:
+	case BEVENT_CALL_CLOSED:
 		win = get_call_window(mod, call);
 		if (win)
 			call_window_closed(win, txt);
@@ -667,26 +667,26 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 		}
 		break;
 
-	case UA_EVENT_CALL_RINGING:
+	case BEVENT_CALL_RINGING:
 		win = get_create_call_window(mod, call);
 		if (win)
 			call_window_ringing(win);
 		break;
 
-	case UA_EVENT_CALL_PROGRESS:
+	case BEVENT_CALL_PROGRESS:
 		win = get_create_call_window(mod, call);
 		if (win)
 			call_window_progress(win);
 		break;
 
-	case UA_EVENT_CALL_ESTABLISHED:
+	case BEVENT_CALL_ESTABLISHED:
 		win = get_create_call_window(mod, call);
 		if (win)
 			call_window_established(win);
 		denotify_incoming_call(mod, call);
 		break;
 
-	case UA_EVENT_CALL_TRANSFER_FAILED:
+	case BEVENT_CALL_TRANSFER_FAILED:
 		win = get_create_call_window(mod, call);
 		if (win)
 			call_window_transfer_failed(win, txt);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -708,7 +708,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 
 #if 0
 	debug("menu: [ ua=%s call=%s ] event: %s (%s)\n",
-	      account_aor(acc), call_id(call), uag_event_str(ev), prm);
+	      account_aor(acc), call_id(call), bevent_id_str(ev), prm);
 #endif
 
 

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -689,7 +689,7 @@ static void apply_contact_mediadir(struct call *call)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct call *call2 = NULL;
 	int32_t adelay = -1;
@@ -708,7 +708,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 
 #if 0
 	debug("menu: [ ua=%s call=%s ] event: %s (%s)\n",
-	      account_aor(acc), call_id(call), bevent_id_str(ev), prm);
+	      account_aor(acc), call_id(call), bevent_str(ev), prm);
 #endif
 
 

--- a/modules/mqtt/publish.c
+++ b/modules/mqtt/publish.c
@@ -19,7 +19,7 @@
 /*
  * Relay UA events as publish messages to the Broker
  */
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct mqtt *mqtt = arg;
 	struct odict *od = NULL;

--- a/modules/mqtt/publish.c
+++ b/modules/mqtt/publish.c
@@ -19,7 +19,7 @@
 /*
  * Relay UA events as publish messages to the Broker
  */
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct mqtt *mqtt = arg;
 	struct odict *od = NULL;
@@ -35,7 +35,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 		goto out;
 
 	/* send audio jitter buffer values together with VU rx values. */
-	if (ev == UA_EVENT_VU_RX) {
+	if (ev == BEVENT_VU_RX) {
 		err = event_add_au_jb_stat(od,call);
 		if (err) {
 			info("Could not add audio jb value.\n");

--- a/modules/mwi/mwi.c
+++ b/modules/mwi/mwi.c
@@ -141,7 +141,7 @@ static struct mwi *mwi_find(const struct ua *ua)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	const struct account *acc = ua_account(ua);

--- a/modules/mwi/mwi.c
+++ b/modules/mwi/mwi.c
@@ -60,7 +60,7 @@ static void notify_handler(struct sip *sip, const struct sip_msg *msg,
 	struct mwi *mwi = arg;
 
 	if (mbuf_get_left(msg->mb)) {
-		bevent_ua_emit(UA_EVENT_MWI_NOTIFY, mwi->ua, "%b",
+		bevent_ua_emit(BEVENT_MWI_NOTIFY, mwi->ua, "%b",
 			  mbuf_buf(msg->mb), mbuf_get_left(msg->mb));
 	}
 
@@ -141,19 +141,19 @@ static struct mwi *mwi_find(const struct ua *ua)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	const struct account *acc = ua_account(ua);
 	(void)arg;
 
-	if (ev == UA_EVENT_REGISTER_OK) {
+	if (ev == BEVENT_REGISTER_OK) {
 
 		if (!mwi_find(ua) && account_mwi(acc))
 			mwi_subscribe(ua);
 	}
-	else if (ev == UA_EVENT_SHUTDOWN ||
-		 (ev == UA_EVENT_UNREGISTERING &&
+	else if (ev == BEVENT_SHUTDOWN ||
+		 (ev == BEVENT_UNREGISTERING &&
 		  str_cmp(account_sipnat(acc), "outbound") == 0)) {
 
 		struct mwi *mwi = mwi_find(ua);

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -56,11 +56,11 @@ static const struct cmd cmdv[] = {
 };
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	(void)arg;
 
-	if (ev == UA_EVENT_SHUTDOWN) {
+	if (ev == BEVENT_SHUTDOWN) {
 		struct ua *ua = bevent_get_ua(event);
 		debug("presence: ua=%p got event %d (%s)\n", ua, ev,
 		      uag_event_str(ev));

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -56,14 +56,14 @@ static const struct cmd cmdv[] = {
 };
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	(void)arg;
 
 	if (ev == BEVENT_SHUTDOWN) {
 		struct ua *ua = bevent_get_ua(event);
 		debug("presence: ua=%p got event %d (%s)\n", ua, ev,
-		      bevent_id_str(ev));
+		      bevent_str(ev));
 
 		publisher_close();
 		notifier_close();

--- a/modules/presence/presence.c
+++ b/modules/presence/presence.c
@@ -63,7 +63,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 	if (ev == BEVENT_SHUTDOWN) {
 		struct ua *ua = bevent_get_ua(event);
 		debug("presence: ua=%p got event %d (%s)\n", ua, ev,
-		      uag_event_str(ev));
+		      bevent_id_str(ev));
 
 		publisher_close();
 		notifier_close();

--- a/modules/presence/publisher.c
+++ b/modules/presence/publisher.c
@@ -233,7 +233,7 @@ static int publisher_alloc(struct ua *ua)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	(void)arg;
@@ -241,7 +241,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	if (account_pubint(ua_account(ua)) == 0)
 		return;
 
-	if (ev == UA_EVENT_REGISTER_OK) {
+	if (ev == BEVENT_REGISTER_OK) {
 		if (ua_presence_status(ua) == PRESENCE_UNKNOWN) {
 			ua_presence_status_set(ua, PRESENCE_OPEN);
 			publisher_update_status(ua);

--- a/modules/presence/publisher.c
+++ b/modules/presence/publisher.c
@@ -233,7 +233,7 @@ static int publisher_alloc(struct ua *ua)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	(void)arg;

--- a/modules/rtcpsummary/rtcpsummary.c
+++ b/modules/rtcpsummary/rtcpsummary.c
@@ -59,7 +59,7 @@ static void print_rtcp_summary_line(const struct call *call,
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	const struct stream *s;
 	struct le *le;
@@ -68,7 +68,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 	switch (ev) {
 
-	case UA_EVENT_CALL_CLOSED:
+	case BEVENT_CALL_CLOSED:
 		for (le = call_streaml(call)->head;
 		     le;
 		     le = le->next) {

--- a/modules/rtcpsummary/rtcpsummary.c
+++ b/modules/rtcpsummary/rtcpsummary.c
@@ -59,7 +59,7 @@ static void print_rtcp_summary_line(const struct call *call,
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	const struct stream *s;
 	struct le *le;

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -311,29 +311,29 @@ static uint32_t min_regint(void)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	(void)arg;
 
 	switch (ev) {
 
-	case UA_EVENT_FALLBACK_FAIL:
+	case BEVENT_FALLBACK_FAIL:
 		debug("serreg: fallback fail %s.\n",
 		      account_aor(ua_account(ua)));
 		break;
 
-	case UA_EVENT_FALLBACK_OK:
+	case BEVENT_FALLBACK_OK:
 		fallback_ok(ua);
 		break;
 
-	case UA_EVENT_REGISTER_OK:
+	case BEVENT_REGISTER_OK:
 		sreg.prio = account_prio(ua_account(ua));
 		check_registrations();
 		sreg.sprio = sreg.prio;
 		break;
 
-	case UA_EVENT_REGISTER_FAIL:
+	case BEVENT_REGISTER_FAIL:
 		next_account(ua);
 		if (account_fbregint(ua_account(ua)))
 			(void)ua_fallback(ua);

--- a/modules/serreg/serreg.c
+++ b/modules/serreg/serreg.c
@@ -311,7 +311,7 @@ static uint32_t min_regint(void)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct ua *ua = bevent_get_ua(event);
 	(void)arg;

--- a/modules/vumeter/vumeter.c
+++ b/modules/vumeter/vumeter.c
@@ -41,7 +41,7 @@ struct vumeter_dec {
 static bool vumeter_stderr;
 
 
-static void send_event(const struct audio *au, enum bevent_id ev, double value)
+static void send_event(const struct audio *au, enum bevent_ev ev, double value)
 {
 	audio_level_put(au, ev == BEVENT_VU_TX, value);
 }

--- a/modules/vumeter/vumeter.c
+++ b/modules/vumeter/vumeter.c
@@ -41,9 +41,9 @@ struct vumeter_dec {
 static bool vumeter_stderr;
 
 
-static void send_event(const struct audio *au, enum ua_event ev, double value)
+static void send_event(const struct audio *au, enum bevent_id ev, double value)
 {
-	audio_level_put(au, ev == UA_EVENT_VU_TX, value);
+	audio_level_put(au, ev == BEVENT_VU_TX, value);
 }
 
 
@@ -104,7 +104,7 @@ static void enc_tmr_handler(void *arg)
 		if (vumeter_stderr)
 			print_vumeter(60, 31, st->avg_rec);
 
-		send_event(st->au, UA_EVENT_VU_TX, st->avg_rec);
+		send_event(st->au, BEVENT_VU_TX, st->avg_rec);
 	}
 }
 
@@ -119,7 +119,7 @@ static void dec_tmr_handler(void *arg)
 		if (vumeter_stderr)
 			print_vumeter(80, 32, st->avg_play);
 
-		send_event(st->au, UA_EVENT_VU_RX, st->avg_play);
+		send_event(st->au, BEVENT_VU_RX, st->avg_play);
 	}
 }
 

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -179,7 +179,7 @@ void *bevent_get_apparg(const struct bevent *event)
  *
  * @return the event type
  */
-enum bevent_id bevent_get_type(const struct bevent *event)
+enum bevent_id bevent_get_id(const struct bevent *event)
 {
 	return event ? event->ev : BEVENT_MAX;
 }
@@ -382,7 +382,7 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 		mem_deref(buf);
 	}
 
-	enum bevent_id ev = bevent_get_type(event);
+	enum bevent_id ev = bevent_get_id(event);
 	err |= odict_entry_add(od, "type", ODICT_STRING, bevent_id_str(ev));
 	if (ua) {
 		err |= odict_entry_add(od, "accountaor",

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -383,7 +383,7 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 	}
 
 	enum bevent_id ev = bevent_get_type(event);
-	err |= odict_entry_add(od, "type", ODICT_STRING, uag_event_str(ev));
+	err |= odict_entry_add(od, "type", ODICT_STRING, bevent_id_str(ev));
 	if (ua) {
 		err |= odict_entry_add(od, "accountaor",
 				       ODICT_STRING,
@@ -720,7 +720,7 @@ int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
  *
  * @return Name of the event
  */
-const char *uag_event_str(enum bevent_id ev)
+const char *bevent_id_str(enum bevent_id ev)
 {
 	switch (ev) {
 

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -25,7 +25,7 @@ enum bevent_class {
 
 
 struct bevent {
-	enum bevent_id ev;
+	enum bevent_ev ev;
 	const char *txt;
 	int err;
 	bool stop;
@@ -173,13 +173,13 @@ void *bevent_get_apparg(const struct bevent *event)
 
 
 /**
- * Returns the event type
+ * Returns the Baresip event value
  *
  * @param event Baresip event
  *
- * @return the event type
+ * @return the event value
  */
-enum bevent_id bevent_get_id(const struct bevent *event)
+enum bevent_ev bevent_get_value(const struct bevent *event)
 {
 	return event ? event->ev : BEVENT_MAX;
 }
@@ -352,6 +352,9 @@ static int odict_encode_call(struct odict *od, struct call *call)
 
 int odict_encode_bevent(struct odict *od, struct bevent *event)
 {
+	if (!event)
+		return EINVAL;
+
 	struct ua *ua     = bevent_get_ua(event);
 	struct call *call = bevent_get_call(event);
 	const char *prm = bevent_get_text(event);
@@ -382,8 +385,8 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 		mem_deref(buf);
 	}
 
-	enum bevent_id ev = bevent_get_id(event);
-	err |= odict_entry_add(od, "type", ODICT_STRING, bevent_id_str(ev));
+	enum bevent_ev ev = event->ev;
+	err |= odict_entry_add(od, "type", ODICT_STRING, bevent_str(ev));
 	if (ua) {
 		err |= odict_entry_add(od, "accountaor",
 				       ODICT_STRING,
@@ -608,7 +611,7 @@ out:
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...)
+int bevent_app_emit(enum bevent_ev ev, void *arg, const char *fmt, ...)
 {
 	va_list ap;
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_APP};
@@ -625,16 +628,16 @@ int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...)
 
 
 /**
- * Emit a Baresip event identifier
+ * Emit a Baresip event value
  *
- * @param ev   Baresip event identifier
+ * @param ev   Baresip event value
  * @param ua   User-Agent
  * @param fmt  Formatted arguments
  * @param ...  Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...)
+int bevent_ua_emit(enum bevent_ev ev, struct ua *ua, const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_UA};
 	va_list ap;
@@ -656,14 +659,14 @@ int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...)
 /**
  * Emit a Call event
  *
- * @param ev    Baresip event identifier
+ * @param ev    Baresip event value
  * @param call  Call object
  * @param fmt   Formatted arguments
  * @param ...   Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_call_emit(enum bevent_id ev, struct call *call,
+int bevent_call_emit(enum bevent_ev ev, struct call *call,
 		     const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_CALL};
@@ -686,14 +689,14 @@ int bevent_call_emit(enum bevent_id ev, struct call *call,
 /**
  * Emit a SIP message event
  *
- * @param ev    Baresip event identifier
+ * @param ev    Baresip event value
  * @param msg   SIP message
  * @param fmt   Formatted arguments
  * @param ...   Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
+int bevent_sip_msg_emit(enum bevent_ev ev, const struct sip_msg *msg,
 		       const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_SIP};
@@ -714,13 +717,13 @@ int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
 
 
 /**
- * Get the name of the Baresip event identifier
+ * Get the name of the Baresip event value
  *
- * @param ev Baresip event identifier
+ * @param ev Baresip event value
  *
  * @return Name of the event
  */
-const char *bevent_id_str(enum bevent_id ev)
+const char *bevent_str(enum bevent_ev ev)
 {
 	switch (ev) {
 

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -25,7 +25,7 @@ enum bevent_class {
 
 
 struct bevent {
-	enum ua_event ev;
+	enum bevent_id ev;
 	const char *txt;
 	int err;
 	bool stop;
@@ -179,9 +179,9 @@ void *bevent_get_apparg(const struct bevent *event)
  *
  * @return the event type
  */
-enum ua_event bevent_get_type(const struct bevent *event)
+enum bevent_id bevent_get_type(const struct bevent *event)
 {
-	return event ? event->ev : UA_EVENT_MAX;
+	return event ? event->ev : BEVENT_MAX;
 }
 
 
@@ -382,7 +382,7 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 		mem_deref(buf);
 	}
 
-	enum ua_event ev = bevent_get_type(event);
+	enum bevent_id ev = bevent_get_type(event);
 	err |= odict_entry_add(od, "type", ODICT_STRING, uag_event_str(ev));
 	if (ua) {
 		err |= odict_entry_add(od, "accountaor",
@@ -396,7 +396,7 @@ int odict_encode_bevent(struct odict *od, struct bevent *event)
 	if (str_isset(prm))
 		err |= odict_entry_add(od, "param", ODICT_STRING, prm);
 
-	if (ev == UA_EVENT_CALL_RTCP && str_isset(prm)) {
+	if (ev == BEVENT_CALL_RTCP && str_isset(prm)) {
 		struct stream *strm = NULL;
 
 		if (0 == str_casecmp(prm, "audio"))
@@ -436,7 +436,7 @@ int event_add_au_jb_stat(struct odict *od_parent, const struct call *call)
  *
  * @return 0 if success, otherwise errorcode
  */
-int  bevent_register(bevent_h *eh, void *arg)
+int  bevent_register_new(bevent_h *eh, void *arg)
 {
 	struct ehe *ehe;
 
@@ -458,12 +458,23 @@ int  bevent_register(bevent_h *eh, void *arg)
 }
 
 
+int  bevent_register_old(old_bevent_h *eh, void *arg)
+{
+	bevent_h *h = (bevent_h *)eh;
+
+	if (!h)
+		return EINVAL;
+
+	return bevent_register_new(h, arg);
+}
+
+
 /**
  * Unregister an Event handler
  *
  * @param eh  Event handler
  */
-void bevent_unregister(bevent_h *eh)
+void bevent_unregister_new(bevent_h *eh)
 {
 	struct le *le;
 
@@ -479,8 +490,18 @@ void bevent_unregister(bevent_h *eh)
 }
 
 
+void bevent_unregister_old(old_bevent_h *eh)
+{
+	bevent_h *h = (bevent_h *)eh;
+
+	if (!h)
+		return;
+
+	bevent_unregister_new(h);
+}
+
 /**
- * Send a UA_EVENT_MODULE event with a general format for modules
+ * Send a BEVENT_MODULE event with a general format for modules
  *
  * @param module Module name
  * @param event  Event name
@@ -514,7 +535,7 @@ void module_event(const char *module, const char *event, struct ua *ua,
 	(void)re_vsnprintf(p, len, fmt, ap);
 	va_end(ap);
 
-	struct bevent bevent = {.ev = UA_EVENT_MODULE, .txt = buf};
+	struct bevent bevent = {.ev = BEVENT_MODULE, .txt = buf};
 	if (call) {
 		bevent.u.call = call;
 		bevent.ec = BEVENT_CLASS_CALL;
@@ -608,7 +629,7 @@ out:
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_app_emit(enum ua_event ev, void *arg, const char *fmt, ...)
+int bevent_app_emit(enum bevent_id ev, void *arg, const char *fmt, ...)
 {
 	va_list ap;
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_APP};
@@ -625,16 +646,16 @@ int bevent_app_emit(enum ua_event ev, void *arg, const char *fmt, ...)
 
 
 /**
- * Emit a User-Agent event
+ * Emit a Baresip event identifier
  *
- * @param ev   User-Agent event
+ * @param ev   Baresip event identifier
  * @param ua   User-Agent
  * @param fmt  Formatted arguments
  * @param ...  Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_ua_emit(enum ua_event ev, struct ua *ua, const char *fmt, ...)
+int bevent_ua_emit(enum bevent_id ev, struct ua *ua, const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_UA};
 	va_list ap;
@@ -656,14 +677,15 @@ int bevent_ua_emit(enum ua_event ev, struct ua *ua, const char *fmt, ...)
 /**
  * Emit a Call event
  *
- * @param ev    User-Agent event
+ * @param ev    Baresip event identifier
  * @param call  Call object
  * @param fmt   Formatted arguments
  * @param ...   Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_call_emit(enum ua_event ev, struct call *call, const char *fmt, ...)
+int bevent_call_emit(enum bevent_id ev, struct call *call,
+		     const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_CALL};
 	va_list ap;
@@ -685,14 +707,14 @@ int bevent_call_emit(enum ua_event ev, struct call *call, const char *fmt, ...)
 /**
  * Emit a SIP message event
  *
- * @param ev    User-Agent event
+ * @param ev    Baresip event identifier
  * @param msg   SIP message
  * @param fmt   Formatted arguments
  * @param ...   Variable arguments
  *
  * @return 0 if success, otherwise errorcode
  */
-int bevent_sip_msg_emit(enum ua_event ev, const struct sip_msg *msg,
+int bevent_sip_msg_emit(enum bevent_id ev, const struct sip_msg *msg,
 		       const char *fmt, ...)
 {
 	struct bevent event = {.ev = ev, .ec = BEVENT_CLASS_SIP};
@@ -713,53 +735,53 @@ int bevent_sip_msg_emit(enum ua_event ev, const struct sip_msg *msg,
 
 
 /**
- * Get the name of the User-Agent event
+ * Get the name of the Baresip event identifier
  *
- * @param ev User-Agent event
+ * @param ev Baresip event identifier
  *
  * @return Name of the event
  */
-const char *uag_event_str(enum ua_event ev)
+const char *uag_event_str(enum bevent_id ev)
 {
 	switch (ev) {
 
-	case UA_EVENT_REGISTERING:          return "REGISTERING";
-	case UA_EVENT_REGISTER_OK:          return "REGISTER_OK";
-	case UA_EVENT_REGISTER_FAIL:        return "REGISTER_FAIL";
-	case UA_EVENT_FALLBACK_OK:          return "FALLBACK_OK";
-	case UA_EVENT_FALLBACK_FAIL:        return "FALLBACK_FAIL";
-	case UA_EVENT_UNREGISTERING:        return "UNREGISTERING";
-	case UA_EVENT_MWI_NOTIFY:           return "MWI_NOTIFY";
-	case UA_EVENT_CREATE:               return "CREATE";
-	case UA_EVENT_SHUTDOWN:             return "SHUTDOWN";
-	case UA_EVENT_EXIT:                 return "EXIT";
-	case UA_EVENT_SIPSESS_CONN:         return "SIPSESS_CONN";
-	case UA_EVENT_CALL_INCOMING:        return "CALL_INCOMING";
-	case UA_EVENT_CALL_OUTGOING:        return "CALL_OUTGOING";
-	case UA_EVENT_CALL_RINGING:         return "CALL_RINGING";
-	case UA_EVENT_CALL_PROGRESS:        return "CALL_PROGRESS";
-	case UA_EVENT_CALL_ANSWERED:        return "CALL_ANSWERED";
-	case UA_EVENT_CALL_ESTABLISHED:     return "CALL_ESTABLISHED";
-	case UA_EVENT_CALL_CLOSED:          return "CALL_CLOSED";
-	case UA_EVENT_CALL_TRANSFER:        return "TRANSFER";
-	case UA_EVENT_CALL_TRANSFER_FAILED: return "TRANSFER_FAILED";
-	case UA_EVENT_CALL_REDIRECT:        return "CALL_REDIRECT";
-	case UA_EVENT_CALL_DTMF_START:      return "CALL_DTMF_START";
-	case UA_EVENT_CALL_DTMF_END:        return "CALL_DTMF_END";
-	case UA_EVENT_CALL_RTPESTAB:        return "CALL_RTPESTAB";
-	case UA_EVENT_CALL_RTCP:            return "CALL_RTCP";
-	case UA_EVENT_CALL_MENC:            return "CALL_MENC";
-	case UA_EVENT_VU_TX:                return "VU_TX_REPORT";
-	case UA_EVENT_VU_RX:                return "VU_RX_REPORT";
-	case UA_EVENT_AUDIO_ERROR:          return "AUDIO_ERROR";
-	case UA_EVENT_CALL_LOCAL_SDP:       return "CALL_LOCAL_SDP";
-	case UA_EVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
-	case UA_EVENT_CALL_HOLD:            return "CALL_HOLD";
-	case UA_EVENT_CALL_RESUME:          return "CALL_RESUME";
-	case UA_EVENT_REFER:                return "REFER";
-	case UA_EVENT_MODULE:               return "MODULE";
-	case UA_EVENT_END_OF_FILE:          return "END_OF_FILE";
-	case UA_EVENT_CUSTOM:               return "CUSTOM";
+	case BEVENT_REGISTERING:          return "REGISTERING";
+	case BEVENT_REGISTER_OK:          return "REGISTER_OK";
+	case BEVENT_REGISTER_FAIL:        return "REGISTER_FAIL";
+	case BEVENT_FALLBACK_OK:          return "FALLBACK_OK";
+	case BEVENT_FALLBACK_FAIL:        return "FALLBACK_FAIL";
+	case BEVENT_UNREGISTERING:        return "UNREGISTERING";
+	case BEVENT_MWI_NOTIFY:           return "MWI_NOTIFY";
+	case BEVENT_CREATE:               return "CREATE";
+	case BEVENT_SHUTDOWN:             return "SHUTDOWN";
+	case BEVENT_EXIT:                 return "EXIT";
+	case BEVENT_SIPSESS_CONN:         return "SIPSESS_CONN";
+	case BEVENT_CALL_INCOMING:        return "CALL_INCOMING";
+	case BEVENT_CALL_OUTGOING:        return "CALL_OUTGOING";
+	case BEVENT_CALL_RINGING:         return "CALL_RINGING";
+	case BEVENT_CALL_PROGRESS:        return "CALL_PROGRESS";
+	case BEVENT_CALL_ANSWERED:        return "CALL_ANSWERED";
+	case BEVENT_CALL_ESTABLISHED:     return "CALL_ESTABLISHED";
+	case BEVENT_CALL_CLOSED:          return "CALL_CLOSED";
+	case BEVENT_CALL_TRANSFER:        return "TRANSFER";
+	case BEVENT_CALL_TRANSFER_FAILED: return "TRANSFER_FAILED";
+	case BEVENT_CALL_REDIRECT:        return "CALL_REDIRECT";
+	case BEVENT_CALL_DTMF_START:      return "CALL_DTMF_START";
+	case BEVENT_CALL_DTMF_END:        return "CALL_DTMF_END";
+	case BEVENT_CALL_RTPESTAB:        return "CALL_RTPESTAB";
+	case BEVENT_CALL_RTCP:            return "CALL_RTCP";
+	case BEVENT_CALL_MENC:            return "CALL_MENC";
+	case BEVENT_VU_TX:                return "VU_TX_REPORT";
+	case BEVENT_VU_RX:                return "VU_RX_REPORT";
+	case BEVENT_AUDIO_ERROR:          return "AUDIO_ERROR";
+	case BEVENT_CALL_LOCAL_SDP:       return "CALL_LOCAL_SDP";
+	case BEVENT_CALL_REMOTE_SDP:      return "CALL_REMOTE_SDP";
+	case BEVENT_CALL_HOLD:            return "CALL_HOLD";
+	case BEVENT_CALL_RESUME:          return "CALL_RESUME";
+	case BEVENT_REFER:                return "REFER";
+	case BEVENT_MODULE:               return "MODULE";
+	case BEVENT_END_OF_FILE:          return "END_OF_FILE";
+	case BEVENT_CUSTOM:               return "CUSTOM";
 	default: return "?";
 	}
 }

--- a/src/bevent.c
+++ b/src/bevent.c
@@ -436,7 +436,7 @@ int event_add_au_jb_stat(struct odict *od_parent, const struct call *call)
  *
  * @return 0 if success, otherwise errorcode
  */
-int  bevent_register_new(bevent_h *eh, void *arg)
+int  bevent_register(bevent_h *eh, void *arg)
 {
 	struct ehe *ehe;
 
@@ -458,23 +458,12 @@ int  bevent_register_new(bevent_h *eh, void *arg)
 }
 
 
-int  bevent_register_old(old_bevent_h *eh, void *arg)
-{
-	bevent_h *h = (bevent_h *)eh;
-
-	if (!h)
-		return EINVAL;
-
-	return bevent_register_new(h, arg);
-}
-
-
 /**
  * Unregister an Event handler
  *
  * @param eh  Event handler
  */
-void bevent_unregister_new(bevent_h *eh)
+void bevent_unregister(bevent_h *eh)
 {
 	struct le *le;
 
@@ -489,16 +478,6 @@ void bevent_unregister_new(bevent_h *eh)
 	}
 }
 
-
-void bevent_unregister_old(old_bevent_h *eh)
-{
-	bevent_h *h = (bevent_h *)eh;
-
-	if (!h)
-		return;
-
-	bevent_unregister_new(h);
-}
 
 /**
  * Send a BEVENT_MODULE event with a general format for modules

--- a/src/call.c
+++ b/src/call.c
@@ -311,7 +311,7 @@ static int update_media(struct call *call)
 {
 	debug("call: update media\n");
 
-	bevent_call_emit(UA_EVENT_CALL_REMOTE_SDP, call,
+	bevent_call_emit(BEVENT_CALL_REMOTE_SDP, call,
 			 call->got_offer ? "offer" : "answer");
 
 	return call_update_media(call);
@@ -382,7 +382,7 @@ static void audio_level_handler(bool tx, double lvl, void *arg)
 	struct call *call = arg;
 	MAGIC_CHECK(call);
 
-	bevent_call_emit(tx ? UA_EVENT_VU_TX : UA_EVENT_VU_RX, call,
+	bevent_call_emit(tx ? BEVENT_VU_TX : BEVENT_VU_RX, call,
 			 "%.2f", lvl);
 }
 
@@ -395,7 +395,7 @@ static void audio_error_handler(int err, const char *str, void *arg)
 	if (err) {
 		warning("call: audio device error: %m (%s)\n", err, str);
 
-		bevent_call_emit(UA_EVENT_AUDIO_ERROR, call,
+		bevent_call_emit(BEVENT_AUDIO_ERROR, call,
 				 "%d,%s", err, str);
 
 		call_stream_stop(call);
@@ -403,7 +403,7 @@ static void audio_error_handler(int err, const char *str, void *arg)
 			"%s", str);
 	}
 	else
-		bevent_call_emit(UA_EVENT_END_OF_FILE, call, "");
+		bevent_call_emit(BEVENT_END_OF_FILE, call, "");
 }
 
 
@@ -524,7 +524,7 @@ static void stream_rtpestab_handler(struct stream *strm, void *arg)
 	struct call *call = arg;
 	MAGIC_CHECK(call);
 
-	bevent_call_emit(UA_EVENT_CALL_RTPESTAB, call,
+	bevent_call_emit(BEVENT_CALL_RTPESTAB, call,
 			 "%s", sdp_media_name(stream_sdpmedia(strm)));
 }
 
@@ -542,12 +542,12 @@ static void stream_rtcp_handler(struct stream *strm,
 		if (call->config_avt.rtp_stats)
 			call_set_xrtpstat(call);
 
-		bevent_call_emit(UA_EVENT_CALL_RTCP, call,
+		bevent_call_emit(BEVENT_CALL_RTCP, call,
 				 "%s", sdp_media_name(stream_sdpmedia(strm)));
 		break;
 
 	case RTCP_APP:
-		bevent_call_emit(UA_EVENT_CALL_RTCP, call,
+		bevent_call_emit(BEVENT_CALL_RTCP, call,
 				 "%s", sdp_media_name(stream_sdpmedia(strm)));
 		break;
 	}
@@ -1095,7 +1095,7 @@ int call_modify(struct call *call)
 	if (call_refresh_allowed(call)) {
 		err = call_sdp_get(call, &desc, true);
 		if (!err) {
-			bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call,
+			bevent_call_emit(BEVENT_CALL_LOCAL_SDP, call,
 					 "offer");
 
 			err = sipsess_modify(call->sess, desc);
@@ -1255,7 +1255,7 @@ int call_progress_dir(struct call *call, enum sdp_dir adir, enum sdp_dir vdir)
 		goto out;
 
 	if (call->got_offer) {
-		bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "answer");
+		bevent_call_emit(BEVENT_CALL_LOCAL_SDP, call, "answer");
 		err = call_update_media(call);
 	}
 
@@ -1326,7 +1326,7 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 			return err;
 	}
 
-	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call,
+	bevent_call_emit(BEVENT_CALL_LOCAL_SDP, call,
 			 "%s", !call->got_offer ? "offer" : "answer");
 
 	err = sdp_encode(&desc, call->sdp, !call->got_offer);
@@ -1781,9 +1781,9 @@ static int sipsess_offer_handler(struct mbuf **descp,
 		}
 
 		if (aurx && !(sdp_media_dir(m) & SDP_SENDONLY))
-			bevent_call_emit(UA_EVENT_CALL_HOLD, call, "");
+			bevent_call_emit(BEVENT_CALL_HOLD, call, "");
 		else if (!aurx && sdp_media_dir(m) & SDP_SENDONLY)
-			bevent_call_emit(UA_EVENT_CALL_RESUME, call, "");
+			bevent_call_emit(BEVENT_CALL_RESUME, call, "");
 
 		err = update_media(call);
 		if (err) {
@@ -1814,7 +1814,7 @@ static int sipsess_offer_handler(struct mbuf **descp,
 	if (err)
 		return err;
 
-	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "%s",
+	bevent_call_emit(BEVENT_CALL_LOCAL_SDP, call, "%s",
 			 got_offer ? "answer" : "offer");
 
 	return 0;
@@ -2307,7 +2307,7 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 			bundle_sdp_decode(call->sdp, &call->streaml);
 		}
 
-		bevent_call_emit(UA_EVENT_CALL_REMOTE_SDP, call, "offer");
+		bevent_call_emit(BEVENT_CALL_REMOTE_SDP, call, "offer");
 	}
 
 	hdr = sip_msg_hdr(msg, SIP_HDR_REPLACES);
@@ -2468,7 +2468,7 @@ static void redirect_handler(const struct sip_msg *msg, const char *uri,
 	struct call *call = arg;
 
 	info("call: redirect to %s\n", uri);
-	bevent_call_emit(UA_EVENT_CALL_REDIRECT, call,
+	bevent_call_emit(BEVENT_CALL_REDIRECT, call,
 			 "%d,%s", msg->scode, uri);
 	return;
 }
@@ -2565,7 +2565,7 @@ static int send_invite(struct call *call)
 	/* save call setup timer */
 	call->time_conn = time(NULL);
 
-	bevent_call_emit(UA_EVENT_CALL_LOCAL_SDP, call, "offer");
+	bevent_call_emit(BEVENT_CALL_LOCAL_SDP, call, "offer");
 
 	return 0;
 }

--- a/src/reg.c
+++ b/src/reg.c
@@ -107,10 +107,10 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 	const struct account *acc = ua_account(reg->ua);
 	const struct sip_hdr *hdr;
 	uint32_t prio = account_prio(acc);
-	enum ua_event evok =  reg->regint ?
-		UA_EVENT_REGISTER_OK : UA_EVENT_FALLBACK_OK;
-	enum ua_event evfail = reg->regint ?
-		UA_EVENT_REGISTER_FAIL : UA_EVENT_FALLBACK_FAIL;
+	enum bevent_id evok =  reg->regint ?
+		BEVENT_REGISTER_OK : BEVENT_FALLBACK_OK;
+	enum bevent_id evfail = reg->regint ?
+		BEVENT_REGISTER_FAIL : BEVENT_FALLBACK_FAIL;
 
 	if (err) {
 		if (reg->regint)

--- a/src/reg.c
+++ b/src/reg.c
@@ -107,9 +107,9 @@ static void register_handler(int err, const struct sip_msg *msg, void *arg)
 	const struct account *acc = ua_account(reg->ua);
 	const struct sip_hdr *hdr;
 	uint32_t prio = account_prio(acc);
-	enum bevent_id evok =  reg->regint ?
+	enum bevent_ev evok =  reg->regint ?
 		BEVENT_REGISTER_OK : BEVENT_FALLBACK_OK;
-	enum bevent_id evfail = reg->regint ?
+	enum bevent_ev evfail = reg->regint ?
 		BEVENT_REGISTER_FAIL : BEVENT_FALLBACK_FAIL;
 
 	if (err) {

--- a/src/ua.c
+++ b/src/ua.c
@@ -46,11 +46,11 @@ static void ua_destructor(void *arg)
 	list_unlink(&ua->le);
 
 	if (!list_isempty(&ua->regl))
-		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
+		bevent_ua_emit(BEVENT_UNREGISTERING, ua, NULL);
 
 	LIST_FOREACH(&ua->calls, le) {
 		struct call *call = le->data;
-		bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+		bevent_call_emit(BEVENT_CALL_CLOSED, call,
 				 "User-Agent deleted");
 	}
 
@@ -220,7 +220,7 @@ static int start_register(struct ua *ua, bool fallback)
 		create_register_clients(ua);
 
 	if (!fallback && !list_isempty(&ua->regl))
-		bevent_ua_emit(UA_EVENT_REGISTERING, ua, NULL);
+		bevent_ua_emit(BEVENT_REGISTERING, ua, NULL);
 
 	for (le = ua->regl.head, i=0; le; le = le->next, i++) {
 		struct reg *reg = le->data;
@@ -236,8 +236,8 @@ static int start_register(struct ua *ua, bool fallback)
 					fallback ? " fallback" : "", err);
 
 			bevent_ua_emit(fallback ?
-				       UA_EVENT_FALLBACK_FAIL :
-				       UA_EVENT_REGISTER_FAIL,
+				       BEVENT_FALLBACK_FAIL :
+				       BEVENT_REGISTER_FAIL,
 				       ua, "%m", err);
 			goto out;
 		}
@@ -303,7 +303,7 @@ void ua_stop_register(struct ua *ua)
 		return;
 
 	if (!list_isempty(&ua->regl))
-		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
+		bevent_ua_emit(BEVENT_UNREGISTERING, ua, NULL);
 
 	for (le = ua->regl.head; le; le = le->next) {
 		struct reg *reg = le->data;
@@ -326,7 +326,7 @@ void ua_unregister(struct ua *ua)
 		return;
 
 	if (!list_isempty(&ua->regl))
-		bevent_ua_emit(UA_EVENT_UNREGISTERING, ua, NULL);
+		bevent_ua_emit(BEVENT_UNREGISTERING, ua, NULL);
 
 	for (le = ua->regl.head; le; le = le->next) {
 		struct reg *reg = le->data;
@@ -426,7 +426,7 @@ unsigned ua_destroy(struct ua *ua)
 	list_unlink(&ua->le);
 
 	/* send the shutdown event */
-	bevent_ua_emit(UA_EVENT_SHUTDOWN, ua, NULL);
+	bevent_ua_emit(BEVENT_SHUTDOWN, ua, NULL);
 
 	/* terminate all calls now */
 	list_flush(&ua->calls);
@@ -541,13 +541,13 @@ static void call_event_handler(struct call *call, enum call_event ev,
 
 			info("ua: blocked access: \"%s\"\n", peeruri);
 
-			bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+			bevent_call_emit(BEVENT_CALL_CLOSED, call,
 					 "%s", str);
 			mem_deref(call);
 			break;
 		}
 
-		bevent_call_emit(UA_EVENT_CALL_INCOMING, call, "%s", peeruri);
+		bevent_call_emit(BEVENT_CALL_INCOMING, call, "%s", peeruri);
 		switch (ua->acc->answermode) {
 
 		case ANSWERMODE_EARLY:
@@ -571,45 +571,45 @@ static void call_event_handler(struct call *call, enum call_event ev,
 		break;
 
 	case CALL_EVENT_RINGING:
-		bevent_call_emit(UA_EVENT_CALL_RINGING, call, "%s", peeruri);
+		bevent_call_emit(BEVENT_CALL_RINGING, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_OUTGOING:
-		bevent_call_emit(UA_EVENT_CALL_OUTGOING, call, "%s", peeruri);
+		bevent_call_emit(BEVENT_CALL_OUTGOING, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_PROGRESS:
 		ua_printf(ua, "Call in-progress: %s\n", peeruri);
-		bevent_call_emit(UA_EVENT_CALL_PROGRESS, call, "%s", peeruri);
+		bevent_call_emit(BEVENT_CALL_PROGRESS, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_ANSWERED:
 		ua_printf(ua, "Call answered: %s\n", peeruri);
-		bevent_call_emit(UA_EVENT_CALL_ANSWERED, call, "%s", peeruri);
+		bevent_call_emit(BEVENT_CALL_ANSWERED, call, "%s", peeruri);
 		break;
 
 	case CALL_EVENT_ESTABLISHED:
 		ua_printf(ua, "Call established: %s\n", peeruri);
-		bevent_call_emit(UA_EVENT_CALL_ESTABLISHED, call,
+		bevent_call_emit(BEVENT_CALL_ESTABLISHED, call,
 				"%s", peeruri);
 		break;
 
 	case CALL_EVENT_CLOSED:
-		bevent_call_emit(UA_EVENT_CALL_CLOSED, call, "%s", str);
+		bevent_call_emit(BEVENT_CALL_CLOSED, call, "%s", str);
 		mem_deref(call);
 		break;
 
 	case CALL_EVENT_TRANSFER:
-		bevent_call_emit(UA_EVENT_CALL_TRANSFER, call, "%s", str);
+		bevent_call_emit(BEVENT_CALL_TRANSFER, call, "%s", str);
 		break;
 
 	case CALL_EVENT_TRANSFER_FAILED:
-		bevent_call_emit(UA_EVENT_CALL_TRANSFER_FAILED, call,
+		bevent_call_emit(BEVENT_CALL_TRANSFER_FAILED, call,
 				"%s", str);
 		break;
 
 	case CALL_EVENT_MENC:
-		bevent_call_emit(UA_EVENT_CALL_MENC, call, "%s", str);
+		bevent_call_emit(BEVENT_CALL_MENC, call, "%s", str);
 		break;
 	}
 }
@@ -627,11 +627,11 @@ static void call_dtmf_handler(struct call *call, char key, void *arg)
 		key_str[0] = key;
 		key_str[1] = '\0';
 
-		bevent_call_emit(UA_EVENT_CALL_DTMF_START, call,
+		bevent_call_emit(BEVENT_CALL_DTMF_START, call,
 				 "%s", key_str);
 	}
 	else {
-		bevent_call_emit(UA_EVENT_CALL_DTMF_END, call, NULL);
+		bevent_call_emit(BEVENT_CALL_DTMF_END, call, NULL);
 	}
 }
 
@@ -780,7 +780,7 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 	if (config->call.accept)
 		(void)ua_accept(ua, msg);
 	else
-		bevent_sip_msg_emit(UA_EVENT_SIPSESS_CONN, msg,
+		bevent_sip_msg_emit(BEVENT_SIPSESS_CONN, msg,
 				    "incoming call");
 }
 
@@ -1146,7 +1146,7 @@ bool ua_handle_refer(struct ua *ua, const struct sip_msg *msg)
 	}
 
 	debug("ua: REFER to %r\n", &hdr->val);
-	bevent_ua_emit(UA_EVENT_REFER, ua, "%r", &hdr->val);
+	bevent_ua_emit(BEVENT_REFER, ua, "%r", &hdr->val);
 
 out:
 
@@ -1260,7 +1260,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 		goto out;
 
 	list_append(uag_list(), &ua->le, ua);
-	bevent_ua_emit(UA_EVENT_CREATE, ua, "%s", account_aor(ua->acc));
+	bevent_ua_emit(BEVENT_CREATE, ua, "%s", account_aor(ua->acc));
 
  out:
 	mem_deref(host);
@@ -1480,7 +1480,7 @@ void ua_hangupf(struct ua *ua, struct call *call,
 	call_hangupf(call, scode, reason, fmt ? "%v" : NULL, fmt, &ap);
 	va_end(ap);
 
-	bevent_call_emit(UA_EVENT_CALL_CLOSED, call,
+	bevent_call_emit(BEVENT_CALL_CLOSED, call,
 			 reason ? reason : "Rejected by user");
 
 	mem_deref(call);

--- a/src/uag.c
+++ b/src/uag.c
@@ -19,7 +19,7 @@ static void exit_handler(void *arg)
 {
 	(void)arg;
 
-	bevent_app_emit(UA_EVENT_EXIT, NULL, NULL);
+	bevent_app_emit(BEVENT_EXIT, NULL, NULL);
 
 	debug("ua: sip-stack exit\n");
 
@@ -734,7 +734,7 @@ int uag_reset_transp(bool reg, bool reinvite)
 				if (!call_refresh_allowed(call)) {
 					call_hangup(call, 500, "Transport of "
 						    "User Agent changed");
-					bevent_call_emit(UA_EVENT_CALL_CLOSED,
+					bevent_call_emit(BEVENT_CALL_CLOSED,
 							 call, "Transport of "
 							 "User Agent changed");
 					mem_deref(call);

--- a/test/bevent.c
+++ b/test/bevent.c
@@ -72,7 +72,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 	const struct odict_entry *entry = odict_lookup(od, "type");
 	ASSERT_TRUE(entry != NULL);
 	ASSERT_EQ(ODICT_STRING, odict_entry_type(entry));
-	ASSERT_STREQ(uag_event_str(ev), odict_entry_str(entry));
+	ASSERT_STREQ(bevent_id_str(ev), odict_entry_str(entry));
 
 out:
 	od = mem_deref(od);

--- a/test/bevent.c
+++ b/test/bevent.c
@@ -14,7 +14,7 @@ struct fixture {
 	struct call *call;
 	int cnt;
 
-	enum bevent_id expected_event;
+	enum bevent_ev expected_event;
 };
 
 
@@ -25,7 +25,7 @@ static struct dummy {
 static struct sip_msg *dummy_msg;
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct fixture *f = arg;
 	void *apparg = bevent_get_apparg(event);
@@ -51,7 +51,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 		bevent_set_error(event, EINVAL);
 
 
-	if (f->expected_event != bevent_get_id(event))
+	if (f->expected_event != bevent_get_value(event))
 		bevent_set_error(event, EINVAL);
 	else
 		++f->cnt;
@@ -72,7 +72,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 	const struct odict_entry *entry = odict_lookup(od, "type");
 	ASSERT_TRUE(entry != NULL);
 	ASSERT_EQ(ODICT_STRING, odict_entry_type(entry));
-	ASSERT_STREQ(bevent_id_str(ev), odict_entry_str(entry));
+	ASSERT_STREQ(bevent_str(ev), odict_entry_str(entry));
 
 out:
 	od = mem_deref(od);

--- a/test/bevent.c
+++ b/test/bevent.c
@@ -14,7 +14,7 @@ struct fixture {
 	struct call *call;
 	int cnt;
 
-	enum ua_event expected_event;
+	enum bevent_id expected_event;
 };
 
 
@@ -25,7 +25,7 @@ static struct dummy {
 static struct sip_msg *dummy_msg;
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct fixture *f = arg;
 	void *apparg = bevent_get_apparg(event);
@@ -46,7 +46,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	if (msg && msg != dummy_msg)
 		bevent_set_error(event, EINVAL);
 
-	if (ev == UA_EVENT_MODULE &&
+	if (ev == BEVENT_MODULE &&
 		 !!str_cmp(txt, "module,event,details"))
 		bevent_set_error(event, EINVAL);
 
@@ -117,27 +117,27 @@ int test_bevent_register(void)
 	err = bevent_register(event_handler, &f);
 	TEST_ERR(err);
 
-	f.expected_event = UA_EVENT_EXIT;
-	err = bevent_app_emit(UA_EVENT_EXIT, &dummy, "%s",
+	f.expected_event = BEVENT_EXIT;
+	err = bevent_app_emit(BEVENT_EXIT, &dummy, "%s",
 			      "details");
 	TEST_ERR(err);
 
-	err = bevent_app_emit(UA_EVENT_SHUTDOWN, &dummy, "%s",
+	err = bevent_app_emit(BEVENT_SHUTDOWN, &dummy, "%s",
 			      "details");
 	ASSERT_EQ(EINVAL, err);
 
-	f.expected_event = UA_EVENT_REGISTER_OK;
-	err = bevent_ua_emit(UA_EVENT_REGISTER_OK, f.ua, NULL);
+	f.expected_event = BEVENT_REGISTER_OK;
+	err = bevent_ua_emit(BEVENT_REGISTER_OK, f.ua, NULL);
 	TEST_ERR(err);
 
-	f.expected_event = UA_EVENT_CALL_INCOMING;
-	err = bevent_call_emit(UA_EVENT_CALL_INCOMING, f.call, NULL);
+	f.expected_event = BEVENT_CALL_INCOMING;
+	err = bevent_call_emit(BEVENT_CALL_INCOMING, f.call, NULL);
 	TEST_ERR(err);
 
-	f.expected_event = UA_EVENT_SIPSESS_CONN;
+	f.expected_event = BEVENT_SIPSESS_CONN;
 	err = sip_msg_readf(&dummy_msg, "invite.sip");
 	TEST_ERR(err);
-	err = bevent_sip_msg_emit(UA_EVENT_SIPSESS_CONN,
+	err = bevent_sip_msg_emit(BEVENT_SIPSESS_CONN,
 				  dummy_msg, NULL);
 	TEST_ERR(err);
 	dummy_msg = mem_deref(dummy_msg);

--- a/test/bevent.c
+++ b/test/bevent.c
@@ -51,7 +51,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 		bevent_set_error(event, EINVAL);
 
 
-	if (f->expected_event != bevent_get_type(event))
+	if (f->expected_event != bevent_get_id(event))
 		bevent_set_error(event, EINVAL);
 	else
 		++f->cnt;

--- a/test/call.c
+++ b/test/call.c
@@ -45,7 +45,7 @@ enum action {
 struct cancel_rule {
 	struct le le;
 
-	enum bevent_id ev;
+	enum bevent_ev ev;
 	const char *prm;
 	struct ua *ua;
 	bool checkack;
@@ -221,7 +221,7 @@ static void cancel_rule_destructor(void *arg)
 }
 
 
-static struct cancel_rule *cancel_rule_alloc(enum bevent_id ev,
+static struct cancel_rule *cancel_rule_alloc(enum bevent_ev ev,
 					     struct ua *ua,
 					     unsigned n_incoming,
 					     unsigned n_progress,
@@ -252,7 +252,7 @@ static struct cancel_rule *cancel_rule_alloc(enum bevent_id ev,
 
 
 static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
-						   enum bevent_id ev,
+						   enum bevent_ev ev,
 						   struct ua *ua,
 						   unsigned n_incoming,
 						   unsigned n_progress,
@@ -269,7 +269,7 @@ static struct cancel_rule *fixture_add_cancel_rule(struct fixture *f,
 
 
 static struct cancel_rule *cancel_rule_and_alloc(struct cancel_rule *cr,
-						 enum bevent_id ev,
+						 enum bevent_ev ev,
 						 struct ua *ua,
 						 unsigned n_incoming,
 						 unsigned n_progress,
@@ -299,7 +299,7 @@ static int cancel_rule_debug(struct re_printf *pf,
 	if (!cr)
 		return 0;
 
-	err  = re_hprintf(pf, "  --- %s ---\n", bevent_id_str(cr->ev));
+	err  = re_hprintf(pf, "  --- %s ---\n", bevent_str(cr->ev));
 	err |= re_hprintf(pf, "    prm:  %s\n", cr->prm);
 	err |= re_hprintf(pf, "    ua:   %s\n",
 			  account_aor(ua_account(cr->ua)));
@@ -484,7 +484,7 @@ out:
 
 
 static bool check_rule(struct cancel_rule *rule, int met_prev,
-		       struct agent *ag, enum bevent_id ev, const char *prm)
+		       struct agent *ag, enum bevent_ev ev, const char *prm)
 {
 	bool met_next = true;
 	if (rule->cr_and) {
@@ -503,28 +503,28 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (str_isset(rule->prm) &&
 	    !str_str(prm, rule->prm)) {
 		info("test: event %s prm=[%s] (expected [%s])\n",
-		     bevent_id_str(ev), prm, rule->prm);
+		     bevent_str(ev), prm, rule->prm);
 		return false;
 	}
 
 	if (rule->ua &&
 	    ag->ua != rule->ua) {
 		info("test: event %s ua=[%s] (expected [%s]\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     account_aor(ua_account(ag->ua)),
 		     account_aor(ua_account(rule->ua)));
 		return false;
 	}
 
 	if (rule->checkack && !ag->gotack) {
-		info("test: event %s waiting for ACK\n", bevent_id_str(ev));
+		info("test: event %s waiting for ACK\n", bevent_str(ev));
 		return false;
 	}
 
 	if (UINTSET(rule->n_incoming) &&
 	    ag->n_incoming != rule->n_incoming) {
 		info("test: event %s n_incoming=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_incoming, rule->n_incoming);
 		return false;
 	}
@@ -532,7 +532,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_progress) &&
 	    ag->n_progress < rule->n_progress) {
 		info("test: event %s n_progress=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_progress, rule->n_progress);
 		return false;
 	}
@@ -540,7 +540,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_established) &&
 	    ag->n_established != rule->n_established) {
 		info("test: event %s n_established=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_established, rule->n_established);
 		return false;
 	}
@@ -548,7 +548,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_audio_estab) &&
 	    ag->n_audio_estab != rule->n_audio_estab) {
 		info("test: event %s n_audio_estab=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_audio_estab, rule->n_audio_estab);
 		return false;
 	}
@@ -556,7 +556,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_video_estab) &&
 	    ag->n_video_estab != rule->n_video_estab) {
 		info("test: event %s n_video_estab=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_video_estab, rule->n_video_estab);
 		return false;
 	}
@@ -564,7 +564,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_offer_cnt) &&
 	    ag->n_offer_cnt != rule->n_offer_cnt) {
 		info("test: event %s n_offer_cnt=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_offer_cnt, rule->n_offer_cnt);
 		return false;
 	}
@@ -572,7 +572,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_answer_cnt) &&
 	    ag->n_answer_cnt != rule->n_answer_cnt) {
 		info("test: event %s n_answer_cnt=%u (expected %u)\n",
-		     bevent_id_str(ev),
+		     bevent_str(ev),
 		     ag->n_answer_cnt, rule->n_answer_cnt);
 		return false;
 	}
@@ -614,7 +614,7 @@ out:
 }
 
 
-static void process_rules(struct agent *ag, enum bevent_id ev, const char *prm)
+static void process_rules(struct agent *ag, enum bevent_ev ev, const char *prm)
 {
 	struct fixture *f = ag->fix;
 	struct le *le;
@@ -625,7 +625,7 @@ static void process_rules(struct agent *ag, enum bevent_id ev, const char *prm)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct fixture *f = arg;
 	struct call *call2 = NULL;
@@ -640,7 +640,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 
 #if 1
 	info("test: [ %s ] event: %s (%s)\n",
-	     account_aor(ua_account(ua)), bevent_id_str(ev), prm);
+	     account_aor(ua_account(ua)), bevent_str(ev), prm);
 #endif
 
 	ASSERT_TRUE(f != NULL);

--- a/test/call.c
+++ b/test/call.c
@@ -299,7 +299,7 @@ static int cancel_rule_debug(struct re_printf *pf,
 	if (!cr)
 		return 0;
 
-	err  = re_hprintf(pf, "  --- %s ---\n", uag_event_str(cr->ev));
+	err  = re_hprintf(pf, "  --- %s ---\n", bevent_id_str(cr->ev));
 	err |= re_hprintf(pf, "    prm:  %s\n", cr->prm);
 	err |= re_hprintf(pf, "    ua:   %s\n",
 			  account_aor(ua_account(cr->ua)));
@@ -503,28 +503,28 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (str_isset(rule->prm) &&
 	    !str_str(prm, rule->prm)) {
 		info("test: event %s prm=[%s] (expected [%s])\n",
-		     uag_event_str(ev), prm, rule->prm);
+		     bevent_id_str(ev), prm, rule->prm);
 		return false;
 	}
 
 	if (rule->ua &&
 	    ag->ua != rule->ua) {
 		info("test: event %s ua=[%s] (expected [%s]\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     account_aor(ua_account(ag->ua)),
 		     account_aor(ua_account(rule->ua)));
 		return false;
 	}
 
 	if (rule->checkack && !ag->gotack) {
-		info("test: event %s waiting for ACK\n", uag_event_str(ev));
+		info("test: event %s waiting for ACK\n", bevent_id_str(ev));
 		return false;
 	}
 
 	if (UINTSET(rule->n_incoming) &&
 	    ag->n_incoming != rule->n_incoming) {
 		info("test: event %s n_incoming=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_incoming, rule->n_incoming);
 		return false;
 	}
@@ -532,7 +532,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_progress) &&
 	    ag->n_progress < rule->n_progress) {
 		info("test: event %s n_progress=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_progress, rule->n_progress);
 		return false;
 	}
@@ -540,7 +540,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_established) &&
 	    ag->n_established != rule->n_established) {
 		info("test: event %s n_established=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_established, rule->n_established);
 		return false;
 	}
@@ -548,7 +548,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_audio_estab) &&
 	    ag->n_audio_estab != rule->n_audio_estab) {
 		info("test: event %s n_audio_estab=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_audio_estab, rule->n_audio_estab);
 		return false;
 	}
@@ -556,7 +556,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_video_estab) &&
 	    ag->n_video_estab != rule->n_video_estab) {
 		info("test: event %s n_video_estab=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_video_estab, rule->n_video_estab);
 		return false;
 	}
@@ -564,7 +564,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_offer_cnt) &&
 	    ag->n_offer_cnt != rule->n_offer_cnt) {
 		info("test: event %s n_offer_cnt=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_offer_cnt, rule->n_offer_cnt);
 		return false;
 	}
@@ -572,7 +572,7 @@ static bool check_rule(struct cancel_rule *rule, int met_prev,
 	if (UINTSET(rule->n_answer_cnt) &&
 	    ag->n_answer_cnt != rule->n_answer_cnt) {
 		info("test: event %s n_answer_cnt=%u (expected %u)\n",
-		     uag_event_str(ev),
+		     bevent_id_str(ev),
 		     ag->n_answer_cnt, rule->n_answer_cnt);
 		return false;
 	}
@@ -640,7 +640,7 @@ static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 
 #if 1
 	info("test: [ %s ] event: %s (%s)\n",
-	     account_aor(ua_account(ua)), uag_event_str(ev), prm);
+	     account_aor(ua_account(ua)), bevent_id_str(ev), prm);
 #endif
 
 	ASSERT_TRUE(f != NULL);

--- a/test/ua.c
+++ b/test/ua.c
@@ -55,7 +55,7 @@ static void test_abort(struct test *t, int err)
 }
 
 
-static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
 {
 	struct test *t = arg;
 	size_t i;
@@ -72,7 +72,7 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 	if (ua != t->ua)
 		return;
 
-	if (ev == UA_EVENT_REGISTER_OK) {
+	if (ev == BEVENT_REGISTER_OK) {
 
 		info("event: Register OK!\n");
 
@@ -87,12 +87,12 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 
 		t->ua = mem_deref(t->ua);
 	}
-	else if (ev == UA_EVENT_REGISTER_FAIL) {
+	else if (ev == BEVENT_REGISTER_FAIL) {
 
 		err = EAUTH;
 		re_cancel();
 	}
-	else if (ev == UA_EVENT_REFER) {
+	else if (ev == BEVENT_REFER) {
 		ASSERT_STREQ(referto, prm);
 		++t->n_ev;
 	}

--- a/test/ua.c
+++ b/test/ua.c
@@ -55,7 +55,7 @@ static void test_abort(struct test *t, int err)
 }
 
 
-static void event_handler(enum bevent_id ev, struct bevent *event, void *arg)
+static void event_handler(enum bevent_ev ev, struct bevent *event, void *arg)
 {
 	struct test *t = arg;
 	size_t i;


### PR DESCRIPTION
- **bevent: rename enum ua_event without breaking API**

It would be really nice if we could rename the enum. But we should not break the API.

The backwards compatibility code is somehow complicated, but can be removed after a while (again one year?).

Is there a better solution? Or should we do without it?
