### PR TITLE
call: prepare to receive video immediately with 200 Ok

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1344,11 +1344,17 @@ int call_answer(struct call *call, uint16_t scode, enum vidmode vmode)
 				"Allow: %H\r\n", ua_print_allowed, call->ua);
 	}
 
+	if (err)
+		goto out;
+
 	call->answered = true;
 	call->ans_queued = false;
 
-	mem_deref(desc);
+	if (call->got_offer && stream_is_ready(video_strm(call->video)))
+		(void)video_update(call->video, call->peer_uri);
 
+out:
+	mem_deref(desc);
 	return err;
 }
 


### PR DESCRIPTION
Currently it is possible that for H.264 SPS+PPS are missed at the decoder side.

Suppose that UA a calls UA b:
- INVITE a -> b
- 200 Answering b -> a
- ACK a ->b

Details for UA a:

`re/src/sipsess/connect.c: invite_resp_handler() -> sess->answerh()
sipsess_answer_handler --> update_media --> ... --> video_update--> video_encoder_set() + video_start_source()`

The 200 Ok enables the encoder.

Details for UA b:

`sipsess/listen.c: request_handler() gets ACK -> ack_handler() -> sipsess_estab_handler() -> update_streams()`

The ACK enables the decoder.

Thus, it is possible that the first RTP packet arrives before the decoder is ready. We observed this sporadically on our ARM devices.

RFC 3264 Section 6.1

```
   Once the answerer has sent the answer, it MUST be prepared to receive
   media for any recvonly streams described by that answer.  It MUST be
   prepared to send and receive media for any sendrecv streams in the
   answer, and it MAY send media immediately.  The answerer MUST be
   prepared to receive media for recvonly or sendrecv streams using any
   media formats listed for those streams in the answer, and it MAY send
   media immediately.
   ...
```
So once the UA has sent the 200 Answering, it MUST be immediately ready to
receive the media. No waiting for an ACK.

Now the video decoder and display is initialized immediately when the 200 Answering was sent out. The second call to `video_update()` from `sipsess_estab_handler() -> update_streams()` does not hurt, because there are checks if the initialization of encoder, decoder, source and display are done already.