### PR TITLE
in_band_dtmf: fix cross compiler alignment warning

### DIFF
--- a/modules/in_band_dtmf/in_band_dtmf.c
+++ b/modules/in_band_dtmf/in_band_dtmf.c
@@ -170,7 +170,7 @@ static int decode_update(struct aufilt_dec_st **stp, void **ctx,
 
 static int decode(struct aufilt_dec_st *st, struct auframe *af)
 {
-	struct in_band_dtmf_filt_dec *sf = (struct in_band_dtmf_filt_dec *)st;
+	struct in_band_dtmf_filt_dec *sf = (void *)st;
 
 	if (!st || !af)
 		return EINVAL;


### PR DESCRIPTION
With arm gcc cross compiler there was a warning
```
src/baresip/modules/in_band_dtmf/in_band_dtmf.c:173:44: warning: cast increases required alignment of target type [-Wcast-align]
  173 |         struct in_band_dtmf_filt_dec *sf = (struct in_band_dtmf_filt_dec *)st;
      |
```
