### PR TITLE
uri: remove password field

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -132,9 +132,6 @@ static int stunsrv_decode(struct account *acc, const struct sip_addr *aor)
 
 	if (0 == msg_param_exists(&aor->params, "stunpass", &tmp))
 		err |= param_dstr(&acc->stun_pass, &aor->params, "stunpass");
-	else if (pl_isset(&uri.password))
-		err |= re_sdprintf(&acc->stun_pass, "%H",
-					uri_password_unescape, &uri.password);
 
 	return err;
 }
@@ -565,7 +562,7 @@ static int encode_uri_user(struct re_printf *pf, const struct uri *uri)
 {
 	struct uri uuri = *uri;
 
-	uuri.password = uuri.params = uuri.headers = pl_null;
+	uuri.params = uuri.headers = pl_null;
 
 	return uri_encode(pf, &uuri);
 }
@@ -606,7 +603,6 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	}
 
 	acc->luri = acc->laddr.uri;
-	acc->luri.password = pl_null;
 
 	err = re_sdprintf(&acc->aor, "%H", encode_uri_user, &acc->luri);
 	if (err)

--- a/src/call.c
+++ b/src/call.c
@@ -2834,7 +2834,6 @@ static int normalize_uri(char **out, const char *uri, const struct uri *luri)
 		uri2 = *luri;
 
 		uri2.user     = pl;
-		uri2.password = pl_null;
 		uri2.params   = pl_null;
 
 		err = re_sdprintf(out, "%H", uri_encode, &uri2);

--- a/src/stunuri.c
+++ b/src/stunuri.c
@@ -117,11 +117,6 @@ int stunuri_decode_uri(struct stun_uri **sup, const struct uri *uri)
 		}
 	}
 
-	if (pl_isset(&uri->password)) {
-		warning("The \"user:password\" format in the stunserver"
-			" userinfo field is deprecated.\n");
-	}
-
 	su = mem_zalloc(sizeof(*su), destructor);
 	if (!su)
 		return ENOMEM;

--- a/src/ua.c
+++ b/src/ua.c
@@ -183,7 +183,7 @@ static int start_register(struct ua *ua, bool fallback)
 		return 0;
 
 	uri = ua->acc->luri;
-	uri.user = uri.password = pl_null;
+	uri.user = pl_null;
 
 	err = re_sdprintf(&reg_uri, "%H", uri_encode, &uri);
 	if (err)

--- a/test/account.c
+++ b/test/account.c
@@ -50,7 +50,6 @@ int test_account(void)
 	TEST_STRCMP("Mr User", 7, addr->dname.p,        addr->dname.l);
 	TEST_STRCMP("sip",     3, addr->uri.scheme.p,   addr->uri.scheme.l);
 	TEST_STRCMP("user",    4, addr->uri.user.p,     addr->uri.user.l);
-	TEST_STRCMP("",        0, addr->uri.password.p, addr->uri.password.l);
 	TEST_STRCMP("domain.com", 10, addr->uri.host.p, addr->uri.host.l);
 	ASSERT_EQ(0, addr->uri.params.l);
 	ASSERT_TRUE(addr->params.l > 0);

--- a/test/sip/location.c
+++ b/test/sip/location.c
@@ -107,9 +107,6 @@ static bool my_uri_cmp(const struct uri *l, const struct uri *r)
 	if (pl_cmp(&l->user, &r->user))
 		return false;
 
-	if (pl_cmp(&l->password, &r->password))
-		return false;
-
 	if (pl_casecmp(&l->host, &r->host))
 		return false;
 	if (l->af != r->af)


### PR DESCRIPTION
The password field in RFC 3986 is deprecated, this is a proposal to remove
the `struct pl password` field from `struct uri`.

Two PRs for baresip and libre have to be merged at the same time.

required PR: https://github.com/baresip/re/pull/1382
