### PR TITLE
package: Fix not working libdir

### DIFF
--- a/packaging/libbaresip.pc.in
+++ b/packaging/libbaresip.pc.in
@@ -1,6 +1,6 @@
 prefix="@CMAKE_INSTALL_PREFIX@"
 exec_prefix=${prefix}
-libdir={$prefix}/lib
+libdir=${prefix}/lib
 includedir=${prefix}/include
 
 Name: libbaresip


### PR DESCRIPTION
Because of a typo in the `packaging/libbaresip.pc.in` file the libdir for baresip package is not set correctly. This brings issues using baresip in CMake when it's not installed to system paths but to local paths.