### PR TITLE
ci: temporary workaround for choco openssl failure

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install OpenSSL
         if: ${{ matrix.config.openssl }}
         run: |
-          choco install --no-progress ${{ matrix.config.choco }} openssl
+          choco install --no-progress ${{ matrix.config.choco }} openssl --version 3.5.2
 
       - uses: sreimers/pr-dependency-action@v1
         with:


### PR DESCRIPTION
The installation of OpenSSL using choco on Windows is currently broken.
The proper solution is to use the builtin OpenSSL that comes with the Windows image.
This should be upgraded to 3.5.x some time on October.

Suggesting using a fixed version for now as a temp solution.