### PR TITLE
audio: a config parameter for tx audio buffer size

### DIFF
--- a/docs/examples/config
+++ b/docs/examples/config
@@ -52,6 +52,7 @@ auplay_format		s16		# s16, float, ..
 auenc_format		s16		# s16, float, ..
 audec_format		s16		# s16, float, ..
 audio_buffer		20-160		# ms
+#audio_buffer_tx	20-120		# ms
 audio_buffer_mode	fixed		# fixed, adaptive
 audio_silence		-35.0		# in [dB]
 audio_telev_pt		101		# payload type for telephone-event

--- a/src/config.c
+++ b/src/config.c
@@ -891,6 +891,7 @@ static int core_config_template(struct re_printf *pf, const struct config *cfg)
 			  "auenc_format\t\ts16\t\t# s16, float, ..\n"
 			  "audec_format\t\ts16\t\t# s16, float, ..\n"
 			  "audio_buffer\t\t%H\t\t# ms\n"
+			  "#audio_buffer_tx\t20-120\t\t# ms\n"
 			  "audio_buffer_mode\t%s\t\t# fixed, adaptive\n"
 			  "audio_silence\t\t%.1lf\t\t# in [dB]\n"
 			  "audio_telev_pt\t\t%u\t\t"


### PR DESCRIPTION
- use tx audio_buffer_tx range setting instead of hard coded 30
- the default max now can be reduced
