### PR TITLE
A flag for unique contact user

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -22,6 +22,7 @@
 #    ;call_transfer=no
 #    ;catchall={yes, no}  # default: no
 #    ;cert=cert.pem
+#    ;cuser_ua={yes, no}  # default: yes
 #    ;mediaenc={srtp,srtp-mand,srtp-mandf,dtls_srtp,zrtp}
 #    ;medianat={stun,turn,ice}
 #    ;natpinhole={yes, no}  # default: no

--- a/modules/account/account.c
+++ b/modules/account/account.c
@@ -63,6 +63,7 @@ static int account_write_template(const char *file)
 			 "#    ;auth_pass=password\n"
 			 "#    ;call_transfer=no\n"
 			 "#    ;cert=cert.pem\n"
+			 "#    ;cuser_ua={yes, no}  # default: yes\n"
 			 "#    ;mediaenc={srtp,srtp-mand,srtp-mandf"
 			 ",dtls_srtp,zrtp}\n"
 			 "#    ;medianat={stun,turn,ice}\n"

--- a/src/account.c
+++ b/src/account.c
@@ -512,6 +512,9 @@ static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 
 	err |= param_dstr(&acc->regq, &aor->params, "regq");
 
+	acc->cuser_ua = true;
+	err |= param_bool(&acc->cuser_ua, &aor->params, "cuser_ua");
+
 	for (i=0; i<RE_ARRAY_SIZE(acc->outboundv); i++) {
 
 		char expr[16] = "outbound";
@@ -2068,6 +2071,8 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 	err |= re_hprintf(pf, " regint:       %u\n", acc->regint);
 	err |= re_hprintf(pf, " prio:         %u\n", acc->prio);
 	err |= re_hprintf(pf, " pubint:       %u\n", acc->pubint);
+	err |= re_hprintf(pf, " cuser_ua:     %s\n",
+			  acc->cuser_ua ? "yes" : "no");
 	err |= re_hprintf(pf, " regq:         %s\n", acc->regq);
 	err |= re_hprintf(pf, " inreq_allowed:%s\n",
 			  inreq_mode_str(acc->inreq_mode));

--- a/src/core.h
+++ b/src/core.h
@@ -73,6 +73,7 @@ struct account {
 	uint32_t pubint;             /**< Publication interval in [seconds]  */
 	uint32_t prio;               /**< Prio for serial registration       */
 	uint16_t tcpsrcport;         /**< TCP source port for SIP            */
+	bool cuser_ua;               /**< Added UA pointer to contact user   */
 	char *regq;                  /**< Registration Q-value               */
 	char *sipnat;                /**< SIP Nat mechanism                  */
 	char *stun_user;             /**< STUN Username                      */

--- a/src/ua.c
+++ b/src/ua.c
@@ -1206,7 +1206,7 @@ int ua_alloc(struct ua **uap, const char *aor)
 		goto out;
 
 
-	if (ua->acc->cuser_ua && list_count(uag_list()) > 0) {
+	if (ua->acc->cuser_ua) {
 		/* generate a unique contact-user, this is needed to route
 		   incoming requests when using multiple useragents */
 		err = re_sdprintf(&ua->cuser, "%r-%z", &ua->acc->luri.user,

--- a/src/ua.c
+++ b/src/ua.c
@@ -1206,11 +1206,11 @@ int ua_alloc(struct ua **uap, const char *aor)
 		goto out;
 
 
-	if (ua->acc->cuser_ua) {
+	if (ua->acc->cuser_ua && list_count(uag_list()) > 0) {
 		/* generate a unique contact-user, this is needed to route
 		   incoming requests when using multiple useragents */
-		err = re_sdprintf(&ua->cuser, "%r-%p", &ua->acc->luri.user,
-				  ua);
+		err = re_sdprintf(&ua->cuser, "%r-%z", &ua->acc->luri.user,
+				  list_count(uag_list()) + 1);
 	}
 	else {
 		err = re_sdprintf(&ua->cuser, "%r", &ua->acc->luri.user);

--- a/src/ua.c
+++ b/src/ua.c
@@ -1206,9 +1206,16 @@ int ua_alloc(struct ua **uap, const char *aor)
 		goto out;
 
 
-	/* generate a unique contact-user, this is needed to route
-	   incoming requests when using multiple useragents */
-	err = re_sdprintf(&ua->cuser, "%r-%p", &ua->acc->luri.user, ua);
+	if (ua->acc->cuser_ua) {
+		/* generate a unique contact-user, this is needed to route
+		   incoming requests when using multiple useragents */
+		err = re_sdprintf(&ua->cuser, "%r-%p", &ua->acc->luri.user,
+				  ua);
+	}
+	else {
+		err = re_sdprintf(&ua->cuser, "%r", &ua->acc->luri.user);
+	}
+
 	if (err)
 		goto out;
 

--- a/src/uag.c
+++ b/src/uag.c
@@ -906,6 +906,10 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 	cuser = &msg->uri.user;
 	for (le = uag.ual.head; le; le = le->next) {
 		struct ua *ua = le->data;
+		struct account *acc = ua_account(ua);
+
+		if (!acc->regint && !acc->cuser_ua)
+			continue;
 
 		if (0 == pl_strcasecmp(cuser, ua_local_cuser(ua))) {
 			ua_printf(ua, "selected for %r\n", cuser);


### PR DESCRIPTION
Discussion: https://github.com/baresip/baresip/discussions/3149

- **account,ua: add flag cuser_ua for unique contact user**

    A new accounts flag `cuser_ua` (by default true) can be used to disable
    the UA pointer suffix for the contact user. The suffix makes the contact
    user unique and thus the UA selection for incoming SIP requests stable
    against chosing the wrong, if there are multiple accounts with equal AOR
    users at different registrars.

```
alice@iptel.org
alice@sipgate.com
``` 
 This setting fixes registration issues on a Siemens HIpath and 1und1.de (see https://github.com/baresip/baresip/discussions/3149)

```
<sip:alice@1und1.de>;cuser_ua=no
```

- **uag: rework for cuser_ua is false**

    The first loop in `uag_find_msg()` compares only the contact user which
    works only reliable if the contact user is unique. For `cuser_ua==false` the
    second loop uses better checks.
