### PR TITLE
play: set audio path to config

### DIFF
--- a/src/play.c
+++ b/src/play.c
@@ -41,7 +41,6 @@ struct play {
 #ifndef PREFIX
 #define PREFIX "/usr"
 #endif
-static const char default_play_path[FS_PATH_MAX] = PREFIX "/share/baresip";
 
 
 struct player {
@@ -660,8 +659,8 @@ int play_init(struct player **playerp)
 
 	list_init(&player->playl);
 
-	str_ncpy(player->play_path, default_play_path,
-		 sizeof(player->play_path));
+	str_ncpy(player->play_path, conf_config()->audio.audio_path,
+			sizeof(player->play_path));
 
 	*playerp = player;
 


### PR DESCRIPTION
The audio path for baresip_player() was never set to the existing config
setting.
