### PR TITLE
g722: add libg722 as alternative to avoid spandsp dependency

### DIFF
--- a/cmake/FindLIBG722.cmake
+++ b/cmake/FindLIBG722.cmake
@@ -1,0 +1,40 @@
+# First try to use the CMake variables set by contrib.mk
+if(DEFINED G722_INCLUDE_DIR AND DEFINED G722_LIBRARY)
+  set(LIBG722_INCLUDE_DIR ${G722_INCLUDE_DIR})
+  set(LIBG722_LIBRARY ${G722_LIBRARY})
+  set(LIBG722_FOUND TRUE)
+else()
+  # Fallback to searching in standard locations
+  find_path(LIBG722_INCLUDE_DIR
+    NAME g722_codec.h
+    HINTS
+      "${LIBG722_INCLUDE_DIRS}"
+      "${LIBG722_HINTS}/include"
+    PATHS /usr/local/include /usr/include
+  )
+
+  find_library(LIBG722_LIBRARY
+    NAME g722
+    HINTS
+      "${LIBG722_LIBRARY_DIRS}"
+      "${LIBG722_HINTS}/lib"
+    PATHS /usr/local/lib /usr/lib
+  )
+endif()
+
+# Only use find_package_handle_standard_args if we haven't already found the library
+if(NOT DEFINED LIBG722_FOUND)
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(LIBG722 DEFAULT_MSG LIBG722_LIBRARY
+      LIBG722_INCLUDE_DIR)
+endif()
+
+if(LIBG722_FOUND)
+  set( LIBG722_INCLUDE_DIRS ${LIBG722_INCLUDE_DIR} )
+  set( LIBG722_LIBRARIES ${LIBG722_LIBRARY} )
+else()
+  set( LIBG722_INCLUDE_DIRS )
+  set( LIBG722_LIBRARIES )
+endif()
+
+mark_as_advanced( LIBG722_LIBRARIES LIBG722_INCLUDE_DIRS )

--- a/modules/g722/CMakeLists.txt
+++ b/modules/g722/CMakeLists.txt
@@ -1,8 +1,14 @@
 project(g722)
 
+# Try to find SPANDSP first (preferred)
 find_package(SPANDSP)
 
-if(NOT SPANDSP_FOUND)
+# Try to find libg722 as fallback
+find_package(LIBG722)
+
+# Check if at least one library is available
+if(NOT SPANDSP_FOUND AND NOT LIBG722_FOUND)
+  message(WARNING "g722: neither SPANDSP nor libg722 found - module will not be built")
   return()
 endif()
 
@@ -17,6 +23,18 @@ else()
     add_library(${PROJECT_NAME} MODULE ${SRCS})
 endif()
 
-target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
-    ${SPANDSP_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${SPANDSP_LIBRARIES})
+# Set preprocessor definitions to indicate which library is being used
+# SPANDSP takes precedence if both are available
+if(SPANDSP_FOUND)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_SPANDSP=1)
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+        ${SPANDSP_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${SPANDSP_LIBRARIES})
+    message(STATUS "g722: using SPANDSP library")
+elseif(LIBG722_FOUND)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE USE_LIBG722=1)
+    target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+        ${LIBG722_INCLUDE_DIRS})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBG722_LIBRARIES})
+    message(STATUS "g722: using libg722 library")
+endif()


### PR DESCRIPTION
This PR adds support for using **libg722** as an alternative G.722 codec backend in addition to the existing g722 implementation which depends on spandsp.

### Key changes

- Added `FindLIBG722.cmake` to locate the library and headers.
- Updated `modules/g722/CMakeLists.txt` to:
    - Prefer SPANDSP if available, but fall back to libg722 if not.
    - Allow building the G.722 module without a SPANDSP dependency.
- Modified `modules/g722/g722.c` to:
    - Support both SPANDSP and libg722 APIs.
    - Add runtime and compile-time selection of the codec backend.
    - Implement proper resource cleanup for libg722.

### Motivation

SPANDSP is licensed under LGPL, which complicates static linking (e.g., for iOS App Store submissions).  
libg722 is in the public domain, making it a lightweight and license-friendly alternative.

This change enables developers to:
- Avoid LGPL restrictions where necessary.
- Build baresip with G.722 support even without SPANDSP installed.

### References
- Discussion: https://github.com/baresip/baresip/discussions/3465
- Related past issue: https://github.com/baresip/baresip/issues/350
- libg722 repository: https://github.com/sippy/libg722