### PR TITLE
ua: avoid duplicates of URI params

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -1302,7 +1302,7 @@ int ua_update_account(struct ua *ua)
  *
  * @return 0 if success, otherwise errorcode
  */
-static int mbuf_append_params(struct mbuf *mb, struct pl *params)
+static int mbuf_append_params(struct mbuf *mb, const struct pl *params)
 {
 	if (!mb || !params)
 		return EINVAL;

--- a/src/ua.c
+++ b/src/ua.c
@@ -1347,7 +1347,7 @@ static int append_params(struct mbuf *mb, struct pl *params)
 out:
 	mem_deref(str);
 	mem_deref(buf);
-	return 0;
+	return err;
 }
 
 


### PR DESCRIPTION
If the dial URI was `sip:b@127.0.0.1:54940;transport=udp` and the account AOR
URI contains `;transport=tcp`, then the result was
```
sip:b@127.0.0.1:54940;transport=udp;transport=tcp
```

This commit fixes the already existing helper function `append_params()`.