### PR TITLE
jbuf: wish size is given in #packets

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1575,7 +1575,6 @@ int  jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem);
 void jbuf_flush(struct jbuf *jb);
 int  jbuf_stats(const struct jbuf *jb, struct jbuf_stat *jstat);
 int  jbuf_debug(struct re_printf *pf, const struct jbuf *jb);
-uint32_t jbuf_frames(const struct jbuf *jb);
 uint32_t jbuf_packets(const struct jbuf *jb);
 
 

--- a/src/jbuf.c
+++ b/src/jbuf.c
@@ -38,7 +38,7 @@ enum {
 };
 
 
-/** Defines a packet frame */
+/** Defines a packet */
 struct packet {
 	struct le le;           /**< Linked list element       */
 	struct rtp_header hdr;  /**< RTP Header                */
@@ -58,11 +58,11 @@ struct jbuf {
 	struct list packetl; /**< List of buffered packets                   */
 	uint32_t n;          /**< [# packets] Current # of packets in buffer */
 	uint32_t nf;         /**< [# frames] Current # of frames in buffer   */
-	uint32_t min;        /**< [# frames] Minimum # of frames to buffer   */
-	uint32_t max;        /**< [# frames] Maximum # of frames to buffer   */
-	uint32_t wish;       /**< [# frames] Wish size for adaptive mode     */
+	uint32_t min;        /**< [# packets] Minimum # of packets to buffer */
+	uint32_t max;        /**< [# packets] Maximum # of packets to buffer */
+	uint32_t wish;       /**< [# packets] Wish size for adaptive mode    */
 	uint16_t seq_put;    /**< Sequence number for last jbuf_put()        */
-	uint16_t seq_get;    /**< Sequence number of last played frame       */
+	uint16_t seq_get;    /**< Sequence number of last played             */
 	uint32_t ssrc;       /**< Previous ssrc                              */
 	uint64_t tr;         /**< Time of previous jbuf_put()                */
 	int pt;              /**< Payload type                               */
@@ -93,14 +93,13 @@ static void plot_jbuf(struct jbuf *jb, uint64_t tr)
 
 	treal = (uint32_t) (tr - jb->tr00);
 	re_snprintf(jb->buf, sizeof(jb->buf),
-		    "%s, 0x%p, %u, %u, %u, %u, %u",
+		    "%s, 0x%p, %u, %u, %u, %u",
 			__func__,               /* row 1  - grep */
 			jb,                     /* row 2  - grep optional */
 			treal,                  /* row 3  - plot x-axis */
 			rdiff,                  /* row 4  - plot */
 			jb->wish,               /* row 5  - plot */
-			jb->n,                  /* row 6  - plot */
-			jb->nf);                /* row 7  - plot */
+			jb->n);                 /* row 6  - plot */
 	re_trace_event("jbuf", "plot", 'P', NULL, 0, RE_TRACE_ARG_STRING_COPY,
 		       "line", jb->buf);
 }
@@ -134,7 +133,7 @@ static void plot_jbuf_event(struct jbuf *jb, char ph)
 
 
 /**
- * Get a frame from the pool
+ * Get a packet from the pool
  */
 static void packet_alloc(struct jbuf *jb, struct packet **f)
 {
@@ -148,16 +147,16 @@ static void packet_alloc(struct jbuf *jb, struct packet **f)
 	else {
 		struct packet *f0;
 
-		/* Steal an old frame */
+		/* Steal an old packet */
 		le = jb->packetl.head;
 		f0 = le->data;
 
 #if JBUF_STAT
 		STAT_INC(n_overflow);
-		DEBUG_WARNING("drop 1 old frame seq=%u (total dropped %u)\n",
+		DEBUG_WARNING("drop 1 old packet seq=%u (total dropped %u)\n",
 			   f0->hdr.seq, jb->stat.n_overflow);
 #else
-		DEBUG_WARNING("drop 1 old frame seq=%u\n", f0->hdr.seq);
+		DEBUG_WARNING("drop 1 old packet seq=%u\n", f0->hdr.seq);
 #endif
 
 		if (le->next) {
@@ -197,6 +196,9 @@ static void jbuf_destructor(void *data)
 	/* Free all packets in the pool list */
 	list_flush(&jb->pooll);
 	mem_deref(jb->lock);
+#ifdef RE_JBUF_TRACE
+	(void)re_trace_close();
+#endif
 }
 
 
@@ -204,7 +206,7 @@ static void jbuf_destructor(void *data)
  * Allocate a new jitter buffer
  *
  * @param jbp    Pointer to returned jitter buffer
- * @param min    Minimum delay in [frames]
+ * @param min    Minimum delay in [packets]
  * @param max    Maximum delay in [packets]
  *
  * @return 0 if success, otherwise errorcode
@@ -238,7 +240,7 @@ int jbuf_alloc(struct jbuf **jbp, uint32_t min, uint32_t max)
 	jb->wish = min;
 	tmr_init(&jb->tmr);
 
-	DEBUG_INFO("alloc: delay=%u-%u frames/packets\n", min, max);
+	DEBUG_INFO("alloc: delay=%u-%u [packets]\n", min, max);
 
 	jb->pt = -1;
 	err = mutex_alloc(&jb->lock);
@@ -258,6 +260,10 @@ int jbuf_alloc(struct jbuf **jbp, uint32_t min, uint32_t max)
 		list_append(&jb->pooll, &f->le, f);
 		DEBUG_INFO("alloc: adding to pool list %u\n", i);
 	}
+
+#ifdef RE_JBUF_TRACE
+	(void)re_trace_init("jbuf.json");
+#endif
 
 out:
 	if (err)
@@ -322,7 +328,6 @@ static void calc_rdiff(struct jbuf *jb, uint16_t seq)
 	int32_t rdiff;
 	int32_t adiff;
 	int32_t s;                         /**< EMA coefficient              */
-	float ratio = 1.0;                 /**< Frame packet ratio           */
 	uint32_t wish;
 	uint32_t max = jb->max;
 	bool down = false;
@@ -333,19 +338,12 @@ static void calc_rdiff(struct jbuf *jb, uint16_t seq)
 	if (!jb->seq_get)
 		return;
 
-	if (jb->nf) {
-		ratio = (float)jb->n / (float)jb->nf;
-		max   = (uint32_t)(max / ratio);
-	}
-
 	rdiff = (int16_t)(jb->seq_put + 1 - seq);
 	adiff = abs(rdiff * JBUF_RDIFF_EMA_COEFF);
-	s = adiff > jb->rdiff ? JBUF_RDIFF_UP_SPEED :
-		jb->wish > 2  ? 1 :
-		jb->wish > 1  ? 2 : 3;
+	s = adiff > jb->rdiff ? JBUF_RDIFF_UP_SPEED : 1;
 	jb->rdiff += (adiff - jb->rdiff) * s / JBUF_RDIFF_EMA_COEFF;
 
-	wish = (uint32_t)(jb->rdiff / (float)JBUF_RDIFF_EMA_COEFF / ratio);
+	wish = (uint32_t)(jb->rdiff / (float)JBUF_RDIFF_EMA_COEFF);
 	if (wish < jb->min)
 		wish = jb->min;
 
@@ -357,7 +355,8 @@ static void calc_rdiff(struct jbuf *jb, uint16_t seq)
 		jb->wish = wish;
 	}
 	else if (wish < jb->wish) {
-		uint32_t dt = wish + 1 == jb->wish ? 6000 : 1000;
+		uint32_t dt = wish + 1 == jb->wish ? 6000 :
+			      wish < jb->wish / 2  ? 100 : 1000;
 		if (!tmr_isrunning(&jb->tmr) || tmr_get_expire(&jb->tmr) > dt)
 			tmr_start(&jb->tmr, dt, wish_down, jb);
 
@@ -398,11 +397,9 @@ static inline void send_gnack(struct jbuf *jb, uint16_t last_seq,
 int jbuf_put(struct jbuf *jb, const struct rtp_header *hdr, void *mem)
 {
 	struct packet *f;
-	struct packet *fc;
 	struct le *le, *tail;
 	uint16_t seq;
 	uint64_t tr, dt;
-	bool equal;
 	int err = 0;
 
 	if (!jb || !hdr)
@@ -517,20 +514,6 @@ success:
 	f->hdr = *hdr;
 	f->mem = mem_ref(mem);
 
-	equal = false;
-	if (f->le.prev) {
-		fc = f->le.prev->data;
-		equal = (fc->hdr.ts == f->hdr.ts);
-	}
-
-	if (!equal && f->le.next) {
-		fc = f->le.next->data;
-		equal = (fc->hdr.ts == f->hdr.ts);
-	}
-
-	if (!equal)
-		++jb->nf;
-
 out:
 #ifdef RE_JBUF_TRACE
 	plot_jbuf(jb, tr);
@@ -561,7 +544,7 @@ int jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	mtx_lock(jb->lock);
 	STAT_INC(n_get);
 
-	if (jb->nf <= jb->wish || !jb->packetl.head) {
+	if (jb->n <= jb->wish || !jb->packetl.head) {
 		DEBUG_INFO("not enough buffer packets - wait.. "
 			   "(n=%u wish=%u)\n", jb->n, jb->wish);
 		STAT_INC(n_underflow);
@@ -598,25 +581,9 @@ int jbuf_get(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	*hdr = f->hdr;
 	*mem = mem_ref(f->mem);
 
-	/* decrease not equal frames */
-	if (f->le.next) {
-		struct packet *next_f = f->le.next->data;
-
-		if (f->hdr.ts != next_f->hdr.ts)
-			--jb->nf;
-	}
-	else {
-		--jb->nf;
-	}
-
 	packet_deref(jb, f);
-
-	if (jb->nf > jb->wish) {
-		DEBUG_INFO("reducing jitter buffer "
-			   "(nf=%u min=%u wish=%u max=%u)\n",
-			   jb->nf, jb->min, jb->wish, jb->max);
+	if (jb->packetl.head && jb->n > jb->wish)
 		err = EAGAIN;
-	}
 
 out:
 	mtx_unlock(jb->lock);
@@ -659,17 +626,6 @@ int jbuf_drain(struct jbuf *jb, struct rtp_header *hdr, void **mem)
 	*hdr = f->hdr;
 	*mem = mem_ref(f->mem);
 
-	/* decrease not equal frames */
-	if (f->le.next) {
-		struct packet *next_f = f->le.next->data;
-
-		if (f->hdr.ts != next_f->hdr.ts)
-			--jb->nf;
-	}
-	else {
-		--jb->nf;
-	}
-
 	packet_deref(jb, f);
 
 out:
@@ -678,7 +634,7 @@ out:
 }
 
 /**
- * Flush all frames in the jitter buffer
+ * Flush all packets in the jitter buffer
  *
  * @param jb   Jitter buffer
  */
@@ -694,19 +650,18 @@ void jbuf_flush(struct jbuf *jb)
 
 	mtx_lock(jb->lock);
 	if (jb->packetl.head) {
-		DEBUG_INFO("flush: %u frames\n", jb->n);
+		DEBUG_INFO("flush: %u packets\n", jb->n);
 	}
 
-	/* put all buffered frames back in free list */
+	/* put all buffered packets back in free list */
 	for (le = jb->packetl.head; le; le = jb->packetl.head) {
-		DEBUG_INFO(" flush frame: seq=%u\n",
+		DEBUG_INFO(" flush packet: seq=%u\n",
 			   ((struct packet *)(le->data))->hdr.seq);
 
 		packet_deref(jb, le->data);
 	}
 
 	jb->n       = 0;
-	jb->nf      = 0;
 	jb->running = false;
 
 	jb->seq_get = 0;
@@ -734,26 +689,6 @@ uint32_t jbuf_packets(const struct jbuf *jb)
 
 	mtx_lock(jb->lock);
 	uint32_t n = jb->n;
-	mtx_unlock(jb->lock);
-
-	return n;
-}
-
-
-/**
- * Get number of current frames
- *
- * @param jb Jitter buffer
- *
- * @return number of frames
- */
-uint32_t jbuf_frames(const struct jbuf *jb)
-{
-	if (!jb)
-		return 0;
-
-	mtx_lock(jb->lock);
-	uint32_t n = jb->nf;
 	mtx_unlock(jb->lock);
 
 	return n;
@@ -808,8 +743,8 @@ int jbuf_debug(struct re_printf *pf, const struct jbuf *jb)
 
 	mtx_lock(jb->lock);
 	err |= mbuf_printf(mb, " running=%d", jb->running);
-	err |= mbuf_printf(mb, " min=%u cur=%u/%u max=%u [frames/packets]\n",
-			  jb->min, jb->nf, jb->n, jb->max);
+	err |= mbuf_printf(mb, " min=%u cur=%u max=%u [packets]\n",
+			  jb->min, jb->n, jb->max);
 	err |= mbuf_printf(mb, " seq_put=%u\n", jb->seq_put);
 
 #if JBUF_STAT

--- a/test/jbuf.c
+++ b/test/jbuf.c
@@ -268,35 +268,30 @@ int test_jbuf_adaptive_video(void)
 	hdr.ts = 100;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(1, jbuf_packets(jb));
 
 	hdr.seq = 2;
 	hdr.ts = 100; /* Same frame */
 	err = jbuf_put(jb, &hdr, frv[1]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(2, jbuf_packets(jb));
 
 	hdr.seq = 4;
 	hdr.ts = 200;
 	err = jbuf_put(jb, &hdr, frv[2]);
 	TEST_ERR(err);
-	ASSERT_EQ(2, jbuf_frames(jb));
 	ASSERT_EQ(3, jbuf_packets(jb));
 
 	hdr.seq = 3; /* unordered late packet */
 	hdr.ts = 200;
 	err = jbuf_put(jb, &hdr, frv[3]);
 	TEST_ERR(err);
-	ASSERT_EQ(2, jbuf_frames(jb));
 	ASSERT_EQ(4, jbuf_packets(jb));
 
 	hdr.seq = 5;
 	hdr.ts = 300;
 	err = jbuf_put(jb, &hdr, frv[4]);
 	TEST_ERR(err);
-	ASSERT_EQ(3, jbuf_frames(jb));
 	ASSERT_EQ(5, jbuf_packets(jb));
 
 	/* --- Test late packet, unique frame --- */
@@ -306,28 +301,24 @@ int test_jbuf_adaptive_video(void)
 	hdr.ts = 100;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(1, jbuf_packets(jb));
 
 	hdr.seq = 2;
 	hdr.ts = 100; /* Same frame */
 	err = jbuf_put(jb, &hdr, frv[1]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(2, jbuf_packets(jb));
 
 	hdr.seq = 4;
 	hdr.ts = 300;
 	err = jbuf_put(jb, &hdr, frv[2]);
 	TEST_ERR(err);
-	ASSERT_EQ(2, jbuf_frames(jb));
 	ASSERT_EQ(3, jbuf_packets(jb));
 
 	hdr.seq = 3; /* unordered late packet */
 	hdr.ts = 200;
 	err = jbuf_put(jb, &hdr, frv[3]);
 	TEST_ERR(err);
-	ASSERT_EQ(3, jbuf_frames(jb));
 	ASSERT_EQ(4, jbuf_packets(jb));
 
 	/* --- Test lost get --- */
@@ -337,14 +328,12 @@ int test_jbuf_adaptive_video(void)
 	hdr.ts = 100;
 	err = jbuf_put(jb, &hdr, frv[0]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(1, jbuf_packets(jb));
 
 	hdr.seq = 2;
 	hdr.ts = 100; /* Same frame */
 	err = jbuf_put(jb, &hdr, frv[1]);
 	TEST_ERR(err);
-	ASSERT_EQ(1, jbuf_frames(jb));
 	ASSERT_EQ(2, jbuf_packets(jb));
 
 	/* LOST hdr.seq = 3; */
@@ -353,26 +342,22 @@ int test_jbuf_adaptive_video(void)
 	hdr.ts = 200;
 	err = jbuf_put(jb, &hdr, frv[2]);
 	TEST_ERR(err);
-	ASSERT_EQ(2, jbuf_frames(jb));
 	ASSERT_EQ(3, jbuf_packets(jb));
 
 	hdr.seq = 5;
 	hdr.ts = 300;
 	err = jbuf_put(jb, &hdr, frv[3]);
 	TEST_ERR(err);
-	ASSERT_EQ(3, jbuf_frames(jb));
 	ASSERT_EQ(4, jbuf_packets(jb));
 
 	err = jbuf_get(jb, &hdr2, &mem);
 	ASSERT_EQ(EAGAIN, err);
 	mem = mem_deref(mem);
-	ASSERT_EQ(3, jbuf_frames(jb));
 	ASSERT_EQ(3, jbuf_packets(jb));
 
 	err = jbuf_get(jb, &hdr2, &mem);
 	ASSERT_EQ(EAGAIN, err);
 	mem = mem_deref(mem);
-	ASSERT_EQ(2, jbuf_frames(jb));
 	ASSERT_EQ(2, jbuf_packets(jb));
 
 	err = 0;


### PR DESCRIPTION
The wish size for the adaptive mode depends on how much the packets are re-
ordered. It can only be measured by looking on the sequence number of the RTP
header and how much it jumps around because of re-ordered packets. Counting
video frames is not needed and causes failures when the wish size is computed.
