### PR TITLE
gst: fix crash on shutdown

### DIFF
--- a/modules/gst/gst.c
+++ b/modules/gst/gst.c
@@ -574,7 +574,6 @@ static int mod_gst_init(void)
 static int mod_gst_close(void)
 {
 	ausrc = mem_deref(ausrc);
-	gst_deinit();
 	return 0;
 }
 


### PR DESCRIPTION
This fixes crash of gst_deinit() when gst module is loaded, not used and
baresip is shutdown.

The Doxygen of gst_deinit() tells that it is not needed to call this function.
It can lead to crashes. E.g. if gstreamer is used also in other modules.

It is no problem to call gst_init() multiple times. But calling
gst_deinit() more than once is not allowed. On the other hand, gstreamer does
its de-initialization automatically when the program terminates.
