### PR TITLE
core: set bundle rtpext before aulevel

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -775,18 +775,6 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	if (err)
 		goto out;
 
-	if (cfg->audio.level && offerer) {
-
-		a->extmap_aulevel = stream_generate_extmap_id(a->strm);
-		aurecv_set_extmap(a->aur, a->extmap_aulevel);
-
-		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					  "extmap",
-					  "%u %s",
-					  a->extmap_aulevel, uri_aulevel);
-		if (err)
-			goto out;
-	}
 
 	tx->mb = mbuf_alloc(STREAM_PRESZ + 4096);
 	tx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(tx->enc_fmt),
@@ -859,6 +847,21 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 		*ap = a;
 
 	return err;
+}
+
+
+int audio_enable_level(struct audio *au)
+{
+	if (!au)
+		return EINVAL;
+
+	au->extmap_aulevel = stream_generate_extmap_id(au->strm);
+	aurecv_set_extmap(au->aur, au->extmap_aulevel);
+
+	return sdp_media_set_lattr(stream_sdpmedia(au->strm), false,
+				   "extmap",
+				   "%u %s",
+				   au->extmap_aulevel, uri_aulevel);
 }
 
 

--- a/src/call.c
+++ b/src/call.c
@@ -792,6 +792,12 @@ int call_streams_alloc(struct call *call)
 			return err;
 	}
 
+	if (call->cfg->audio.level && !call->got_offer) {
+		err = audio_enable_level(call->audio);
+		if (err)
+			return err;
+	}
+
 	return 0;
 }
 

--- a/src/core.h
+++ b/src/core.h
@@ -110,6 +110,7 @@ struct audio;
 
 int  audio_send_digit(struct audio *a, char key);
 void audio_sdp_attr_decode(struct audio *a);
+int  audio_enable_level(struct audio *au);
 
 
 /*


### PR DESCRIPTION
The extmap ID of the Bundle extension (a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid)
should be the same for all bundled streams (e.g. audio, video).

This PR swaps the order of "bundle" id and "aulevel" id so that Bundle is the first one.

Thanks to Richard Fuchs for reporting.

fixes #3496
