### PR TITLE
test: add test_uag_find_msg()

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -9,6 +9,7 @@
 #include <rem.h>
 #include <baresip.h>
 #include "test.h"
+#include "sip/sipsrv.h"
 #include "../src/core.h"  /* NOTE: temp */
 
 
@@ -3815,3 +3816,103 @@ out:
 	return err;
 }
 #endif
+
+
+static void sip_server_exit_handler(void *arg)
+{
+	(void)arg;
+	re_cancel();
+}
+
+
+int test_call_uag_find_msg(void)
+{
+	struct fixture fix, *f = &fix;
+	struct sip_server *srv1 = NULL;
+	struct sip_server *srv2 = NULL;
+	struct sa sa1;
+	struct sa sa2;
+	char *aor=NULL;
+	char *curi=NULL;
+	struct cancel_rule *cr;
+	int err = 0;
+
+	fixture_init(f);
+
+	err = sip_server_alloc(&srv1, sip_server_exit_handler, NULL);
+	TEST_ERR(err);
+
+	err = sip_server_alloc(&srv2, sip_server_exit_handler, NULL);
+	TEST_ERR(err);
+
+	err = sip_transp_laddr(srv1->sip, &sa1, SIP_TRANSP_UDP, NULL);
+	TEST_ERR(err);
+
+	err = sip_transp_laddr(srv2->sip, &sa2, SIP_TRANSP_UDP, NULL);
+	TEST_ERR(err);
+
+	mem_deref(f->a.ua);
+	mem_deref(f->b.ua);
+	mem_deref(f->c.ua);
+
+	err = re_sdprintf(&aor, "A <sip:alice@%J>;regint=60", &sa1);
+	TEST_ERR(err);
+	err = ua_alloc(&f->a.ua, aor);
+	TEST_ERR(err);
+	aor = mem_deref(aor);
+	err = re_sdprintf(&aor, "B <sip:alice@%J>;regint=60", &sa2);
+	TEST_ERR(err);
+	err = ua_alloc(&f->b.ua, aor);
+	TEST_ERR(err);
+	aor = mem_deref(aor);
+	err = re_sdprintf(&aor, "C <sip:bob@%J>;regint=60", &sa2);
+	TEST_ERR(err);
+	err = ua_alloc(&f->c.ua, aor);
+	TEST_ERR(err);
+
+	err = ua_register(f->a.ua);
+	TEST_ERR(err);
+	err = ua_register(f->b.ua);
+	TEST_ERR(err);
+	err = ua_register(f->c.ua);
+	TEST_ERR(err);
+
+	cancel_rule_new(BEVENT_REGISTER_OK, f->a.ua, 0, 0, 0);
+	cancel_rule_and(BEVENT_REGISTER_OK, f->b.ua, 0, 0, 0);
+	cancel_rule_and(BEVENT_REGISTER_OK, f->c.ua, 0, 0, 0);
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+
+	cancel_rule_pop();
+
+	f->b.peer = &f->c;
+	f->c.peer = &f->b;
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	cancel_rule_new(BEVENT_CALL_ESTABLISHED, f->c.ua, 0, 0, 1);
+	cancel_rule_and(BEVENT_CALL_ESTABLISHED, f->b.ua, 1, 0, 1);
+
+	err = re_sdprintf(&curi, "sip:alice@%J", &sa2);
+	TEST_ERR(err);
+	err = ua_connect(f->c.ua, 0, NULL, curi, VIDMODE_OFF);
+	TEST_ERR(err);
+
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	/* verify that the right UA was selected and got established call */
+	ASSERT_EQ(0, fix.a.n_incoming);
+	ASSERT_EQ(0, fix.a.n_established);
+	ASSERT_EQ(1, fix.b.n_incoming);
+	ASSERT_EQ(1, fix.b.n_established);
+
+ out:
+	mem_deref(aor);
+	mem_deref(srv1);
+	mem_deref(srv2);
+	fixture_close(f);
+	mem_deref(curi);
+
+	return err;
+}

--- a/test/main.c
+++ b/test/main.c
@@ -54,6 +54,7 @@ static const struct test tests[] = {
 	TEST(test_call_100rel_video),
 	TEST(test_call_hold_resume),
 	TEST(test_call_srtp_tx_rekey),
+	TEST(test_call_uag_find_msg),
 #ifdef USE_TLS
 	TEST(test_call_sni),
 	TEST(test_call_cert_select),

--- a/test/test.h
+++ b/test/test.h
@@ -228,6 +228,7 @@ int test_call_100rel_audio(void);
 int test_call_100rel_video(void);
 int test_call_hold_resume(void);
 int test_call_srtp_tx_rekey(void);
+int test_call_uag_find_msg(void);
 #ifdef USE_TLS
 int test_call_sni(void);
 int test_call_cert_select(void);


### PR DESCRIPTION
This PR adds stateless proxy to test/sip/sipsrv that up to now only had
registrar features.

Futher adds positive and negative test for UA selection. Thus it is also tested
if - so called - spam calls are rejected.

- **test: sipsrv - SIP message forwarding**
- **test: call - add test_call_uag_find_msg()**
- **test: registered UA rejects peer-to-peer calls**
