### PR TITLE
video: find new encoder if not available

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -1585,12 +1585,12 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 	vtx = &v->vtx;
 
 	if (!vc->encupdh) {
-		struct list *vidcodecl = vc->le.list;
-		struct vidcodec *vcd;
-
 		info("video: vidcodec '%s' has no encoder\n", vc->name);
 
-		vcd = (struct vidcodec *)vidcodec_find_encoder(vidcodecl,
+		struct list *vidcodecl = vc->le.list;
+
+		struct vidcodec *vcd =
+			(struct vidcodec *)vidcodec_find_encoder(vidcodecl,
 							       vc->name);
 		if (!vcd) {
 			warning("video: could not find encoder (%s)\n",


### PR DESCRIPTION
Fix an issue where video_encoder_set may encounter an unimplemented vc->encupdh.
A new vidcodec is enumerated, and if none is found, ENOENT is returned.