### PR TITLE
video: null pointer checks for codec functions

### DIFF
--- a/src/vidcodec.c
+++ b/src/vidcodec.c
@@ -90,7 +90,7 @@ const struct vidcodec *vidcodec_find_encoder(const struct list *vidcodecl,
 		if (name && 0 != str_casecmp(name, vc->name))
 			continue;
 
-		if (vc->ench)
+		if (vc->ench && vc->encupdh)
 			return vc;
 	}
 
@@ -118,7 +118,7 @@ const struct vidcodec *vidcodec_find_decoder(const struct list *vidcodecl,
 		if (name && 0 != str_casecmp(name, vc->name))
 			continue;
 
-		if (vc->dech)
+		if (vc->dech && vc->decupdh)
 			return vc;
 	}
 

--- a/src/video.c
+++ b/src/video.c
@@ -1584,14 +1584,13 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 
 	vtx = &v->vtx;
 
-	if (!vc->encupdh) {
+	if (!vc->encupdh || !vc->ench) {
 		info("video: vidcodec '%s' has no encoder\n", vc->name);
 
 		struct list *vidcodecl = vc->le.list;
 
-		struct vidcodec *vcd =
-			(struct vidcodec *)vidcodec_find_encoder(vidcodecl,
-							       vc->name);
+		struct vidcodec *vcd = (struct vidcodec *)
+			vidcodec_find_encoder(vidcodecl, vc->name);
 		if (!vcd) {
 			warning("video: could not find encoder (%s)\n",
 				vc->name);
@@ -1645,14 +1644,13 @@ int video_decoder_set(struct video *v, struct vidcodec *vc, int pt_rx,
 		return EINVAL;
 
 	/* handle vidcodecs without a decoder */
-	if (!vc->decupdh) {
+	if (!vc->decupdh || !vc->dech) {
 		struct list *vidcodecl = vc->le.list;
-		struct vidcodec *vcd;
 
 		info("video: vidcodec '%s' has no decoder\n", vc->name);
 
-		vcd = (struct vidcodec *)vidcodec_find_decoder(vidcodecl,
-							       vc->name);
+		struct vidcodec *vcd = (struct vidcodec *)
+			vidcodec_find_decoder(vidcodecl, vc->name);
 		if (!vcd) {
 			warning("video: could not find decoder (%s)\n",
 				vc->name);


### PR DESCRIPTION
Tiny rework on https://github.com/baresip/baresip/pull/3532

Now there will be a SEGV if `ench` is implemented but `encupdh` not.