### PR TITLE
uag: use GRUU if available for selecting UA

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -941,7 +941,7 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 		if (!acc || !acc->regint)
 			continue;
 
-		if (0 == pl_strcasecmp(cuser, ua_local_cuser(ua))) {
+		if (0 == pl_strcasecmp(cuser, ua_cuser(ua))) {
 			ua_printf(ua, "selected for %r\n", cuser);
 			return ua;
 		}


### PR DESCRIPTION
If the registrar generated a GRUU which is returned in the response to the SIP REGISTER, then following requests will use the GRUU in the Request-URI. Thus baresip needs to compare the gruu if it is set to select the right UA.

Note: We try to find relevant sections in [RFC 5627](https://www.rfc-editor.org/rfc/rfc5627) and find a test setup.
