### PR TITLE
menu, cparam: initialize stack variable, free memory

### DIFF
--- a/modules/menu/dynamic_menu.c
+++ b/modules/menu/dynamic_menu.c
@@ -356,11 +356,12 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 			"Audio & video must not be"
 			" inactive at the same time\n";
 
-	struct cparam_call *cp;
+	struct cparam_call *cp = NULL;
 	err = cparam_call_decode(&cp, carg->prm, pf);
 	if (err || !cp->mdir) {
 		(void) re_hprintf(pf, "%s", usage);
-		return EINVAL;
+		err = EINVAL;
+		goto out;
 	}
 
 	(void)pl_strdup(&cid, &cp->callid);
@@ -374,7 +375,7 @@ static int set_media_ldir(struct re_printf *pf, void *arg)
 	call_set_media_direction(call, cp->adir, cp->vdir);
 out:
 	mem_deref(cp);
-	return 0;
+	return err;
 }
 
 

--- a/src/cparam.c
+++ b/src/cparam.c
@@ -54,7 +54,7 @@ static int decode_media_dir(struct pl *pl, enum sdp_dir *dirp,
  */
 int cparam_decode(const char *prm, const char *name, struct pl *val)
 {
-	struct pl pl;
+	struct pl pl = pl_null;
 	pl_set_str(&pl, prm);
 	return fmt_param_sep_get(&pl, name, ' ', val) ? 0 : ENOENT;
 }


### PR DESCRIPTION
* Inside cparam_decode *prm may be a nullptr whenever a command is called without parameters. (e.g.: /acceptdir)
* Initialize struct pl with pl_null to avoid uninizialized variable usage in fmt_param_sep_get if *prm is nullptr.
* Fix possible memleak in dynamic_menu if *cp is allocated but cp->mdir evaluates to false