### PR TITLE
rtprecv: fix tmr_cancel decode data race

### DIFF
--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -198,6 +198,7 @@ static void rtprecv_periodic(void *arg)
 		}
 	}
 	else {
+		tmr_cancel(&rx->tmr_decode);
 		udp_thread_detach(rtp_sock(rx->rtp));
 		udp_thread_detach(rtcp_sock(rx->rtp));
 		re_cancel();
@@ -720,7 +721,6 @@ int rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx)
 static void destructor(void *arg)
 {
 	struct rtp_receiver *rx = arg;
-	tmr_cancel(&rx->tmr_decode);
 
 	if (re_atomic_rlx(&rx->run)) {
 		rtprecv_enable(rx, false);
@@ -732,6 +732,8 @@ static void destructor(void *arg)
 		udp_thread_detach(rtp_sock(rx->rtp));
 		udp_thread_detach(rtcp_sock(rx->rtp));
 	}
+
+	tmr_cancel(&rx->tmr_decode);
 
 	mem_deref(rx->metric);
 	mem_deref(rx->name);


### PR DESCRIPTION
WARNING: ThreadSanitizer: data race (pid=5539)
  Write of size 8 at 0x725800000e40 by thread T143 (mutexes: write M0, write M1):
    #0 list_insert_after re/src/list/list.c:210:12 (libre.so.40+0x685f0)
    #1 tmr_startcont_dbg re/src/tmr/tmr.c:447:4 (libre.so.40+0xa33d9)
    #2 tmr_start_dbg re/src/tmr/tmr.c:463:2 (libre.so.40+0xa2fbc)
    #3 decode_frames src/rtprecv.c:387:2 (selftest+0x1ce779)
    #4 decode_tmr src/rtprecv.c:327:2 (selftest+0x1cbabd)
    #5 tmr_poll re/src/tmr/tmr.c:160:3 (libre.so.40+0xa269b)
    #6 re_main re/src/main/main.c:1085:3 (libre.so.40+0x6a2df)
    #7 rtprecv_thread src/rtprecv.c:231:8 (selftest+0x1ce01d)
    #8 handler re/src/thread/thread.c:105:9 (libre.so.40+0xa2371)
    #9 handler re/src/thread/posix.c:21:12 (libre.so.40+0x10603b)

  Previous read of size 8 at 0x725800000e40 by main thread:
    #0 tmr_startcont_dbg re/src/tmr/tmr.c:402:30 (libre.so.40+0xa30d3)
    #1 tmr_start_dbg re/src/tmr/tmr.c:463:2 (libre.so.40+0xa2fbc)
    #2 tmr_cancel re/src/tmr/tmr.c:481:2 (libre.so.40+0xa34ec)
    #3 destructor src/rtprecv.c:723:2 (selftest+0x1cdbe4)
    #4 mem_deref re/src/mem/mem.c:373:3 (libre.so.40+0x6f321)
    #5 stream_destructor src/stream.c:141:2 (selftest+0x19fa6b)
    #6 mem_deref re/src/mem/mem.c:373:3 (libre.so.40+0x6f321)