### PR TITLE
test: cast expected and actual to int

### DIFF
--- a/test/test.h
+++ b/test/test.h
@@ -15,11 +15,11 @@
 
 #define ASSERT_EQ(expected, actual)				\
 	if ((expected) != (actual)) {				\
-		warning("selftest: ASSERT_EQ: %s:%u: %s():"	\
-			" expected=%d(0x%x), actual=%d(0x%x)\n",\
-			__FILE__, __LINE__, __func__,		\
-			(expected), (expected),			\
-			(actual), (actual));			\
+		warning("selftest: ASSERT_EQ: %s:%u: %s(): "	\
+			"expected=%ld(0x%lx), actual=%ld(0x%lx)\n",	\
+			__FILE__, __LINE__, __func__,			\
+			(long int)(expected), (long int)(expected),	\
+			(long int)(actual),   (long int)(actual));	\
 		err = EINVAL;					\
 		goto out;					\
 	}


### PR DESCRIPTION
I got this runtime error output from the warning in `ASSERT_EQ()` if `expected != actual`

https://github.com/baresip/baresip/pull/3607#issuecomment-3705311492

```
Format: "selftest: ASSERT_EQ: %s:%u: %s(): expected=%d<-- SIZE ERROR
selftest: /home/cspiel/src/re/src/fmt/print.c:501: int vhprintf(const char *, struct __va_list_tag *, re_vprintf_h *, void *, _Bool): Assertion `0 && "RE_VA_ARG: arg is not compatible"' failed.
```
@sreimers Note, the call stack printed by the `vhprintf()` Assertion seems to be wrong. See https://github.com/baresip/baresip/pull/3607#issuecomment-3705311492!