### PR TITLE
uag: uag_filter_calls() support unlink in listh

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -185,12 +185,11 @@ void uag_filter_calls(call_list_h *listh, call_match_h *matchh, void *arg)
 
 	for (leu = list_head(uag_list()); leu; leu = leu->next) {
 		struct ua *ua = leu->data;
-		struct le *lec;
-		struct le *leprev;
+		struct le *lec = list_tail(ua_calls(ua));
 
-		for (lec = list_tail(ua_calls(ua)); lec; lec = leprev) {
+		while (lec) {
 			struct call *call = lec->data;
-			leprev = lec->prev;
+			lec = lec->prev;
 
 			if (!matchh || matchh(call, arg))
 				listh(call, arg);


### PR DESCRIPTION
If in the given list handler the call is unlinked (terminated) then the `le` got invalid.
