### PR TITLE
menu: use answtmr for autoanswer

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -531,7 +531,9 @@ static int menu_autoanwser_call(struct call *call)
 		mem_deref(outgoing);
 	}
 
-	return call_answer(call, 200, VIDMODE_ON);
+	call_start_answtmr(call, 0);
+
+	return 0;
 }
 
 


### PR DESCRIPTION
The function `call_start_answtmr` correctly queues the answer in case we cannot answer yet due to an outstanding PRACK. This fixes broken autoanswers in case 100rel is used and there is an outstanding PRACK.

This is how it is used in the sip_autoanswer case and the sip_autoanswer case works.