### PR TITLE
test: disable peerconn test (ref #3645)

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -72,7 +72,7 @@ static const struct test tests[] = {
 	TEST(test_jbuf_gnack),
 	TEST(test_message),
 	TEST(test_network),
-	TEST(test_peerconn),
+	/*TEST(test_peerconn),*/
 	TEST(test_play),
 	TEST(test_stunuri),
 	TEST(test_ua_alloc),


### PR DESCRIPTION
There is a crash in test_peerconn when WiFi is disabled:

```
$ ./test/selftest -r main test_peerconn
running baresip selftest version 4.5.0 with 1 tests
get_resolv_dns: Undefined family 0
[ RUN      ] test_peerconn (rx main)
ice: set default cands failed (No such file or directory [2])
ice: gather error: No such file or directory [2] (0 )
peerconnection: medianat failed: No such file or directory [2]
ice: set default cands failed (No such file or directory [2])
ice: gather error: No such file or directory [2] (0 )
peerconnection: medianat failed: No such file or directory [2]

TEST_ERR: /Users/alfredh/git/baresip/test/peerconn.c:411: (No such file or directory [2])
mem: mem_deref: magic check failed 0x00000091 (0x1586124f0)
Trace/BPT trap: 5
```


