### PR TITLE
mixausrc: do not check ctx pointer as it is unused

### DIFF
--- a/modules/mixausrc/mixausrc.c
+++ b/modules/mixausrc/mixausrc.c
@@ -454,7 +454,7 @@ static int decode_update(struct aufilt_dec_st **stp, void **ctx,
 	(void)af;
 	(void)ctx;
 
-	if (!stp || !ctx || !prm)
+	if (!stp || !prm)
 		return EINVAL;
 
 	if (*stp)


### PR DESCRIPTION
Users of mixausrc may pass NULL as ctx pointer. ctx is unused, so a NULL check for it is not necessary.