### PR TITLE
Revert "call: do not go back to RINGING state if already in EARLY"

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2493,8 +2493,7 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	switch (msg->scode) {
 
 	case 180:
-		if (call_state(call) != CALL_STATE_EARLY)
-			set_state(call, CALL_STATE_RINGING);
+		set_state(call, CALL_STATE_RINGING);
 		break;
 
 	case 183:
@@ -2509,7 +2508,7 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
                                    call->peer_uri);
 		mem_deref(call);
 	}
-	else if (call_state(call) != CALL_STATE_EARLY) {
+	else {
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_RINGING, "%s",
                                    call->peer_uri);


### PR DESCRIPTION
Causes to never get into CALL_STATE_RINGING on some SIP providers. Therefore the ringback_aufile is never played.

This reverts commit 5699d42e508ca3a222c4550e42c114dbf08aaba3.

-----

Hi,

since that commit 5699d42e508ca3a222c4550e42c114dbf08aaba3, I noticed all my outgoing SIP calls do not play back the ringback_aufile audio. The PR might not be a final solution for you, but it will shine some light on the issue.