### PR TITLE
stream,rtprecv: harden RTP receiver teardown against races

### DIFF
--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -567,7 +567,7 @@ void rtprecv_set_socket(struct rtp_receiver *rx, struct rtp_sock *rtp)
 
 void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc)
 {
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return;
 
 	mtx_lock(rx->mtx);
@@ -589,7 +589,7 @@ void rtprecv_set_ssrc(struct rtp_receiver *rx, uint32_t ssrc)
 
 uint64_t rtprecv_ts_last(struct rtp_receiver *rx)
 {
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return 0;
 
 	uint64_t ts_last;
@@ -604,7 +604,7 @@ uint64_t rtprecv_ts_last(struct rtp_receiver *rx)
 
 void rtprecv_set_ts_last(struct rtp_receiver *rx, uint64_t ts_last)
 {
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return;
 
 	mtx_lock(rx->mtx);
@@ -624,7 +624,7 @@ void rtprecv_flush(struct rtp_receiver *rx)
 
 void rtprecv_enable(struct rtp_receiver *rx, bool enable)
 {
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return;
 
 	mtx_lock(rx->mtx);
@@ -637,7 +637,7 @@ int rtprecv_get_ssrc(struct rtp_receiver *rx, uint32_t *ssrc)
 {
 	int err;
 
-	if (!rx || !ssrc)
+	if (!rx || !ssrc || !rx->mtx)
 		return EINVAL;
 
 	mtx_lock(rx->mtx);
@@ -658,7 +658,7 @@ static bool rtprecv_consume_ssrc_change(struct rtp_receiver *rx,
 {
 	bool changed = false;
 
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return false;
 
 	mtx_lock(rx->mtx);
@@ -684,7 +684,7 @@ struct jbuf *rtprecv_jbuf(struct rtp_receiver *rx)
 
 void rtprecv_enable_mux(struct rtp_receiver *rx, bool enable)
 {
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return;
 
 	mtx_lock(rx->mtx);
@@ -706,7 +706,7 @@ int rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx)
 	int err;
 	bool enabled;
 
-	if (!rx)
+	if (!rx || !rx->mtx)
 		return 0;
 
 	mtx_lock(rx->mtx);
@@ -723,6 +723,7 @@ int rtprecv_debug(struct re_printf *pf, const struct rtp_receiver *rx)
 static void destructor(void *arg)
 {
 	struct rtp_receiver *rx = arg;
+	mtx_t *mtx = rx->mtx;
 
 	if (re_atomic_rlx(&rx->run)) {
 		rtprecv_enable(rx, false);
@@ -739,7 +740,8 @@ static void destructor(void *arg)
 
 	mem_deref(rx->metric);
 	mem_deref(rx->name);
-	mem_deref(rx->mtx);
+	rx->mtx = NULL;
+	mem_deref(mtx);
 	mem_deref(rx->jbuf);
 	mem_deref(rx->cname);
 }

--- a/src/stream.c
+++ b/src/stream.c
@@ -87,6 +87,7 @@ struct stream {
 	struct sender tx;
 
 	struct rtp_receiver *rx;
+	RE_ATOMIC bool rx_closed;
 	struct rxmain rxm;
 };
 
@@ -228,6 +229,13 @@ int stream_enable_tx(struct stream *strm, bool enable)
 static void stream_start_receiver(void *arg)
 {
 	struct stream *s = arg;
+
+	if (!s || re_atomic_rlx(&s->rx_closed) || !s->rx) {
+		if (s)
+			tmr_cancel(&s->rxm.tmr_rec);
+		return;
+	}
+
 	rtprecv_start_thread(s->rx);
 }
 
@@ -244,6 +252,9 @@ int stream_enable_rx(struct stream *strm, bool enable)
 {
 	if (!strm)
 		return EINVAL;
+
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx)
+		return 0;
 
 	if (!enable) {
 		debug("stream: disable %s RTP receiver\n",
@@ -282,10 +293,16 @@ static void stream_close(struct stream *strm, int err)
 	stream_error_h *errorh = strm->errorh;
 
 	strm->terminated = true;
+	re_atomic_rlx_set(&strm->rx_closed, true);
 	stream_enable(strm, false);
 	strm->errorh = NULL;
 
-	strm->rx = mem_deref(strm->rx);
+	tmr_cancel(&strm->rxm.tmr_rtp);
+	tmr_cancel(&strm->rxm.tmr_rec);
+	tmr_cancel(&strm->tmr_natph);
+	struct rtp_receiver *rx = strm->rx;
+	strm->rx = NULL;
+	mem_deref(rx);
 	if (errorh)
 		errorh(strm, err, strm->sess_arg);
 }
@@ -299,6 +316,11 @@ static void check_rtp_handler(void *arg)
 	int diff_ms;
 
 	MAGIC_CHECK(strm);
+
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx) {
+		tmr_cancel(&strm->rxm.tmr_rtp);
+		return;
+	}
 
 	tmr_start(&strm->rxm.tmr_rtp, RTP_CHECK_INTERVAL,
 		  check_rtp_handler, strm);
@@ -1077,6 +1099,11 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
 	if (!strm)
 		return;
 
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx) {
+		tmr_cancel(&strm->rxm.tmr_rtp);
+		return;
+	}
+
 	m = stream_sdpmedia(strm);
 	if (!sdp_media_has_media(m))
 		return;
@@ -1356,6 +1383,9 @@ static void natpinhole_handler(void *arg)
 	struct sa raddr_rtp;
 	int err = 0;
 
+	if (!strm || strm->terminated || !strm->rtp)
+		return;
+
 	sc = sdp_media_rformat(strm->sdp, NULL);
 	if (!sc)
 		return;
@@ -1364,7 +1394,6 @@ static void natpinhole_handler(void *arg)
 	if (!mb)
 		return;
 
-	tmr_start(&strm->tmr_natph, phwait(strm), natpinhole_handler, strm);
 	mbuf_set_end(mb, RTP_HEADER_SIZE);
 	mbuf_advance(mb, RTP_HEADER_SIZE);
 
@@ -1381,6 +1410,10 @@ static void natpinhole_handler(void *arg)
 	}
 
 	mem_deref(mb);
+
+	if (!strm->terminated)
+		tmr_start(&strm->tmr_natph, phwait(strm),
+				natpinhole_handler, strm);
 }
 
 


### PR DESCRIPTION
Add RX teardown guards in stream/rtprecv shutdown paths.

This change cancels pending RX-related timers, marks the receiver as closed
before dereferencing it, and avoids taking a mutex after it has been cleared
during receiver destruction.

The goal is to prevent use-after-free / teardown races during stream shutdown
without changing normal RTP/RTCP/media behavior.