### PR TITLE
net: guard net_laddr_apply() against NULL local address entries

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -777,6 +777,8 @@ bool net_laddr_apply(const struct network *net, net_ifaddr_h *ifh, void *arg)
 
 	LIST_FOREACH(&net->laddrs, le) {
 		struct laddr *laddr = le->data;
+		if (!laddr || !laddr->ifname)
+			continue;
 		if (ifh(laddr->ifname, &laddr->sa, arg))
 			return true;
 	}


### PR DESCRIPTION
This change adds a defensive guard in net_laddr_apply().

The current implementation passes laddr->ifname to the callback without
validating the local-address entry first. If a malformed entry reaches
the local address list, this can lead to a NULL dereference during
address iteration.

With this change, entries with a NULL element or NULL ifname are skipped,
while the behavior for valid entries remains unchanged.

This is a small robustness fix and does not change the normal code path.