### PR TITLE
Android: serialize AAudio stream open/close and harden media teardown…

### DIFF
--- a/modules/aaudio/aaudio.h
+++ b/modules/aaudio/aaudio.h
@@ -7,6 +7,8 @@
 #include <aaudio/AAudio.h>
 
 void aaudio_close_stream(AAudioStream *stream);
+void aaudio_lock(void);
+void aaudio_unlock(void);
 
 int aaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 			struct auplay_prm *prm, const char *device,

--- a/modules/aaudio/player.c
+++ b/modules/aaudio/player.c
@@ -8,30 +8,161 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#include <stdatomic.h>
+#include <string.h>
 
 #include "aaudio.h"
 
 
-struct auplay_st {
-	AAudioStream *playerStream;
+enum {
+	CONTROL_WAIT_MS    = 2,
+	SHUTDOWN_WAIT_MS   = 1000,
+	SHUTDOWN_POLL_MS   = 10,
+};
+
+
+struct auplay_state {
+	_Atomic(AAudioStream *) published_stream;
+	_Atomic(AAudioStream *) pending_stream;
+	_Atomic unsigned epoch;      /* even = running, odd = quiescing */
+	_Atomic unsigned cb_active;
+	_Atomic bool closing;
+	_Atomic bool broken;
+	_Atomic bool restart_requested;
+	_Atomic bool close_requested;
+	_Atomic bool ctl_exited;
+
 	auplay_write_h *wh;
 	void *arg;
 	struct auplay_prm play_prm;
 	size_t sampsz;
+	size_t bytes_per_frame;
+
+	mtx_t *cmd_lock;
+	cnd_t cmd_cnd;
+	bool cmd_cnd_ok;
+	thrd_t ctl_thr;
+	bool ctl_started;
 };
 
 
-static int open_player_stream(struct auplay_st *st);
+struct auplay_st {
+	struct auplay_state *state;
+};
+
+
+static int open_player_stream(struct auplay_state *state,
+		AAudioStream **streamp);
+static int player_control_thread(void *arg);
+
+
+static void auplay_state_destructor(void *arg)
+{
+	struct auplay_state *state = arg;
+
+	if (state->cmd_cnd_ok)
+		cnd_destroy(&state->cmd_cnd);
+	mem_deref(state->cmd_lock);
+}
+
+
+static void signal_control_thread(struct auplay_state *state)
+{
+	if (!state || !state->cmd_lock || !state->cmd_cnd_ok)
+		return;
+
+	mtx_lock(state->cmd_lock);
+	cnd_signal(&state->cmd_cnd);
+	mtx_unlock(state->cmd_lock);
+}
+
+
+static void request_stop_if_needed(AAudioStream *stream)
+{
+	if (stream)
+		(void)AAudioStream_requestStop(stream);
+}
+
+
+static void wait_callbacks_drain(struct auplay_state *state)
+{
+	while (atomic_load(&state->cb_active) != 0)
+		sys_msleep(CONTROL_WAIT_MS);
+}
+
+
+static void begin_quiesce_running(struct auplay_state *state,
+		AAudioStream **publishedp,
+		AAudioStream **pendingp)
+{
+	atomic_fetch_add(&state->epoch, 1u); /* even -> odd */
+
+	*publishedp = atomic_exchange(&state->published_stream, NULL);
+	*pendingp   = atomic_exchange(&state->pending_stream, NULL);
+
+	if (*pendingp && *pendingp != *publishedp)
+		request_stop_if_needed(*pendingp);
+	if (*publishedp)
+		request_stop_if_needed(*publishedp);
+
+	wait_callbacks_drain(state);
+}
+
+
+static void begin_quiesce_starting(struct auplay_state *state,
+		AAudioStream *stream)
+{
+	AAudioStream *expected = stream;
+
+	atomic_fetch_add(&state->epoch, 1u); /* even -> odd */
+	(void)atomic_compare_exchange_strong(&state->pending_stream,
+			&expected, NULL);
+
+	request_stop_if_needed(stream);
+	wait_callbacks_drain(state);
+}
+
+
+static void end_quiesce(struct auplay_state *state)
+{
+	atomic_fetch_add(&state->epoch, 1u); /* odd -> even */
+}
 
 
 static void auplay_destructor(void *arg)
 {
 	struct auplay_st *st = arg;
+	struct auplay_state *state = st->state;
+	uint32_t waited = 0;
 
 	info("aaudio: player: closing stream\n");
-	aaudio_close_stream(st->playerStream);
 
-	st->wh = NULL;
+	if (!state)
+		return;
+
+	st->state = NULL;
+
+	atomic_store(&state->closing, true);
+	atomic_store(&state->broken, true);
+	atomic_store(&state->close_requested, true);
+	signal_control_thread(state);
+
+	if (state->ctl_started) {
+		while (!atomic_load(&state->ctl_exited) &&
+				waited < SHUTDOWN_WAIT_MS) {
+			sys_msleep(SHUTDOWN_POLL_MS);
+			waited += SHUTDOWN_POLL_MS;
+		}
+
+		if (!atomic_load(&state->ctl_exited)) {
+			warning("aaudio: player: control thread did not exit "
+					"within %u ms, leaking state to avoid race\n",
+					SHUTDOWN_WAIT_MS);
+			return;
+		}
+	}
+
+	mem_deref(state);
 }
 
 
@@ -40,139 +171,286 @@ static void auplay_destructor(void *arg)
  * userData numFrames of data in the streams current data format to
  * the audioData buffer.
  */
- static int dataCallback(AAudioStream *stream, void *userData,
-			 void *audioData, int32_t numFrames) {
-	(void)stream;
-	struct auplay_st *st = userData;
+static aaudio_data_callback_result_t dataCallback(AAudioStream *stream,
+		void *userData,
+		void *audioData,
+		int32_t numFrames)
+{
+	struct auplay_state *state = userData;
 	struct auframe af;
+	auplay_write_h *wh;
+	void *arg;
+	struct auplay_prm play_prm;
+	AAudioStream *published;
+	unsigned epoch;
+	size_t nbytes = 0;
 
-	auframe_init(&af, st->play_prm.fmt, audioData, numFrames,
-		     st->play_prm.srate, st->play_prm.ch);
+	if (!state)
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
 
-	st->wh(&af, st->arg);
+	nbytes = (size_t)numFrames * state->bytes_per_frame;
 
-	return 0;
-}
+	epoch = atomic_load(&state->epoch);
+	published = atomic_load(&state->published_stream);
 
-
-static void* restart_player_stream(void* data) {
-	aaudio_result_t result;
-	struct auplay_st *st = data;
-
-	AAudioStream_close(st->playerStream);
-
-	result = open_player_stream(st);
-	if (result != AAUDIO_OK) {
-		warning("aaudio: failed to open player stream\n");
-		return NULL;
+	if ((epoch & 1u) || atomic_load(&state->closing) ||
+			atomic_load(&state->broken) || stream != published || !state->wh) {
+		memset(audioData, 0, nbytes);
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
 	}
 
-	result = AAudioStream_requestStart(st->playerStream);
-	if (result != AAUDIO_OK)
-		warning("aaudio: player: failed to start stream\n");
-	else
-		info("aaudio: player: stream started\n");
+	atomic_fetch_add(&state->cb_active, 1u);
 
-	pthread_exit(NULL);
+	published = atomic_load(&state->published_stream);
+	if (epoch != atomic_load(&state->epoch) ||
+			atomic_load(&state->closing) ||
+			atomic_load(&state->broken) ||
+			stream != published || !state->wh) {
+		atomic_fetch_sub(&state->cb_active, 1u);
+		memset(audioData, 0, nbytes);
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
+	}
+
+	wh = state->wh;
+	arg = state->arg;
+	play_prm = state->play_prm;
+
+	auframe_init(&af, play_prm.fmt, audioData, numFrames,
+			play_prm.srate, play_prm.ch);
+
+	wh(&af, arg);
+
+	atomic_fetch_sub(&state->cb_active, 1u);
+	return AAUDIO_CALLBACK_RESULT_CONTINUE;
 }
 
 
 static void errorCallback(AAudioStream *stream, void *userData,
-			  aaudio_result_t error) {
-	struct auplay_st *st = userData;
+		aaudio_result_t error)
+{
+	struct auplay_state *state = userData;
+	AAudioStream *published;
+	AAudioStream *pending;
+	AAudioStream *expected;
+	unsigned epoch;
 	(void)error;
-	pthread_t thread_id;
-	int res;
 
-	aaudio_stream_state_t streamState = AAudioStream_getState(stream);
-	if (streamState == AAUDIO_STREAM_STATE_DISCONNECTED) {
-		info("aaudio: player: stream disconnected\n");
-		res = pthread_create(&thread_id, NULL, restart_player_stream,
-				     (void *)st);
-		if (res) {
-			warning("aaudio: player: error creating thread: %d\n",
-				res);
-			return;
-		}
-		info("aaudio: player: created new thread (%u)\n", thread_id);
+	if (!state)
+		return;
+
+	epoch = atomic_load(&state->epoch);
+	published = atomic_load(&state->published_stream);
+	pending   = atomic_load(&state->pending_stream);
+
+	if ((epoch & 1u) || atomic_load(&state->closing) ||
+			(stream != published && stream != pending))
+		return;
+
+	atomic_fetch_add(&state->cb_active, 1u);
+
+	published = atomic_load(&state->published_stream);
+	pending   = atomic_load(&state->pending_stream);
+	if (epoch != atomic_load(&state->epoch) ||
+			atomic_load(&state->closing) ||
+			(stream != published && stream != pending)) {
+		atomic_fetch_sub(&state->cb_active, 1u);
+		return;
 	}
+
+	atomic_store(&state->broken, true);
+
+	if (stream == pending) {
+		expected = stream;
+		(void)atomic_compare_exchange_strong(&state->pending_stream,
+				&expected, NULL);
+	}
+
+	if (!atomic_exchange(&state->restart_requested, true))
+		signal_control_thread(state);
+
+	atomic_fetch_sub(&state->cb_active, 1u);
 }
 
 
-static int open_player_stream(struct auplay_st *st) {
-
-	AAudioStreamBuilder *builder;
+static int open_player_stream(struct auplay_state *state,
+		AAudioStream **streamp)
+{
+	AAudioStreamBuilder *builder = NULL;
+	AAudioStream *stream = NULL;
 	aaudio_result_t result;
+
+	if (!state || !streamp)
+		return EINVAL;
 
 	result = AAudio_createStreamBuilder(&builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: player: failed to create stream builder: "
-			"error %s\n", AAudio_convertResultToText(result));
+				"error %s\n", AAudio_convertResultToText(result));
 		return result;
 	}
 
 	AAudioStreamBuilder_setDirection(builder, AAUDIO_DIRECTION_OUTPUT);
-	AAudioStreamBuilder_setSharingMode(builder,
-		AAUDIO_SHARING_MODE_SHARED);
-	AAudioStreamBuilder_setSampleRate(builder, st->play_prm.srate);
-	AAudioStreamBuilder_setChannelCount(builder, 1);
+	AAudioStreamBuilder_setSharingMode(builder, AAUDIO_SHARING_MODE_SHARED);
+	AAudioStreamBuilder_setSampleRate(builder, state->play_prm.srate);
+	AAudioStreamBuilder_setChannelCount(builder, state->play_prm.ch);
 	AAudioStreamBuilder_setFormat(builder, AAUDIO_FORMAT_PCM_I16);
 	AAudioStreamBuilder_setSessionId(builder, AAUDIO_SESSION_ID_ALLOCATE);
-	AAudioStreamBuilder_setUsage(builder,
-		AAUDIO_USAGE_VOICE_COMMUNICATION);
-	AAudioStreamBuilder_setPerformanceMode(builder,
-		AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
-	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, st);
-	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, st);
+	AAudioStreamBuilder_setUsage(builder, AAUDIO_USAGE_VOICE_COMMUNICATION);
+	AAudioStreamBuilder_setPerformanceMode(
+			builder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, state);
+	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, state);
 
-	result = AAudioStreamBuilder_openStream(builder, &st->playerStream);
+	aaudio_lock();
+	result = AAudioStreamBuilder_openStream(builder, &stream);
+	aaudio_unlock();
+	AAudioStreamBuilder_delete(builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: player: failed to open stream: error %s\n",
-			AAudio_convertResultToText(result));
+				AAudio_convertResultToText(result));
 		return result;
 	}
 
 	info("aaudio: player: opened stream with direction %d, "
-	     "sharing mode %d, sample rate %d, format %d, sessionId %d, "
-	     "usage %d, performance mode %d\n",
-	     AAudioStream_getDirection(st->playerStream),
-	     AAudioStream_getSharingMode(st->playerStream),
-	     AAudioStream_getSampleRate(st->playerStream),
-	     AAudioStream_getFormat(st->playerStream),
-	     AAudioStream_getSessionId(st->playerStream),
-	     AAudioStream_getUsage(st->playerStream),
-	     AAudioStream_getPerformanceMode(st->playerStream));
+		 "sharing mode %d, sample rate %d, format %d, sessionId %d, "
+		 "usage %d, performance mode %d\n",
+			AAudioStream_getDirection(stream),
+			AAudioStream_getSharingMode(stream),
+			AAudioStream_getSampleRate(stream),
+			AAudioStream_getFormat(stream),
+			AAudioStream_getSessionId(stream),
+			AAudioStream_getUsage(stream),
+			AAudioStream_getPerformanceMode(stream));
 
-	AAudioStreamBuilder_delete(builder);
+	(void)AAudioStream_setBufferSizeInFrames(
+			stream, AAudioStream_getFramesPerBurst(stream) * 2);
 
-	AAudioStream_setBufferSizeInFrames(st->playerStream,
-		AAudioStream_getFramesPerBurst(st->playerStream) * 2);
-
+	*streamp = stream;
 	return AAUDIO_OK;
 }
 
 
+static int player_control_thread(void *arg)
+{
+	struct auplay_state *state = arg;
+	AAudioStream *published;
+	AAudioStream *pending;
+	AAudioStream *stream = NULL;
+	AAudioStream *expected;
+	aaudio_result_t result;
+
+	(void)thrd_detach(thrd_current());
+
+	for (;;) {
+		mtx_lock(state->cmd_lock);
+		while (!atomic_load(&state->close_requested) &&
+				!atomic_load(&state->restart_requested)) {
+			cnd_wait(&state->cmd_cnd, state->cmd_lock);
+		}
+		if (atomic_load(&state->close_requested)) {
+			mtx_unlock(state->cmd_lock);
+			break;
+		}
+		(void)atomic_exchange(&state->restart_requested, false);
+		mtx_unlock(state->cmd_lock);
+
+		begin_quiesce_running(state, &published, &pending);
+
+		if (pending && pending != published)
+			aaudio_close_stream(pending);
+		if (published)
+			aaudio_close_stream(published);
+		sys_msleep(20);
+
+		if (atomic_load(&state->closing))
+			continue;
+
+		end_quiesce(state);
+
+		result = open_player_stream(state, &stream);
+		if (result != AAUDIO_OK) {
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		if (atomic_load(&state->closing)) {
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			continue;
+		}
+
+		atomic_store(&state->pending_stream, stream);
+
+		result = AAudioStream_requestStart(stream);
+		if (result != AAUDIO_OK) {
+			warning("aaudio: player: restart failed to start stream: "
+					"%s\n", AAudio_convertResultToText(result));
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			end_quiesce(state);
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		if (atomic_load(&state->closing) ||
+				atomic_load(&state->pending_stream) != stream) {
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			if (!atomic_load(&state->closing))
+				end_quiesce(state);
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		atomic_store(&state->published_stream, stream);
+		expected = stream;
+		(void)atomic_compare_exchange_strong(&state->pending_stream,
+				&expected, NULL);
+		atomic_store(&state->broken, false);
+		info("aaudio: player: stream restarted\n");
+	}
+
+	begin_quiesce_running(state, &published, &pending);
+
+	if (pending && pending != published)
+		aaudio_close_stream(pending);
+	if (published)
+		aaudio_close_stream(published);
+	sys_msleep(20);
+
+	atomic_store(&state->ctl_exited, true);
+	mem_deref(state);
+	return 0;
+}
+
+
 int aaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
-	struct auplay_prm *prm, const char *dev, auplay_write_h *wh, void *arg)
+		struct auplay_prm *prm, const char *dev,
+		auplay_write_h *wh, void *arg)
 {
 	struct auplay_st *st;
+	struct auplay_state *state;
+	AAudioStream *stream = NULL;
+	AAudioStream *expected;
 	aaudio_result_t result;
+	int err;
+	struct auplay_state *ref;
 
 	if (!stp || !ap || !prm || !wh)
 		return EINVAL;
 
-	info ("aadio: opening player (%u Hz, %d channels, device %s, "
-		"ptime %u)\n", prm->srate, prm->ch, dev, prm->ptime);
+	info("aadio: opening player (%u Hz, %d channels, device %s, "
+		 "ptime %u)\n", prm->srate, prm->ch, dev, prm->ptime);
 
 	if (prm->fmt != AUFMT_S16LE) {
 		warning("aaudio: player: unsupported sample format (%s)\n",
-			aufmt_name((enum aufmt)prm->fmt));
+				aufmt_name((enum aufmt)prm->fmt));
 		return ENOTSUP;
 	}
 
 	if (prm->ch != 1) {
 		warning("aaudio: player: unsupported channel count (%u)\n",
-			prm->ch);
+				prm->ch);
 		return ENOTSUP;
 	}
 
@@ -180,31 +458,93 @@ int aaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (!st)
 		return ENOMEM;
 
-	st->play_prm = *prm;
+	state = mem_zalloc(sizeof(*state), auplay_state_destructor);
+	if (!state) {
+		mem_deref(st);
+		return ENOMEM;
+	}
 
-	st->wh  = wh;
-	st->arg = arg;
+	st->state = state;
 
-	result = open_player_stream(st);
+	atomic_init(&state->published_stream, NULL);
+	atomic_init(&state->pending_stream, NULL);
+	atomic_init(&state->epoch, 0u);
+	atomic_init(&state->cb_active, 0u);
+	atomic_init(&state->closing, false);
+	atomic_init(&state->broken, false);
+	atomic_init(&state->restart_requested, false);
+	atomic_init(&state->close_requested, false);
+	atomic_init(&state->ctl_exited, false);
+
+	state->play_prm = *prm;
+	state->sampsz = aufmt_sample_size(prm->fmt);
+	state->bytes_per_frame = state->sampsz * prm->ch;
+	state->wh  = wh;
+	state->arg = arg;
+
+	err = mutex_alloc(&state->cmd_lock);
+	if (err) {
+		mem_deref(st);
+		return err;
+	}
+
+	err = cnd_init(&state->cmd_cnd);
+	if (err != thrd_success) {
+		mem_deref(st);
+		return ENOMEM;
+	}
+	state->cmd_cnd_ok = true;
+
+	result = open_player_stream(state, &stream);
 	if (result != AAUDIO_OK)
 		goto out;
 
-	result = AAudioStream_requestStart(st->playerStream);
+	atomic_store(&state->pending_stream, stream);
+
+	result = AAudioStream_requestStart(stream);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: player: failed to start stream\n");
+		begin_quiesce_starting(state, stream);
+		aaudio_close_stream(stream);
 		goto out;
 	}
 
-	module_event("aaudio", "player sessionid", NULL, NULL, "%d",
-		     AAudioStream_getSessionId(st->playerStream));
-
-	info ("aaudio: player: stream started\n");
-
-  out:
-	if (result != AAUDIO_OK) {
-		aaudio_close_stream(st->playerStream);
-		mem_deref(st);
+	if (atomic_load(&state->closing) ||
+			atomic_load(&state->pending_stream) != stream) {
+		begin_quiesce_starting(state, stream);
+		aaudio_close_stream(stream);
+		result = AAUDIO_ERROR_DISCONNECTED;
+		goto out;
 	}
+
+	atomic_store(&state->published_stream, stream);
+	expected = stream;
+	(void)atomic_compare_exchange_strong(&state->pending_stream,
+			&expected, NULL);
+	atomic_store(&state->broken, false);
+
+	ref = mem_ref(state);
+	err = thread_create_name(&state->ctl_thr, "AAudio Player Control",
+			player_control_thread, ref);
+	if (err) {
+		mem_deref(ref);
+		begin_quiesce_running(state, &stream, &expected);
+		if (expected && expected != stream)
+			aaudio_close_stream(expected);
+		if (stream)
+			aaudio_close_stream(stream);
+		result = err;
+		goto out;
+	}
+	state->ctl_started = true;
+
+	module_event("aaudio", "player sessionid", NULL, NULL, "%d",
+			AAudioStream_getSessionId(stream));
+	info("aaudio: player: stream started\n");
+
+	out:
+	if (result != AAUDIO_OK)
+		mem_deref(st);
 	else
 		*stp = st;
 

--- a/modules/aaudio/recorder.c
+++ b/modules/aaudio/recorder.c
@@ -8,37 +8,188 @@
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
+#include <stdatomic.h>
 #include <string.h>
 
 #include "aaudio.h"
 
 
-struct ausrc_st {
-	AAudioStream *recorderStream;
+enum {
+	CONTROL_WAIT_MS    = 2,
+	SHUTDOWN_WAIT_MS   = 1000,
+	SHUTDOWN_POLL_MS   = 10,
+};
+
+
+struct ausrc_state {
+	_Atomic(AAudioStream *) published_stream;
+	_Atomic(AAudioStream *) pending_stream;
+	_Atomic unsigned epoch;      /* even = running, odd = quiescing */
+	_Atomic unsigned cb_active;
+	_Atomic bool closing;
+	_Atomic bool broken;
+	_Atomic bool restart_requested;
+	_Atomic bool close_requested;
+	_Atomic bool ctl_exited;
+
 	ausrc_read_h *rh;
 	void *arg;
 	struct ausrc_prm src_prm;
 	ausrc_error_h *errh;
 	void   *sampv;
 	size_t  sampsz;
+	size_t  bytes_per_frame;
 	size_t  sampc;
 	uint64_t samps;
+
+	mtx_t *cmd_lock;
+	cnd_t cmd_cnd;
+	bool cmd_cnd_ok;
+	thrd_t ctl_thr;
+	bool ctl_started;
 };
 
 
-static int open_recorder_stream(struct ausrc_st *st);
+struct ausrc_st {
+	struct ausrc_state *state;
+};
+
+
+static int open_recorder_stream(struct ausrc_state *state,
+		AAudioStream **streamp);
+static int prepare_recorder_stream(struct ausrc_state *state,
+		AAudioStream *stream);
+static int recorder_control_thread(void *arg);
+
+
+static void ausrc_state_destructor(void *arg)
+{
+	struct ausrc_state *state = arg;
+
+	if (state->cmd_cnd_ok)
+		cnd_destroy(&state->cmd_cnd);
+	mem_deref(state->sampv);
+	mem_deref(state->cmd_lock);
+}
+
+
+static void signal_control_thread(struct ausrc_state *state)
+{
+	if (!state || !state->cmd_lock || !state->cmd_cnd_ok)
+		return;
+
+	mtx_lock(state->cmd_lock);
+	cnd_signal(&state->cmd_cnd);
+	mtx_unlock(state->cmd_lock);
+}
+
+
+static void request_stop_if_needed(AAudioStream *stream)
+{
+	if (stream)
+		(void)AAudioStream_requestStop(stream);
+}
+
+
+static void wait_callbacks_drain(struct ausrc_state *state)
+{
+	while (atomic_load(&state->cb_active) != 0)
+		sys_msleep(CONTROL_WAIT_MS);
+}
+
+
+static void begin_quiesce_running(struct ausrc_state *state,
+		AAudioStream **publishedp,
+		AAudioStream **pendingp)
+{
+	atomic_fetch_add(&state->epoch, 1u); /* even -> odd */
+
+	*publishedp = atomic_exchange(&state->published_stream, NULL);
+	*pendingp   = atomic_exchange(&state->pending_stream, NULL);
+
+	if (*pendingp && *pendingp != *publishedp)
+		request_stop_if_needed(*pendingp);
+	if (*publishedp)
+		request_stop_if_needed(*publishedp);
+
+	wait_callbacks_drain(state);
+}
+
+
+static void begin_quiesce_starting(struct ausrc_state *state,
+		AAudioStream *stream)
+{
+	AAudioStream *expected = stream;
+
+	atomic_fetch_add(&state->epoch, 1u); /* even -> odd */
+	(void)atomic_compare_exchange_strong(&state->pending_stream,
+			&expected, NULL);
+
+	request_stop_if_needed(stream);
+	wait_callbacks_drain(state);
+}
+
+
+static void end_quiesce(struct ausrc_state *state)
+{
+	atomic_fetch_add(&state->epoch, 1u); /* odd -> even */
+}
+
+
+static int ensure_recorder_buffer(struct ausrc_state *state, size_t frames)
+{
+	void *buf;
+
+	if (!state)
+		return EINVAL;
+
+	if (frames <= state->sampc)
+		return 0;
+
+	buf = mem_realloc(state->sampv, state->bytes_per_frame * frames);
+	if (!buf)
+		return ENOMEM;
+
+	state->sampv = buf;
+	state->sampc = frames;
+	return 0;
+}
 
 
 static void ausrc_destructor(void *arg)
 {
 	struct ausrc_st *st = arg;
+	struct ausrc_state *state = st->state;
+	uint32_t waited = 0;
 
 	info("aaudio: recorder: closing stream\n");
-	aaudio_close_stream(st->recorderStream);
 
-	mem_deref(st->sampv);
-	st->rh = NULL;
-	st->errh = NULL;
+	if (!state)
+		return;
+
+	st->state = NULL;
+
+	atomic_store(&state->closing, true);
+	atomic_store(&state->broken, true);
+	atomic_store(&state->close_requested, true);
+	signal_control_thread(state);
+
+	if (state->ctl_started) {
+		while (!atomic_load(&state->ctl_exited) &&
+				waited < SHUTDOWN_WAIT_MS) {
+			sys_msleep(SHUTDOWN_POLL_MS);
+			waited += SHUTDOWN_POLL_MS;
+		}
+
+		if (!atomic_load(&state->ctl_exited)) {
+			warning("aaudio: recorder: control thread did not exit "
+					"within %u ms, leaking state to avoid race\n",
+					SHUTDOWN_WAIT_MS);
+			return;
+		}
+	}
+
+	mem_deref(state);
 }
 
 
@@ -46,170 +197,338 @@ static void ausrc_destructor(void *arg)
  * For an input stream, this function should read and process numFrames of
  * data from the audioData buffer. The data in the audioData buffer must not
  * be modified directly. Instead, it should be copied to another buffer
- * before doing any modification. Note that numFrames can vary unless
- * AAudioStreamBuilder_setFramesPerDataCallback() is called. Not currently
- * called.
+ * before doing any modification.
  */
- static int dataCallback(AAudioStream *stream, void *userData,
-			 void *audioData, int32_t numFrames) {
-	(void)stream;
-	struct ausrc_st *st = userData;
+static aaudio_data_callback_result_t dataCallback(AAudioStream *stream,
+		void *userData,
+		void *audioData,
+		int32_t numFrames)
+{
+	struct ausrc_state *state = userData;
 	struct auframe af;
+	ausrc_read_h *rh;
+	void *arg;
+	struct ausrc_prm src_prm;
+	AAudioStream *published;
+	unsigned epoch;
+	size_t sampc;
 
-	size_t sampc = 0;
+	if (!state)
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
 
-	sampc = numFrames;
-	if (sampc > st->sampc) {
-		st->sampv = mem_realloc(st->sampv, st->sampsz * sampc);
-		st->sampc = sampc;
+	epoch = atomic_load(&state->epoch);
+	published = atomic_load(&state->published_stream);
+
+	if ((epoch & 1u) || atomic_load(&state->closing) ||
+			atomic_load(&state->broken) || stream != published || !state->rh)
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
+
+	atomic_fetch_add(&state->cb_active, 1u);
+
+	published = atomic_load(&state->published_stream);
+	if (epoch != atomic_load(&state->epoch) ||
+			atomic_load(&state->closing) ||
+			atomic_load(&state->broken) ||
+			stream != published || !state->rh) {
+		atomic_fetch_sub(&state->cb_active, 1u);
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
 	}
 
-	if (!st->sampv)
-		return ENOMEM;
+	rh = state->rh;
+	arg = state->arg;
+	src_prm = state->src_prm;
+	sampc = (size_t)numFrames;
 
-	auframe_init(&af, st->src_prm.fmt, st->sampv, sampc,
-		     st->src_prm.srate, st->src_prm.ch);
-
-	memcpy(st->sampv, audioData, auframe_size(&af) * af.ch);
-
-	af.timestamp = st->samps * AUDIO_TIMEBASE /
-		       (st->src_prm.srate * st->src_prm.ch);
-	st->samps += sampc;
-	st->rh(&af, st->arg);
-
-	return 0;
-}
-
-
-static void* restart_recorder_stream(void* data) {
-	aaudio_result_t result;
-	struct ausrc_st *st = data;
-
-	AAudioStream_close(st->recorderStream);
-
-	result = open_recorder_stream(st);
-	if (result != AAUDIO_OK) {
-		warning("aaudio: recorder: failed to open stream\n");
-		return NULL;
+	if (sampc > state->sampc) {
+		atomic_fetch_sub(&state->cb_active, 1u);
+		return AAUDIO_CALLBACK_RESULT_CONTINUE;
 	}
 
-	result = AAudioStream_requestStart(st->recorderStream);
-	if (result != AAUDIO_OK)
-		warning("aaudio: recorder: failed to start stream\n");
-	else
-		info("aaudio: recorder: stream started\n");
+	auframe_init(&af, src_prm.fmt, state->sampv, numFrames,
+			src_prm.srate, src_prm.ch);
 
-	pthread_exit(NULL);
+	memcpy(state->sampv, audioData, state->bytes_per_frame * sampc);
+
+	af.timestamp = state->samps * AUDIO_TIMEBASE /
+			(src_prm.srate * src_prm.ch);
+	state->samps += sampc;
+	rh(&af, arg);
+
+	atomic_fetch_sub(&state->cb_active, 1u);
+	return AAUDIO_CALLBACK_RESULT_CONTINUE;
 }
 
 
 static void errorCallback(AAudioStream *stream, void *userData,
-			  aaudio_result_t error) {
-	struct ausrc_st *st = userData;
+		aaudio_result_t error)
+{
+	struct ausrc_state *state = userData;
+	AAudioStream *published;
+	AAudioStream *pending;
+	AAudioStream *expected;
+	unsigned epoch;
 	(void)error;
-	pthread_t thread_id;
-	int res;
 
-	aaudio_stream_state_t streamState = AAudioStream_getState(stream);
-	if (streamState == AAUDIO_STREAM_STATE_DISCONNECTED) {
-		info("aaudio: recorder: stream disconnected\n");
-		res = pthread_create(&thread_id, NULL,
-				     restart_recorder_stream, (void *)st);
-		if (res) {
-			warning("aaudio: recorder: error creating thread: "
-				"%d\n",	res);
-			return;
-		}
-		info("aaudio: recorder: created new thread (%u)\n",
-		     thread_id);
+	if (!state)
+		return;
+
+	epoch = atomic_load(&state->epoch);
+	published = atomic_load(&state->published_stream);
+	pending   = atomic_load(&state->pending_stream);
+
+	if ((epoch & 1u) || atomic_load(&state->closing) ||
+			(stream != published && stream != pending))
+		return;
+
+	atomic_fetch_add(&state->cb_active, 1u);
+
+	published = atomic_load(&state->published_stream);
+	pending   = atomic_load(&state->pending_stream);
+	if (epoch != atomic_load(&state->epoch) ||
+			atomic_load(&state->closing) ||
+			(stream != published && stream != pending)) {
+		atomic_fetch_sub(&state->cb_active, 1u);
+		return;
 	}
+
+	atomic_store(&state->broken, true);
+
+	if (stream == pending) {
+		expected = stream;
+		(void)atomic_compare_exchange_strong(&state->pending_stream,
+				&expected, NULL);
+	}
+
+	if (!atomic_exchange(&state->restart_requested, true))
+		signal_control_thread(state);
+
+	atomic_fetch_sub(&state->cb_active, 1u);
 }
 
 
-static int open_recorder_stream(struct ausrc_st *st) {
-
-	AAudioStreamBuilder *builder;
+static int open_recorder_stream(struct ausrc_state *state,
+		AAudioStream **streamp)
+{
+	AAudioStreamBuilder *builder = NULL;
+	AAudioStream *stream = NULL;
 	aaudio_result_t result;
+
+	if (!state || !streamp)
+		return EINVAL;
 
 	result = AAudio_createStreamBuilder(&builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: recorder: failed to create stream builder: "
-			"error %s\n", AAudio_convertResultToText(result));
+				"error %s\n", AAudio_convertResultToText(result));
 		return result;
 	}
 
 	AAudioStreamBuilder_setDirection(builder, AAUDIO_DIRECTION_INPUT);
-	AAudioStreamBuilder_setSharingMode(builder,
-		AAUDIO_SHARING_MODE_SHARED);
-	AAudioStreamBuilder_setSampleRate(builder, st->src_prm.srate);
-	AAudioStreamBuilder_setChannelCount(builder, st->src_prm.ch);
+	AAudioStreamBuilder_setSharingMode(builder, AAUDIO_SHARING_MODE_SHARED);
+	AAudioStreamBuilder_setSampleRate(builder, state->src_prm.srate);
+	AAudioStreamBuilder_setChannelCount(builder, state->src_prm.ch);
 	AAudioStreamBuilder_setFormat(builder, AAUDIO_FORMAT_PCM_I16);
 	AAudioStreamBuilder_setSessionId(builder, AAUDIO_SESSION_ID_ALLOCATE);
-	AAudioStreamBuilder_setUsage(builder,
-		AAUDIO_USAGE_VOICE_COMMUNICATION);
-	AAudioStreamBuilder_setPerformanceMode(builder,
-		AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
-	AAudioStreamBuilder_setInputPreset(builder,
-		AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION);
-	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, st);
-	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, st);
+	AAudioStreamBuilder_setUsage(builder, AAUDIO_USAGE_VOICE_COMMUNICATION);
+	AAudioStreamBuilder_setPerformanceMode(
+			builder, AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+	AAudioStreamBuilder_setInputPreset(
+			builder, AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION);
+	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, state);
+	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, state);
 
-	result = AAudioStreamBuilder_openStream(builder, &st->recorderStream);
+	aaudio_lock();
+	result = AAudioStreamBuilder_openStream(builder, &stream);
+	aaudio_unlock();
+	AAudioStreamBuilder_delete(builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: recorder: failed to open stream: error %s\n",
-			AAudio_convertResultToText(result));
+				AAudio_convertResultToText(result));
 		return result;
 	}
 
 	info("aaudio: recorder: opened stream with direction %d, "
-	     "sharing mode %d, sample rate %d, format %d, sessionId %d, "
-	     "input preset %d, usage %d, performance mode %d\n",
-	     AAudioStream_getDirection(st->recorderStream),
-	     AAudioStream_getSharingMode(st->recorderStream),
-	     AAudioStream_getSampleRate(st->recorderStream),
-	     AAudioStream_getFormat(st->recorderStream),
-	     AAudioStream_getSessionId(st->recorderStream),
-	     AAudioStream_getInputPreset(st->recorderStream),
-	     AAudioStream_getUsage(st->recorderStream),
-	     AAudioStream_getPerformanceMode(st->recorderStream));
+		 "sharing mode %d, sample rate %d, format %d, sessionId %d, "
+		 "input preset %d, usage %d, performance mode %d\n",
+			AAudioStream_getDirection(stream),
+			AAudioStream_getSharingMode(stream),
+			AAudioStream_getSampleRate(stream),
+			AAudioStream_getFormat(stream),
+			AAudioStream_getSessionId(stream),
+			AAudioStream_getInputPreset(stream),
+			AAudioStream_getUsage(stream),
+			AAudioStream_getPerformanceMode(stream));
 
-	AAudioStreamBuilder_delete(builder);
-
-	AAudioStream_setBufferSizeInFrames(st->recorderStream,
-		AAudioStream_getFramesPerBurst(st->recorderStream) * 2);
-	int32_t bufferCapacity =
-		AAudioStream_getBufferCapacityInFrames(st->recorderStream);
-	int32_t bufferSize = AAudioStream_getBufferSizeInFrames(
-		st->recorderStream);
-	info("aaudio: recorder: buffer capacity: %d, buffer size: %d\n",
-	     bufferCapacity,  bufferSize);
-
+	*streamp = stream;
 	return AAUDIO_OK;
 }
 
 
+static int prepare_recorder_stream(struct ausrc_state *state,
+		AAudioStream *stream)
+{
+	int32_t frames_per_burst;
+	int32_t buffer_capacity;
+	int32_t buffer_size;
+	size_t want_frames;
+	int err;
+
+	if (!state || !stream)
+		return EINVAL;
+
+	frames_per_burst = AAudioStream_getFramesPerBurst(stream);
+	(void)AAudioStream_setBufferSizeInFrames(stream, frames_per_burst * 2);
+
+	buffer_capacity = AAudioStream_getBufferCapacityInFrames(stream);
+	buffer_size = AAudioStream_getBufferSizeInFrames(stream);
+
+	want_frames = state->src_prm.ptime * state->src_prm.ch *
+			state->src_prm.srate / 1000;
+	if (buffer_capacity > 0 && (size_t)buffer_capacity > want_frames)
+		want_frames = (size_t)buffer_capacity;
+	if (frames_per_burst > 0 && (size_t)frames_per_burst > want_frames)
+		want_frames = (size_t)frames_per_burst;
+
+	err = ensure_recorder_buffer(state, want_frames);
+	if (err)
+		return err;
+
+	info("aaudio: recorder: buffer capacity: %d, buffer size: %d\n",
+			buffer_capacity, buffer_size);
+	return 0;
+}
+
+
+static int recorder_control_thread(void *arg)
+{
+	struct ausrc_state *state = arg;
+	AAudioStream *published;
+	AAudioStream *pending;
+	AAudioStream *stream = NULL;
+	AAudioStream *expected;
+	aaudio_result_t result;
+	int err;
+
+	(void)thrd_detach(thrd_current());
+
+	for (;;) {
+		mtx_lock(state->cmd_lock);
+		while (!atomic_load(&state->close_requested) &&
+				!atomic_load(&state->restart_requested)) {
+			cnd_wait(&state->cmd_cnd, state->cmd_lock);
+		}
+		if (atomic_load(&state->close_requested)) {
+			mtx_unlock(state->cmd_lock);
+			break;
+		}
+		(void)atomic_exchange(&state->restart_requested, false);
+		mtx_unlock(state->cmd_lock);
+
+		begin_quiesce_running(state, &published, &pending);
+
+		if (pending && pending != published)
+			aaudio_close_stream(pending);
+		if (published)
+			aaudio_close_stream(published);
+		sys_msleep(20);
+
+		if (atomic_load(&state->closing))
+			continue;
+
+		end_quiesce(state);
+
+		result = open_recorder_stream(state, &stream);
+		if (result != AAUDIO_OK) {
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		err = prepare_recorder_stream(state, stream);
+		if (err) {
+			aaudio_close_stream(stream);
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		if (atomic_load(&state->closing)) {
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			continue;
+		}
+
+		atomic_store(&state->pending_stream, stream);
+
+		result = AAudioStream_requestStart(stream);
+		if (result != AAUDIO_OK) {
+			warning("aaudio: recorder: restart failed to start "
+					"stream: %s\n",
+					AAudio_convertResultToText(result));
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			end_quiesce(state);
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		if (atomic_load(&state->closing) ||
+				atomic_load(&state->pending_stream) != stream) {
+			begin_quiesce_starting(state, stream);
+			aaudio_close_stream(stream);
+			if (!atomic_load(&state->closing))
+				end_quiesce(state);
+			atomic_store(&state->broken, true);
+			continue;
+		}
+
+		atomic_store(&state->published_stream, stream);
+		expected = stream;
+		(void)atomic_compare_exchange_strong(&state->pending_stream,
+				&expected, NULL);
+		atomic_store(&state->broken, false);
+		info("aaudio: recorder: stream restarted\n");
+	}
+
+	begin_quiesce_running(state, &published, &pending);
+
+	if (pending && pending != published)
+		aaudio_close_stream(pending);
+	if (published)
+		aaudio_close_stream(published);
+	sys_msleep(20);
+
+	atomic_store(&state->ctl_exited, true);
+	mem_deref(state);
+	return 0;
+}
+
+
 int aaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
-			  struct ausrc_prm *prm, const char *dev,
-			  ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
+		struct ausrc_prm *prm, const char *dev,
+		ausrc_read_h *rh, ausrc_error_h *errh, void *arg)
 {
 	struct ausrc_st *st;
+	struct ausrc_state *state;
+	AAudioStream *stream = NULL;
+	AAudioStream *expected;
 	aaudio_result_t result;
+	int err;
+	struct ausrc_state *ref;
 
 	if (!stp || !as || !prm || !rh)
 		return EINVAL;
 
-	info ("aaudio: recorder: opening recorder(%u Hz, %d channels,"
-	      "device '%s')\n", prm->srate, prm->ch, dev);
+	info("aaudio: recorder: opening recorder(%u Hz, %d channels,"
+		 "device '%s')\n", prm->srate, prm->ch, dev);
 
 	if (prm->fmt != AUFMT_S16LE) {
 		warning("aaudio: recorder: unsupported sample format (%s)\n",
-			aufmt_name((enum aufmt)prm->fmt));
+				aufmt_name((enum aufmt)prm->fmt));
 		return ENOTSUP;
 	}
 
 	if (prm->ch != 1) {
 		warning("aaudio: recorder: unsupported channel count (%u)\n",
-			prm->ch);
+				prm->ch);
 		return ENOTSUP;
 	}
 
@@ -217,41 +536,101 @@ int aaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 	if (!st)
 		return ENOMEM;
 
-	st->src_prm = *prm;
-
-	st->sampsz = aufmt_sample_size(prm->fmt);
-	st->sampc  = prm->ptime * prm->ch * prm->srate / 1000;
-	st->samps  = 0;
-	st->sampv  = mem_zalloc(st->sampsz * st->sampc, NULL);
-	if (!st->sampv) {
-		result = ENOMEM;
-		goto out;
+	state = mem_zalloc(sizeof(*state), ausrc_state_destructor);
+	if (!state) {
+		mem_deref(st);
+		return ENOMEM;
 	}
 
-	st->rh  = rh;
-	st->errh = errh;
-	st->arg = arg;
+	st->state = state;
 
-	result = open_recorder_stream(st);
+	atomic_init(&state->published_stream, NULL);
+	atomic_init(&state->pending_stream, NULL);
+	atomic_init(&state->epoch, 0u);
+	atomic_init(&state->cb_active, 0u);
+	atomic_init(&state->closing, false);
+	atomic_init(&state->broken, false);
+	atomic_init(&state->restart_requested, false);
+	atomic_init(&state->close_requested, false);
+	atomic_init(&state->ctl_exited, false);
+
+	state->src_prm = *prm;
+	state->sampsz = aufmt_sample_size(prm->fmt);
+	state->bytes_per_frame = state->sampsz * prm->ch;
+	state->rh   = rh;
+	state->errh = errh;
+	state->arg  = arg;
+
+	err = mutex_alloc(&state->cmd_lock);
+	if (err) {
+		mem_deref(st);
+		return err;
+	}
+
+	err = cnd_init(&state->cmd_cnd);
+	if (err != thrd_success) {
+		mem_deref(st);
+		return ENOMEM;
+	}
+	state->cmd_cnd_ok = true;
+
+	result = open_recorder_stream(state, &stream);
 	if (result != AAUDIO_OK)
 		goto out;
 
-	result = AAudioStream_requestStart(st->recorderStream);
-	if (result != AAUDIO_OK) {
-		warning("aaudio: recorder: failed to start stream\n");
+	err = prepare_recorder_stream(state, stream);
+	if (err) {
+		result = err;
+		aaudio_close_stream(stream);
 		goto out;
 	}
 
-	module_event("aaudio", "recorder sessionid", NULL, NULL, "%d",
-		     AAudioStream_getSessionId(st->recorderStream));
+	atomic_store(&state->pending_stream, stream);
 
+	result = AAudioStream_requestStart(stream);
+	if (result != AAUDIO_OK) {
+		warning("aaudio: recorder: failed to start stream\n");
+		begin_quiesce_starting(state, stream);
+		aaudio_close_stream(stream);
+		goto out;
+	}
+
+	if (atomic_load(&state->closing) ||
+			atomic_load(&state->pending_stream) != stream) {
+		begin_quiesce_starting(state, stream);
+		aaudio_close_stream(stream);
+		result = AAUDIO_ERROR_DISCONNECTED;
+		goto out;
+	}
+
+	atomic_store(&state->published_stream, stream);
+	expected = stream;
+	(void)atomic_compare_exchange_strong(&state->pending_stream,
+			&expected, NULL);
+	atomic_store(&state->broken, false);
+
+	ref = mem_ref(state);
+	err = thread_create_name(&state->ctl_thr, "AAudio Recorder Control",
+			recorder_control_thread, ref);
+	if (err) {
+		mem_deref(ref);
+		begin_quiesce_running(state, &stream, &expected);
+		if (expected && expected != stream)
+			aaudio_close_stream(expected);
+		if (stream)
+			aaudio_close_stream(stream);
+		result = err;
+		goto out;
+	}
+	state->ctl_started = true;
+
+	module_event("aaudio", "recorder sessionid", NULL, NULL, "%d",
+			AAudioStream_getSessionId(stream));
 	info("aaudio: recorder: stream started\n");
 
-  out:
-	if (result != AAUDIO_OK) {
-		aaudio_close_stream(st->recorderStream);
+	out:
+	if (result != AAUDIO_OK)
 		mem_deref(st);
-	}
 	else
 		*stp = st;
 

--- a/modules/aaudio/utils.c
+++ b/modules/aaudio/utils.c
@@ -9,12 +9,38 @@
 #include "aaudio.h"
 
 
-void aaudio_close_stream(AAudioStream *stream) {
-	if (stream) {
-		aaudio_stream_state_t state =
-			AAudioStream_getState(stream);
-		if (state !=  AAUDIO_STREAM_STATE_CLOSED &&
-		    state != AAUDIO_STREAM_STATE_CLOSING)
-			AAudioStream_close(stream);
+static once_flag aaudio_lock_once = ONCE_FLAG_INIT;
+static mtx_t aaudio_global_lock;
+
+static void aaudio_lock_init(void)
+{
+	(void)mtx_init(&aaudio_global_lock, mtx_recursive);
+}
+
+void aaudio_lock(void)
+{
+	call_once(&aaudio_lock_once, aaudio_lock_init);
+	mtx_lock(&aaudio_global_lock);
+}
+
+void aaudio_unlock(void)
+{
+	mtx_unlock(&aaudio_global_lock);
+}
+
+void aaudio_close_stream(AAudioStream *stream)
+{
+	aaudio_stream_state_t state;
+
+	if (!stream)
+		return;
+
+	aaudio_lock();
+	state = AAudioStream_getState(stream);
+	if (state != AAUDIO_STREAM_STATE_CLOSED &&
+			state != AAUDIO_STREAM_STATE_CLOSING) {
+		(void)AAudioStream_requestStop(stream);
+		(void)AAudioStream_close(stream);
 	}
+	aaudio_unlock();
 }

--- a/src/audio.c
+++ b/src/audio.c
@@ -176,7 +176,9 @@ static void stop_tx(struct autx *tx, struct audio *a)
 	if (!tx || !a)
 		return;
 
-	stream_enable_tx(a->strm, false);
+	if (a->strm)
+		stream_enable_tx(a->strm, false);
+
 	if (re_atomic_rlx(&tx->thr.run)) {
 		re_atomic_rlx_set(&tx->thr.run, false);
 		thrd_join(tx->thr.tid, NULL);
@@ -245,18 +247,18 @@ static int add_audio_codec(struct sdp_media *m, struct aucodec *ac)
 
 	if (ac->ch == 0 || ac->pch == 0) {
 		warning("audio: illegal channels for audio codec '%s'\n",
-			ac->name);
+				ac->name);
 		return EINVAL;
 	}
 
 	return sdp_format_add(NULL, m, false, ac->pt, ac->name, ac->crate,
-			      ac->pch, ac->fmtp_ench, ac->fmtp_cmph, ac, false,
-			      "%s", ac->fmtp);
+			ac->pch, ac->fmtp_ench, ac->fmtp_cmph, ac, false,
+			"%s", ac->fmtp);
 }
 
 
 static int append_rtpext(struct audio *au, struct mbuf *mb,
-			 enum aufmt fmt, const void *sampv, size_t sampc)
+		enum aufmt fmt, const void *sampv, size_t sampc)
 {
 	uint8_t data[1];
 	double level;
@@ -284,7 +286,7 @@ static int append_rtpext(struct audio *au, struct mbuf *mb,
  * @note This function has REAL-TIME properties
  */
 static void encode_rtp_send(struct audio *a, struct autx *tx,
-			    struct auframe *af)
+		struct auframe *af)
 {
 	struct bundle *bun = stream_bundle(a->strm);
 	bool bundled = bundle_state(bun) != BUNDLE_NONE;
@@ -301,8 +303,8 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 
 	if (tx->ac->srate != af->srate || tx->ac->ch != af->ch) {
 		warning("audio: srate/ch of frame %u/%u vs audio codec %u/%u. "
-			"Use module auresamp!\n",
-			af->srate, af->ch, tx->ac->srate, tx->ac->ch);
+				"Use module auresamp!\n",
+				af->srate, af->ch, tx->ac->srate, tx->ac->ch);
 		return;
 	}
 
@@ -315,7 +317,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 
 		if (a->level_enabled) {
 			err = append_rtpext(a, tx->mb, af->fmt,
-					    af->sampv, af->sampc);
+					af->sampv, af->sampc);
 			if (err)
 				return;
 		}
@@ -324,7 +326,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 			const char *mid = stream_mid(a->strm);
 
 			rtpext_encode(tx->mb, bundle_extmap_mid(bun),
-				      str_len(mid), (void *)mid);
+					str_len(mid), (void *)mid);
 		}
 
 		ext_len = tx->mb->pos - STREAM_PRESZ;
@@ -343,7 +345,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	len = mbuf_get_space(tx->mb);
 
 	err = tx->ac->ench(tx->enc, &marker, mbuf_buf(tx->mb), &len,
-			   af->fmt, af->sampv, af->sampc);
+			af->fmt, af->sampv, af->sampc);
 
 	if ((err & 0xffff0000) == 0x00010000) {
 
@@ -354,7 +356,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	}
 	else if (err) {
 		warning("audio: %s encode error: %d samples (%m)\n",
-			tx->ac->name, af->sampc, err);
+				tx->ac->name, af->sampc, err);
 		goto out;
 	}
 
@@ -368,7 +370,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 		if (len) {
 			mtx_lock(a->tx.mtx);
 			err = stream_send(a->strm, ext_len!=0, marker, -1,
-					  rtp_ts, tx->mb);
+					rtp_ts, tx->mb);
 			mtx_unlock(a->tx.mtx);
 			if (err)
 				goto out;
@@ -396,7 +398,7 @@ static void encode_rtp_send(struct audio *a, struct autx *tx,
 	tx->ts_ext += (uint32_t)frame_size;
 	mtx_unlock(a->tx.mtx);
 
- out:
+	out:
 	tx->marker = false;
 }
 
@@ -444,9 +446,9 @@ static void poll_aubuf_tx(struct audio *a)
 
 	if (af.fmt != tx->enc_fmt) {
 		warning("audio: tx: invalid sample formats (%s -> %s). %s\n",
-			aufmt_name(af.fmt), aufmt_name(tx->enc_fmt),
-			tx->enc_fmt == AUFMT_S16LE ? "Use module auconv!" : ""
-			);
+				aufmt_name(af.fmt), aufmt_name(tx->enc_fmt),
+				tx->enc_fmt == AUFMT_S16LE ? "Use module auconv!" : ""
+		);
 	}
 
 	/* Encode and send */
@@ -488,7 +490,7 @@ static void check_telev(struct audio *a, struct autx *tx)
 		warning("audio: telev: stream_send %m\n", err);
 	}
 
- out:
+	out:
 	mem_deref(mb);
 }
 
@@ -539,9 +541,9 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 
 	if (fmt != af->fmt) {
 		warning("audio: ausrc format mismatch:"
-			" expected=%d(%s), actual=%d(%s)\n",
-			fmt, aufmt_name(tx->src_fmt),
-			af->fmt, aufmt_name(af->fmt));
+				" expected=%d(%s), actual=%d(%s)\n",
+				fmt, aufmt_name(tx->src_fmt),
+				af->fmt, aufmt_name(af->fmt));
 		return;
 	}
 
@@ -553,13 +555,13 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 		++tx->stats.aubuf_overrun;
 
 		debug("audio: tx aubuf overrun (total %llu)\n",
-		      tx->stats.aubuf_overrun);
+				tx->stats.aubuf_overrun);
 	}
 
 	(void)aubuf_write_auframe(tx->aubuf, af);
 
 	if (!re_atomic_rlx(&tx->aubuf_started) &&
-	    (aubuf_cur_size(tx->aubuf) >= psize)) {
+			(aubuf_cur_size(tx->aubuf) >= psize)) {
 		re_atomic_rlx_set(&tx->aubuf_started, true);
 	}
 }
@@ -623,11 +625,11 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
  * Stream receive handler for audio is called from RX thread if enabled
  */
 static void stream_recv_handler(const struct rtp_header *hdr,
-				struct rtpext *extv, size_t extc,
-				struct mbuf *mb, unsigned lostc,
-				bool new_source,
-				bool *ignore,
-				void *arg)
+		struct rtpext *extv, size_t extc,
+		struct mbuf *mb, unsigned lostc,
+		bool new_source,
+		bool *ignore,
+		void *arg)
 {
 	struct audio *a = arg;
 
@@ -656,9 +658,9 @@ static int add_telev_codec(struct audio *a)
 
 	/* Use payload-type 101 if available, for CiscoGW interop */
 	err = sdp_format_add(&sf, m, false,
-			     add ? pts : NULL,
-			     telev_rtpfmt, TELEV_SRATE, 1, NULL,
-			     NULL, NULL, false, "0-15");
+			add ? pts : NULL,
+			telev_rtpfmt, TELEV_SRATE, 1, NULL,
+			NULL, NULL, false, "0-15");
 	if (err)
 		return err;
 
@@ -710,7 +712,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 
 	if (ptime < 1 || ptime > MAX_PTIME) {
 		warning("audio: ptime %ums out of range (%ums - %ums)\n",
-			ptime, 1, MAX_PTIME);
+				ptime, 1, MAX_PTIME);
 		return ENOTSUP;
 	}
 
@@ -727,11 +729,11 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	tx->enc_fmt = cfg->audio.enc_fmt;
 
 	err = stream_alloc(&a->strm, streaml,
-			   stream_prm, &cfg->avt, sdp_sess,
-			   MEDIA_AUDIO,
-			   mnat, mnat_sess, menc, menc_sess, offerer,
-			   stream_recv_handler, NULL, stream_pt_handler,
-			   a);
+			stream_prm, &cfg->avt, sdp_sess,
+			MEDIA_AUDIO,
+			mnat, mnat_sess, menc, menc_sess, offerer,
+			stream_recv_handler, NULL, stream_pt_handler,
+			a);
 	if (err)
 		goto out;
 
@@ -741,8 +743,8 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 
 	if (cfg->avt.rtp_bw.max) {
 		sdp_media_set_lbandwidth(stream_sdpmedia(a->strm),
-					 SDP_BANDWIDTH_AS,
-					 AUDIO_BANDWIDTH / 1000);
+				SDP_BANDWIDTH_AS,
+				AUDIO_BANDWIDTH / 1000);
 	}
 
 	/* Audio codecs */
@@ -759,16 +761,16 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	}
 
 	err  = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-				   "minptime", "%u", minptime);
+			"minptime", "%u", minptime);
 	err |= sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-				   "ptime", "%u", ptime);
+			"ptime", "%u", ptime);
 	if (err)
 		goto out;
 
 
 	tx->mb = mbuf_alloc(STREAM_PRESZ + 4096);
 	tx->sampv = mem_zalloc(AUDIO_SAMPSZ * aufmt_sample_size(tx->enc_fmt),
-			       NULL);
+			NULL);
 
 	if (!tx->mb || !tx->sampv) {
 		err = ENOMEM;
@@ -792,7 +794,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 		tx->device = mem_ref(acc->ausrc_dev);
 
 		info("audio: using account specific source: (%s,%s)\n",
-		     tx->module, tx->device);
+				tx->module, tx->device);
 	}
 	else {
 		err  = str_dup(&tx->module, a->cfg.src_mod);
@@ -812,7 +814,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 			goto out;
 
 		info("audio: using account specific player: (%s,%s)\n",
-		     acc->auplay_mod, acc->auplay_dev);
+				acc->auplay_mod, acc->auplay_dev);
 	}
 	else {
 		err  = aurecv_set_module(a->aur, a->cfg.play_mod);
@@ -830,7 +832,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 	a->errh    = errh;
 	a->arg     = arg;
 
- out:
+	out:
 	if (err)
 		mem_deref(a);
 	else
@@ -849,9 +851,9 @@ int audio_enable_level(struct audio *au)
 	aurecv_set_extmap(au->aur, au->extmap_aulevel);
 
 	return sdp_media_set_lattr(stream_sdpmedia(au->strm), false,
-				   "extmap",
-				   "%u %s",
-				   au->extmap_aulevel, uri_aulevel);
+			"extmap",
+			"%u %s",
+			au->extmap_aulevel, uri_aulevel);
 }
 
 
@@ -896,7 +898,7 @@ static int tx_thread(void *arg)
 			++tx->stats.aubuf_underrun;
 
 			debug("audio: thread: tx aubuf underrun"
-			      " (total %llu)\n", tx->stats.aubuf_underrun);
+				  " (total %llu)\n", tx->stats.aubuf_underrun);
 		}
 
 		ts += tx->ptime;
@@ -906,7 +908,7 @@ static int tx_thread(void *arg)
 		 */
 		check_telev(a, tx);
 
-loop:
+		loop:
 		mtx_lock(tx->mtx);
 	}
 
@@ -916,7 +918,7 @@ loop:
 
 
 static void aufilt_param_set(struct aufilt_prm *prm,
-			     const struct aucodec *ac, enum aufmt fmt)
+		const struct aucodec *ac, enum aufmt fmt)
 {
 	prm->srate      = ac->srate;
 	prm->ch         = ac->ch;
@@ -933,7 +935,7 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 		return 0;
 
 	err = re_hprintf(pf, "audio tx pipeline:  %10s",
-			 autx->as ? autx->as->name : "(src)");
+			autx->as ? autx->as->name : "(src)");
 
 	err |= re_hprintf(pf, " ---> aubuf");
 	for (le = list_head(&autx->filtl); le; le = le->next) {
@@ -944,7 +946,7 @@ static int autx_print_pipeline(struct re_printf *pf, const struct autx *autx)
 	}
 
 	err |= re_hprintf(pf, " ---> %s",
-			  autx->ac ? autx->ac->name : "(encoder)");
+			autx->ac ? autx->ac->name : "(encoder)");
 
 	return err;
 }
@@ -998,7 +1000,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			err = af->encupdh(&encst, &ctx, af, &encprm, a);
 			if (err) {
 				warning("audio: error in encode audio-filter"
-					" '%s' (%m)\n", af->name, err);
+						" '%s' (%m)\n", af->name, err);
 			}
 			else {
 				encst->af = af;
@@ -1012,7 +1014,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 			err = af->decupdh(&decst, &ctx, af, &plprm, a);
 			if (err) {
 				warning("audio: error in decode audio-filter"
-					" '%s' (%m)\n", af->name, err);
+						" '%s' (%m)\n", af->name, err);
 			}
 			else {
 				decst->af = af;
@@ -1022,7 +1024,7 @@ static int aufilt_setup(struct audio *a, struct list *aufiltl)
 
 		if (err) {
 			warning("audio: audio-filter '%s'"
-				" update failed (%m)\n", af->name, err);
+					" update failed (%m)\n", af->name, err);
 			break;
 		}
 	}
@@ -1057,10 +1059,10 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 		size_t sz;
 		size_t psize_alloc;
 		struct ausrc_prm prm = {
-			.srate      = srate_dsp,
-			.ch         = channels_dsp,
-			.ptime      = tx->ptime,
-			.fmt        = tx->src_fmt
+				.srate      = srate_dsp,
+				.ch         = channels_dsp,
+				.ptime      = tx->ptime,
+				.fmt        = tx->src_fmt
 		};
 
 		tx->ausrc_prm = prm;
@@ -1073,18 +1075,18 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 
 		if (!tx->aubuf) {
 			err = aubuf_alloc(&tx->aubuf, tx->psize,
-					  tx->aubuf_maxsz);
+					tx->aubuf_maxsz);
 			if (err)
 				return err;
 		}
 
 		err = ausrc_alloc(&tx->ausrc, ausrcl,
-				  tx->module,
-				  &prm, tx->device,
-				  ausrc_read_handler, ausrc_error_handler, a);
+				tx->module,
+				&prm, tx->device,
+				ausrc_read_handler, ausrc_error_handler, a);
 		if (err) {
 			warning("audio: start_source failed (%s.%s): %m\n",
-				tx->module, tx->device, err);
+					tx->module, tx->device, err);
 			return err;
 		}
 
@@ -1097,7 +1099,7 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			tx->ausrc_prm = prm;
 			tx->aubuf_maxsz = tx->psize * 30;
 			err = aubuf_resize(tx->aubuf, tx->psize,
-					   tx->aubuf_maxsz);
+					tx->aubuf_maxsz);
 			if (err) {
 				mtx_unlock(tx->mtx);
 				return err;
@@ -1110,17 +1112,17 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 		if (!re_atomic_rlx(&tx->thr.run)) {
 			re_atomic_rlx_set(&tx->thr.run, true);
 			err = thread_create_name(&tx->thr.tid,
-						 "Audio TX",
-						 tx_thread, a);
+					"Audio TX",
+					tx_thread, a);
 			if (err) {
 				re_atomic_rlx_set(&tx->thr.run,
-						  false);
+						false);
 				return err;
 			}
 		}
 
 		info("audio: source started with sample format %s\n",
-		     aufmt_name(tx->src_fmt));
+				aufmt_name(tx->src_fmt));
 	}
 
 	stream_enable_tx(a->strm, true);
@@ -1211,8 +1213,8 @@ int audio_update(struct audio *a)
 
 		if (!a->started) {
 			info("%H\n%H\n",
-			     autx_print_pipeline, &a->tx,
-			     aurecv_print_pipeline, a->aur);
+					autx_print_pipeline, &a->tx,
+					aurecv_print_pipeline, a->aur);
 		}
 
 		a->started = true;
@@ -1232,7 +1234,7 @@ int audio_update(struct audio *a)
  * @return 0 if success, otherwise errorcode
  */
 int audio_start_source(struct audio *a, struct list *ausrcl,
-		       struct list *aufiltl)
+		struct list *aufiltl)
 {
 	int err;
 
@@ -1309,7 +1311,7 @@ bool audio_started(const struct audio *a)
  * @return 0 if success, otherwise errorcode
  */
 int audio_encoder_set(struct audio *a, const struct aucodec *ac,
-		      int pt_tx, const char *params)
+		int pt_tx, const char *params)
 {
 	struct autx *tx;
 	int err = 0;
@@ -1321,7 +1323,7 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 
 	if (ac != tx->ac) {
 		info("audio: Set audio encoder: %s %uHz %dch\n",
-		     ac->name, ac->srate, ac->ch);
+				ac->name, ac->srate, ac->ch);
 
 		/* Should the source be stopped first? */
 		if (!aucodec_equal(ac, tx->ac)) {
@@ -1375,7 +1377,7 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
  * @return 0 if success, otherwise errorcode
  */
 int audio_decoder_set(struct audio *a, const struct aucodec *ac,
-		      int pt, const char *params)
+		int pt, const char *params)
 {
 	int err = 0;
 	bool reset = false;
@@ -1447,7 +1449,7 @@ int audio_send_digit(struct audio *a, char key)
 		info("audio: send DTMF digit end: '%c'\n", a->tx.cur_key);
 		mtx_lock(a->tx.mtx);
 		err = telev_send(a->telev,
-				 telev_digit2code(a->tx.cur_key), true);
+				telev_digit2code(a->tx.cur_key), true);
 		mtx_unlock(a->tx.mtx);
 	}
 
@@ -1507,7 +1509,7 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 
 		if (extmap.id < RTPEXT_ID_MIN || extmap.id > RTPEXT_ID_MAX) {
 			warning("audio: extmap id out of range (%u)\n",
-				extmap.id);
+					extmap.id);
 			return false;
 		}
 
@@ -1515,10 +1517,10 @@ static bool extmap_handler(const char *name, const char *value, void *arg)
 		aurecv_set_extmap(a->aur, a->extmap_aulevel);
 
 		err = sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					  "extmap",
-					  "%u %s",
-					  a->extmap_aulevel,
-					  uri_aulevel);
+				"extmap",
+				"%u %s",
+				a->extmap_aulevel,
+				uri_aulevel);
 		if (err)
 			return false;
 
@@ -1545,10 +1547,10 @@ void audio_sdp_attr_decode(struct audio *a)
 		uint32_t ptime_tx = atoi(attr);
 
 		if (ptime_tx && ptime_tx != a->tx.ptime
-		    && ptime_tx <= MAX_PTIME) {
+				&& ptime_tx <= MAX_PTIME) {
 
 			info("audio: peer changed ptime_tx %ums -> %ums\n",
-			     a->tx.ptime, ptime_tx);
+					a->tx.ptime, ptime_tx);
 
 			tx->ptime = ptime_tx;
 
@@ -1558,20 +1560,20 @@ void audio_sdp_attr_decode(struct audio *a)
 				sz = aufmt_sample_size(tx->src_fmt);
 
 				tx->psize = sz * au_calc_nsamp(tx->ac->srate,
-							    tx->ac->ch,
-							    ptime_tx);
+						tx->ac->ch,
+						ptime_tx);
 			}
 
 			sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					    "ptime", "%u", ptime_tx);
+					"ptime", "%u", ptime_tx);
 		}
 	}
 
 	/* Client-to-Mixer Audio Level Indication */
 	if (a->cfg.level) {
 		sdp_media_rattr_apply(stream_sdpmedia(a->strm),
-				      "extmap",
-				      extmap_handler, a);
+				"extmap",
+				extmap_handler, a);
 	}
 }
 
@@ -1642,33 +1644,33 @@ int audio_debug(struct re_printf *pf, const struct audio *a)
 	err  = re_hprintf(pf, "%s", "\n--- Audio stream ---\n");
 
 	err |= re_hprintf(pf, " tx:   encode: %H ptime=%ums %s\n",
-			  aucodec_print, tx->ac,
-			  tx->ptime,
-			  aufmt_name(tx->enc_fmt));
+			aucodec_print, tx->ac,
+			tx->ptime,
+			aufmt_name(tx->enc_fmt));
 	err |= re_hprintf(pf, "       aubuf: %H"
-			  " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
-			  aubuf_debug, tx->aubuf,
-			  calc_ptime(aubuf_cur_size(tx->aubuf)/sztx,
-				     tx->ausrc_prm.srate,
-				     tx->ausrc_prm.ch),
-			  calc_ptime(tx->aubuf_maxsz/sztx,
-				     tx->ausrc_prm.srate,
-				     tx->ausrc_prm.ch),
-			  tx->stats.aubuf_overrun,
-			  tx->stats.aubuf_underrun);
+						  " (cur %.2fms, max %.2fms, or %llu, ur %llu)\n",
+			aubuf_debug, tx->aubuf,
+			calc_ptime(aubuf_cur_size(tx->aubuf)/sztx,
+					tx->ausrc_prm.srate,
+					tx->ausrc_prm.ch),
+			calc_ptime(tx->aubuf_maxsz/sztx,
+					tx->ausrc_prm.srate,
+					tx->ausrc_prm.ch),
+			tx->stats.aubuf_overrun,
+			tx->stats.aubuf_underrun);
 	err |= re_hprintf(pf, "       source: %s,%s %s\n",
-			  tx->as ? tx->as->name : "none",
-			  tx->device,
-			  aufmt_name(tx->src_fmt));
+			tx->as ? tx->as->name : "none",
+			tx->device,
+			aufmt_name(tx->src_fmt));
 	err |= re_hprintf(pf, "       time = %.3f sec\n",
-			  autx_calc_seconds(tx));
+			autx_calc_seconds(tx));
 
 	err |= aurecv_debug(pf, a->aur);
 	err |= re_hprintf(pf,
-			  " %H\n"
-			  " %H\n",
-			  autx_print_pipeline, tx,
-			  aurecv_print_pipeline, a->aur);
+			" %H\n"
+			" %H\n",
+			autx_print_pipeline, tx,
+			aurecv_print_pipeline, a->aur);
 
 	err |= stream_debug(pf, a->strm);
 
@@ -1728,11 +1730,11 @@ int audio_set_source(struct audio *au, const char *mod, const char *device)
 	if (str_isset(mod)) {
 
 		err = ausrc_alloc(&tx->ausrc, baresip_ausrcl(),
-				  mod, &tx->ausrc_prm, device,
-				  ausrc_read_handler, ausrc_error_handler, au);
+				mod, &tx->ausrc_prm, device,
+				ausrc_read_handler, ausrc_error_handler, au);
 		if (err) {
 			warning("audio: set_source failed (%s.%s): %m\n",
-				mod, device, err);
+					mod, device, err);
 			return err;
 		}
 
@@ -1770,10 +1772,10 @@ int audio_set_player(struct audio *a, const char *mod, const char *device)
 		goto out;
 
 	err = aurecv_start_player(a->aur, baresip_auplayl());
-out:
+	out:
 	if (err) {
 		warning("audio: set player failed (%s.%s): %m\n",
-			mod, device, err);
+				mod, device, err);
 		return err;
 	}
 
@@ -1803,8 +1805,8 @@ int audio_set_bitrate(struct audio *au, uint32_t bitrate)
 	ac = tx->ac;
 
 	info("audio: set bitrate for encoder '%s' to %u bits/s\n",
-	     ac ? ac->name : "?",
-	     bitrate);
+			ac ? ac->name : "?",
+			bitrate);
 
 	if (ac) {
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -87,6 +87,7 @@ struct stream {
 	struct sender tx;
 
 	struct rtp_receiver *rx;
+	RE_ATOMIC bool rx_closed;
 	struct rxmain rxm;
 };
 
@@ -101,27 +102,27 @@ static void print_rtp_stats(const struct stream *s)
 		return;
 
 	info("\n%-9s       Transmit:     Receive:\n"
-	     "packets:        %7u      %7u\n"
-	     "avg. bitrate:   %7.1f      %7.1f  (kbit/s)\n"
-	     "errors:         %7d      %7d\n"
-	     ,
-	     sdp_media_name(s->sdp),
-	     tx_n_packets, rx_n_packets,
-	     1.0*metric_avg_bitrate(s->tx.metric)/1000.0,
-	     1.0*metric_avg_bitrate(rtprecv_metric(s->rx))/1000.0,
-	     metric_n_err(s->tx.metric),
-	     metric_n_err(rtprecv_metric(s->rx))
-	     );
+		 "packets:        %7u      %7u\n"
+		 "avg. bitrate:   %7.1f      %7.1f  (kbit/s)\n"
+		 "errors:         %7d      %7d\n"
+			,
+			sdp_media_name(s->sdp),
+			tx_n_packets, rx_n_packets,
+			1.0*metric_avg_bitrate(s->tx.metric)/1000.0,
+			1.0*metric_avg_bitrate(rtprecv_metric(s->rx))/1000.0,
+			metric_n_err(s->tx.metric),
+			metric_n_err(rtprecv_metric(s->rx))
+	);
 
 	if (s->rtcp_stats.tx.sent || s->rtcp_stats.rx.sent) {
 
 		info("pkt.report:     %7u      %7u\n"
-		     "lost:           %7d      %7d\n"
-		     "jitter:         %7.1f      %7.1f  (ms)\n",
-		     s->rtcp_stats.tx.sent, s->rtcp_stats.rx.sent,
-		     s->rtcp_stats.tx.lost, s->rtcp_stats.rx.lost,
-		     1.0*s->rtcp_stats.tx.jit/1000,
-		     1.0*s->rtcp_stats.rx.jit/1000);
+			 "lost:           %7d      %7d\n"
+			 "jitter:         %7.1f      %7.1f  (ms)\n",
+				s->rtcp_stats.tx.sent, s->rtcp_stats.rx.sent,
+				s->rtcp_stats.tx.lost, s->rtcp_stats.rx.lost,
+				1.0*s->rtcp_stats.tx.jit/1000,
+				1.0*s->rtcp_stats.rx.jit/1000);
 	}
 }
 
@@ -157,9 +158,9 @@ static const char *media_name(enum media_type type)
 {
 	switch (type) {
 
-	case MEDIA_AUDIO: return "audio";
-	case MEDIA_VIDEO: return "video";
-	default:          return "???";
+		case MEDIA_AUDIO: return "audio";
+		case MEDIA_VIDEO: return "video";
+		default:          return "???";
 	}
 }
 
@@ -167,7 +168,7 @@ static const char *media_name(enum media_type type)
 static void send_set_raddr(struct stream *strm, const struct sa *raddr)
 {
 	debug("stream: set remote addr for '%s': %J\n",
-	     media_name(strm->type), raddr);
+			media_name(strm->type), raddr);
 
 	mtx_lock(strm->tx.lock);
 	strm->tx.raddr_rtp  = *raddr;
@@ -200,11 +201,14 @@ int stream_enable_tx(struct stream *strm, bool enable)
 
 	if (!enable) {
 		debug("stream: disable %s RTP sender\n",
-		      media_name(strm->type));
+				media_name(strm->type));
 
 		re_atomic_rls_set(&strm->tx.enabled, false);
 		return 0;
 	}
+
+	if (!strm->sdp || !strm->tx.lock)
+		return EINVAL;
 
 	if (!stream_is_ready(strm))
 		return EAGAIN;
@@ -228,6 +232,13 @@ int stream_enable_tx(struct stream *strm, bool enable)
 static void stream_start_receiver(void *arg)
 {
 	struct stream *s = arg;
+
+	if (!s || re_atomic_rlx(&s->rx_closed) || !s->rx) {
+		if (s)
+			tmr_cancel(&s->rxm.tmr_rec);
+		return;
+	}
+
 	rtprecv_start_thread(s->rx);
 }
 
@@ -245,9 +256,12 @@ int stream_enable_rx(struct stream *strm, bool enable)
 	if (!strm)
 		return EINVAL;
 
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx)
+		return 0;
+
 	if (!enable) {
 		debug("stream: disable %s RTP receiver\n",
-		      media_name(strm->type));
+				media_name(strm->type));
 
 		rtprecv_enable(strm->rx, false);
 		return 0;
@@ -260,16 +274,16 @@ int stream_enable_rx(struct stream *strm, bool enable)
 	rtprecv_enable(strm->rx, true);
 
 	if (strm->rtp && strm->cfg.rxmode == RECEIVE_MODE_THREAD &&
-	    strm->type == MEDIA_AUDIO && !rtprecv_running(strm->rx)) {
+			strm->type == MEDIA_AUDIO && !rtprecv_running(strm->rx)) {
 		if (stream_bundle(strm)) {
 			warning("stream: rtp_rxmode thread was disabled "
-				"because it is not supported in combination "
-				"with avt_bundle\n");
+					"because it is not supported in combination "
+					"with avt_bundle\n");
 		}
 		else {
 			strm->rxm.use_rxthread = true;
 			tmr_start(&strm->rxm.tmr_rec, 1, stream_start_receiver,
-				  strm);
+					strm);
 		}
 	}
 
@@ -282,10 +296,16 @@ static void stream_close(struct stream *strm, int err)
 	stream_error_h *errorh = strm->errorh;
 
 	strm->terminated = true;
+	re_atomic_rlx_set(&strm->rx_closed, true);
 	stream_enable(strm, false);
 	strm->errorh = NULL;
 
-	strm->rx = mem_deref(strm->rx);
+	tmr_cancel(&strm->rxm.tmr_rtp);
+	tmr_cancel(&strm->rxm.tmr_rec);
+	tmr_cancel(&strm->tmr_natph);
+	struct rtp_receiver *rx = strm->rx;
+	strm->rx = NULL;
+	mem_deref(rx);
 	if (errorh)
 		errorh(strm, err, strm->sess_arg);
 }
@@ -300,8 +320,13 @@ static void check_rtp_handler(void *arg)
 
 	MAGIC_CHECK(strm);
 
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx) {
+		tmr_cancel(&strm->rxm.tmr_rtp);
+		return;
+	}
+
 	tmr_start(&strm->rxm.tmr_rtp, RTP_CHECK_INTERVAL,
-		  check_rtp_handler, strm);
+			check_rtp_handler, strm);
 
 	/* If no RTP was received at all, check later */
 	ts_last = rtprecv_ts_last(strm->rx);
@@ -317,8 +342,8 @@ static void check_rtp_handler(void *arg)
 
 		if (diff_ms > 100) {
 			debug("stream: last \"%s\" RTP packet: %d "
-			      "milliseconds\n",
-			      sdp_media_name(strm->sdp), diff_ms);
+				  "milliseconds\n",
+					sdp_media_name(strm->sdp), diff_ms);
 		}
 
 		/* check for large jumps in time */
@@ -330,16 +355,16 @@ static void check_rtp_handler(void *arg)
 		if (diff_ms > (int)strm->rxm.rtp_timeout) {
 
 			info("stream: no %s RTP packets received for"
-			     " %d milliseconds\n",
-			     sdp_media_name(strm->sdp), diff_ms);
+				 " %d milliseconds\n",
+					sdp_media_name(strm->sdp), diff_ms);
 
 			stream_close(strm, ETIMEDOUT);
 		}
 	}
 	else {
 		debug("check_rtp: not checking \"%s\" RTP (dir=%s)\n",
-			  sdp_media_name(strm->sdp),
-			  sdp_dir_name(sdp_media_dir(strm->sdp)));
+				sdp_media_name(strm->sdp),
+				sdp_dir_name(sdp_media_dir(strm->sdp)));
 	}
 }
 
@@ -374,12 +399,12 @@ static int stream_sock_alloc(struct stream *s, int af)
 	sa_init(&laddr, af);
 
 	err = rtp_listen(&s->rtp, IPPROTO_UDP, &laddr,
-			 s->cfg.rtp_ports.min, s->cfg.rtp_ports.max,
-			 true, rtprecv_decode, rtprecv_handle_rtcp, s->rx);
+			s->cfg.rtp_ports.min, s->cfg.rtp_ports.max,
+			true, rtprecv_decode, rtprecv_handle_rtcp, s->rx);
 	if (err) {
 		warning("stream: rtp_listen failed: af=%s ports=%u-%u"
-			" (%m)\n", net_af2name(af),
-			s->cfg.rtp_ports.min, s->cfg.rtp_ports.max, err);
+				" (%m)\n", net_af2name(af),
+				s->cfg.rtp_ports.min, s->cfg.rtp_ports.max, err);
 		return err;
 	}
 
@@ -418,8 +443,8 @@ int stream_start_mediaenc(struct stream *strm)
 		struct sa raddr_rtcp;
 
 		info("stream: %s: starting mediaenc '%s' (wait_secure=%d)\n",
-		     media_name(strm->type), strm->menc->id,
-		     strm->menc->wait_secure);
+				media_name(strm->type), strm->menc->id,
+				strm->menc->wait_secure);
 
 		mtx_lock(strm->tx.lock);
 		sa_cpy(&raddr_rtp,  &strm->tx.raddr_rtp);
@@ -427,11 +452,11 @@ int stream_start_mediaenc(struct stream *strm)
 		mtx_unlock(strm->tx.lock);
 
 		err = strm->menc->mediah(&strm->mes, strm->mencs, strm->rtp,
-				 rtp_sock(strm->rtp),
-				 strm->rtcp_mux ? NULL : rtcp_sock(strm->rtp),
-				 &raddr_rtp,
-				 strm->rtcp_mux ? NULL : &raddr_rtcp,
-					 strm->sdp, strm);
+				rtp_sock(strm->rtp),
+				strm->rtcp_mux ? NULL : rtcp_sock(strm->rtp),
+				&raddr_rtp,
+				strm->rtcp_mux ? NULL : &raddr_rtcp,
+				strm->sdp, strm);
 		if (err) {
 			warning("stream: start mediaenc error: %m\n", err);
 			return err;
@@ -443,7 +468,7 @@ int stream_start_mediaenc(struct stream *strm)
 
 
 static void update_all_remote_addr(struct list *streaml,
-				   const struct sa *raddr)
+		const struct sa *raddr)
 {
 	struct le *le;
 
@@ -460,15 +485,15 @@ static void update_all_remote_addr(struct list *streaml,
 
 
 void stream_mnat_connected(struct stream *strm, const struct sa *raddr1,
-			   const struct sa *raddr2)
+		const struct sa *raddr2)
 {
 	info("stream: '%s' mnat '%s' connected: raddr %J %J\n",
-	     media_name(strm->type),
-	     strm->mnat->id, raddr1, raddr2);
+			media_name(strm->type),
+			strm->mnat->id, raddr1, raddr2);
 
 	if (bundle_state(stream_bundle(strm)) == BUNDLE_MUX) {
 		warning("stream: unexpected mnat connected"
-			" in bundle state Mux\n");
+				" in bundle state Mux\n");
 		return;
 	}
 
@@ -529,15 +554,15 @@ static int sender_init(struct sender *tx)
 
 
 int stream_alloc(struct stream **sp, struct list *streaml,
-		 const struct stream_param *prm,
-		 const struct config_avt *cfg,
-		 struct sdp_session *sdp_sess,
-		 enum media_type type,
-		 const struct mnat *mnat, struct mnat_sess *mnat_sess,
-		 const struct menc *menc, struct menc_sess *menc_sess,
-		 bool offerer,
-		 stream_rtp_h *rtph, stream_rtcp_h *rtcph, stream_pt_h *pth,
-		 void *arg)
+		const struct stream_param *prm,
+		const struct config_avt *cfg,
+		struct sdp_session *sdp_sess,
+		enum media_type type,
+		const struct mnat *mnat, struct mnat_sess *mnat_sess,
+		const struct menc *menc, struct menc_sess *menc_sess,
+		bool offerer,
+		stream_rtp_h *rtph, stream_rtcp_h *rtcph, stream_pt_h *pth,
+		void *arg)
 {
 	struct stream *s;
 	int err;
@@ -573,11 +598,11 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 
 	if (prm->use_rtp) {
 		err = rtprecv_alloc(&s->rx, s, media_name(type), cfg,
-			       rtph, pth, arg);
+				rtph, pth, arg);
 		if (err) {
 			warning("stream: failed to create receiver"
-				" for media '%s' (%m)\n",
-				media_name(type), err);
+					" for media '%s' (%m)\n",
+					media_name(type), err);
 			goto out;
 		}
 
@@ -586,8 +611,8 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		err = stream_sock_alloc(s, prm->af);
 		if (err) {
 			warning("stream: failed to create socket"
-				" for media '%s' (%m)\n",
-				media_name(type), err);
+					" for media '%s' (%m)\n",
+					media_name(type), err);
 			goto out;
 		}
 	}
@@ -603,9 +628,9 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	}
 
 	err = sdp_media_add(&s->sdp, sdp_sess, media_name(type),
-			    s->rtp ? sa_port(rtp_local(s->rtp)) : PORT_DISCARD,
-			    (menc && menc->sdp_proto) ? menc->sdp_proto :
-			    sdp_proto_rtpavp);
+			s->rtp ? sa_port(rtp_local(s->rtp)) : PORT_DISCARD,
+			(menc && menc->sdp_proto) ? menc->sdp_proto :
+					sdp_proto_rtpavp);
 	if (err)
 		goto out;
 
@@ -615,12 +640,12 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 
 	/* RFC 5576 */
 	err |= sdp_media_set_lattr(s->sdp, true,
-				   "ssrc", "%u cname:%s",
-				   rtp_sess_ssrc(s->rtp), prm->cname);
+			"ssrc", "%u cname:%s",
+			rtp_sess_ssrc(s->rtp), prm->cname);
 
 	/* RFC 5761 */
 	if (s->cfg.rtcp_mux &&
-	    (offerer || sdp_media_rattr(s->sdp, "rtcp-mux"))) {
+			(offerer || sdp_media_rattr(s->sdp, "rtcp-mux"))) {
 
 		err |= sdp_media_set_lattr(s->sdp, true, "rtcp-mux", NULL);
 	}
@@ -629,7 +654,7 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 		uint32_t ix = list_count(streaml);
 
 		err |= sdp_media_set_lattr(s->sdp, true, "mid", "%u",
-					   ix);
+				ix);
 
 		re_sdprintf(&s->mid, "%u", ix);
 	}
@@ -640,10 +665,10 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 	if (mnat && s->rtp) {
 		s->mnat = mnat;
 		err = mnat->mediah(&s->mns, mnat_sess,
-				   rtp_sock(s->rtp),
-				   s->cfg.rtcp_mux ? NULL : rtcp_sock(s->rtp),
-				   s->sdp,
-				   rtprecv_mnat_connected_handler, s->rx);
+				rtp_sock(s->rtp),
+				s->cfg.rtcp_mux ? NULL : rtcp_sock(s->rtp),
+				s->sdp,
+				rtprecv_mnat_connected_handler, s->rx);
 		if (err)
 			goto out;
 	}
@@ -659,7 +684,7 @@ int stream_alloc(struct stream **sp, struct list *streaml,
 
 	list_append(streaml, &s->le, s);
 
- out:
+	out:
 	if (err)
 		mem_deref(s);
 	else
@@ -762,7 +787,7 @@ int stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
 	if (pt >= 0) {
 		mtx_lock(s->tx.lock);
 		err = rtp_send(s->rtp, &s->tx.raddr_rtp, ext, marker, pt, ts,
-			       tmr_jiffies_rt_usec(), mb);
+				tmr_jiffies_rt_usec(), mb);
 		mtx_unlock(s->tx.lock);
 		if (err)
 			metric_inc_err(s->tx.metric);
@@ -786,7 +811,7 @@ int stream_send(struct stream *s, bool ext, bool marker, int pt, uint32_t ts,
  * @return int	0 if success, errorcode otherwise
  */
 int stream_resend(struct stream *s, uint16_t seq, bool ext, bool marker,
-		  int pt, uint32_t ts, struct mbuf *mb)
+		int pt, uint32_t ts, struct mbuf *mb)
 {
 	struct sa raddr_rtp;
 
@@ -852,7 +877,7 @@ static void stream_remote_set(struct stream *s)
 
 		if (!s->rtcp_mux)
 			info("%s: RTP/RTCP multiplexing enabled\n",
-			     sdp_media_name(s->sdp));
+					sdp_media_name(s->sdp));
 		s->rtcp_mux = true;
 
 		sdp_media_set_lattr(s->sdp, true, "rtcp-mux", NULL);
@@ -1077,6 +1102,11 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
 	if (!strm)
 		return;
 
+	if (re_atomic_rlx(&strm->rx_closed) || !strm->rx) {
+		tmr_cancel(&strm->rxm.tmr_rtp);
+		return;
+	}
+
 	m = stream_sdpmedia(strm);
 	if (!sdp_media_has_media(m))
 		return;
@@ -1095,7 +1125,7 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
 	if (timeout_ms) {
 
 		info("stream: Enable RTP timeout (%u milliseconds)\n",
-		     timeout_ms);
+				timeout_ms);
 
 		rtprecv_set_ts_last(strm->rx, tmr_jiffies());
 		tmr_start(&strm->rxm.tmr_rtp, 10, check_rtp_handler, strm);
@@ -1114,10 +1144,10 @@ void stream_enable_rtp_timeout(struct stream *strm, uint32_t timeout_ms)
  * @param arg       Handler argument
  */
 void stream_set_session_handlers(struct stream *strm,
-				 stream_mnatconn_h *mnatconnh,
-				 stream_rtpestab_h *rtpestabh,
-				 stream_rtcp_h *rtcph,
-				 stream_error_h *errorh, void *arg)
+		stream_mnatconn_h *mnatconnh,
+		stream_rtpestab_h *rtpestabh,
+		stream_rtcp_h *rtcph,
+		stream_error_h *errorh, void *arg)
 {
 	if (!strm)
 		return;
@@ -1356,6 +1386,9 @@ static void natpinhole_handler(void *arg)
 	struct sa raddr_rtp;
 	int err = 0;
 
+	if (!strm || strm->terminated || !strm->rtp)
+		return;
+
 	sc = sdp_media_rformat(strm->sdp, NULL);
 	if (!sc)
 		return;
@@ -1364,7 +1397,6 @@ static void natpinhole_handler(void *arg)
 	if (!mb)
 		return;
 
-	tmr_start(&strm->tmr_natph, phwait(strm), natpinhole_handler, strm);
 	mbuf_set_end(mb, RTP_HEADER_SIZE);
 	mbuf_advance(mb, RTP_HEADER_SIZE);
 
@@ -1374,13 +1406,17 @@ static void natpinhole_handler(void *arg)
 
 	/* Send a dummy RTP packet to open NAT pinhole */
 	err = rtp_send(strm->rtp, &raddr_rtp, false, false,
-		       sc->pt, 0, tmr_jiffies_rt_usec(), mb);
+			sc->pt, 0, tmr_jiffies_rt_usec(), mb);
 	if (err) {
 		warning("stream: rtp_send to open natpinhole"
-			"failed (%m)\n", err);
+				"failed (%m)\n", err);
 	}
 
 	mem_deref(mb);
+
+	if (!strm->terminated)
+		tmr_start(&strm->tmr_natph, phwait(strm),
+				natpinhole_handler, strm);
 }
 
 
@@ -1434,11 +1470,11 @@ int stream_start_rtcp(const struct stream *strm)
 		return EINVAL;
 
 	debug("stream: %s: starting RTCP with remote %J\n",
-	      media_name(strm->type), &strm->tx.raddr_rtcp);
+			media_name(strm->type), &strm->tx.raddr_rtcp);
 
 	if (strm->rxm.use_rxthread) {
 		err = rtprecv_start_rtcp(strm->rx, strm->cname,
-					 &strm->tx.raddr_rtcp, !strm->mnat);
+				&strm->tx.raddr_rtcp, !strm->mnat);
 	}
 	else {
 		rtcp_start(strm->rtp, strm->cname, &strm->tx.raddr_rtcp);
@@ -1446,10 +1482,10 @@ int stream_start_rtcp(const struct stream *strm)
 		if (!strm->mnat) {
 			/* Send a dummy RTCP packet to open NAT pinhole */
 			err = rtcp_send_app(strm->rtp, "PING",
-					    (void *)"PONG", 4);
+					(void *)"PONG", 4);
 			if (err) {
 				warning("stream: rtcp_send_app failed (%m)\n",
-					err);
+						err);
 				return err;
 			}
 		}
@@ -1588,7 +1624,7 @@ struct rtp_sock *stream_rtp_sock(const struct stream *strm)
 
 
 struct stream *stream_lookup_mid(const struct list *streaml,
-				 const char *mid, size_t len)
+		const char *mid, size_t len)
 {
 	struct le *le;
 
@@ -1596,7 +1632,7 @@ struct stream *stream_lookup_mid(const struct list *streaml,
 		struct stream *strm = le->data;
 
 		if (len == str_len(strm->mid) &&
-		    0 == memcmp(strm->mid, mid, len))
+				0 == memcmp(strm->mid, mid, len))
 			return strm;
 	}
 
@@ -1670,24 +1706,24 @@ int stream_debug(struct re_printf *pf, const struct stream *s)
 	err  = mbuf_printf(mb, "--- Stream debug ---\n");
 	mtx_lock(s->tx.lock);
 	err |= mbuf_printf(mb, " %s dir=%s pt_enc=%d\n",
-			   sdp_media_name(s->sdp),
-			   sdp_dir_name(sdp_media_dir(s->sdp)),
-			   s->tx.pt_enc);
+			sdp_media_name(s->sdp),
+			sdp_dir_name(sdp_media_dir(s->sdp)),
+			s->tx.pt_enc);
 
 	err |= mbuf_printf(mb, " local: %J, remote: %J/%J\n",
-			   sdp_media_laddr(s->sdp),
-			   &s->tx.raddr_rtp, &s->tx.raddr_rtcp);
+			sdp_media_laddr(s->sdp),
+			&s->tx.raddr_rtp, &s->tx.raddr_rtcp);
 
 	err |= mbuf_printf(mb, " mnat: %s (connected=%s)\n",
-			   s->mnat ? s->mnat->id : "(none)",
-			   s->mnat_connected ? "yes" : "no");
+			s->mnat ? s->mnat->id : "(none)",
+			s->mnat_connected ? "yes" : "no");
 
 	err |= mbuf_printf(mb, " menc: %s (secure=%s)\n",
-			   s->menc ? s->menc->id : "(none)",
-			   s->menc_secure ? "yes" : "no");
+			s->menc ? s->menc->id : "(none)",
+			s->menc_secure ? "yes" : "no");
 
 	err |= mbuf_printf(mb, " tx.enabled: %s\n",
-			   re_atomic_rlx(&s->tx.enabled) ? "yes" : "no");
+			re_atomic_rlx(&s->tx.enabled) ? "yes" : "no");
 	err |= rtprecv_debug(&pfmb, s->rx);
 	err |= rtp_debug(&pfmb, s->rtp);
 
@@ -1699,7 +1735,7 @@ int stream_debug(struct re_printf *pf, const struct stream *s)
 		goto out;
 
 	err = re_hprintf(pf, "%b", mb->buf, mb->pos);
-out:
+	out:
 	mem_deref(mb);
 	return err;
 }
@@ -1711,8 +1747,8 @@ int stream_print(struct re_printf *pf, const struct stream *s)
 		return 0;
 
 	return re_hprintf(pf, " %s=%u/%u", sdp_media_name(s->sdp),
-			  metric_bitrate(s->tx.metric),
-			  metric_bitrate(rtprecv_metric(s->rx)));
+			metric_bitrate(s->tx.metric),
+			metric_bitrate(rtprecv_metric(s->rx)));
 }
 
 
@@ -1729,7 +1765,7 @@ void stream_parse_mid(struct stream *strm)
 
 		if (str_isset(strm->mid)) {
 			info("stream: parse mid: '%s' -> '%s'\n",
-			     strm->mid, rmid);
+					strm->mid, rmid);
 		}
 
 		strm->mid = mem_deref(strm->mid);
@@ -1748,7 +1784,7 @@ void stream_enable_bundle(struct stream *strm, enum bundle_state st)
 		return;
 
 	info("stream: '%s' enable bundle (%s)\n",
-	     media_name(strm->type), bundle_state_name(st));
+			media_name(strm->type), bundle_state_name(st));
 
 	bundle_set_state(strm->bundle, st);
 

--- a/src/video.c
+++ b/src/video.c
@@ -198,9 +198,9 @@ static void vidqent_destructor(void *arg)
 
 
 static int vidqent_alloc(struct vidqent **qentp, struct stream *strm,
-			 bool marker, uint8_t pt, uint32_t ts,
-			 const uint8_t *hdr, size_t hdr_len,
-			 const uint8_t *pld, size_t pld_len)
+		bool marker, uint8_t pt, uint32_t ts,
+		const uint8_t *hdr, size_t hdr_len,
+		const uint8_t *pld, size_t pld_len)
 {
 	struct bundle *bun = stream_bundle(strm);
 	struct vidqent *qent;
@@ -239,7 +239,7 @@ static int vidqent_alloc(struct vidqent **qentp, struct stream *strm,
 		pos = qent->mb->pos;
 
 		rtpext_encode(qent->mb, bundle_extmap_mid(bun),
-			      str_len(mid), (void *)mid);
+				str_len(mid), (void *)mid);
 
 		ext_len = qent->mb->pos - pos;
 
@@ -263,7 +263,7 @@ static int vidqent_alloc(struct vidqent **qentp, struct stream *strm,
 
 	qent->mb->pos = RTP_PRESZ;
 
- out:
+	out:
 	if (err)
 		mem_deref(qent);
 	else
@@ -331,9 +331,9 @@ static double get_fps(const struct video *v)
 
 
 static int packet_handler(bool marker, uint64_t ts,
-			  const uint8_t *hdr, size_t hdr_len,
-			  const uint8_t *pld, size_t pld_len,
-			  const struct video *vid)
+		const uint8_t *hdr, size_t hdr_len,
+		const uint8_t *pld, size_t pld_len,
+		const struct video *vid)
 {
 	struct vtx *vtx = (struct vtx *)&vid->vtx;
 	struct stream *strm = vid->strm;
@@ -355,7 +355,7 @@ static int packet_handler(bool marker, uint64_t ts,
 	rtp_ts = vtx->ts_offset + (ts & 0xffffffff);
 
 	err = vidqent_alloc(&qent, strm, marker, pt, rtp_ts,
-			    hdr, hdr_len, pld, pld_len);
+			hdr, hdr_len, pld, pld_len);
 	if (err)
 		return err;
 
@@ -379,7 +379,7 @@ static int packet_handler(bool marker, uint64_t ts,
  * @param timestamp  Frame timestamp in VIDEO_TIMEBASE units
  */
 static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
-			    struct vidpacket *packet, uint64_t timestamp)
+		struct vidpacket *packet, uint64_t timestamp)
 {
 	struct le *le;
 	int err = 0;
@@ -401,7 +401,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 		}
 		else {
 			warning("video: Skipping Packet as"
-				" Packetize Handler not initialized ..\n");
+					" Packetize Handler not initialized ..\n");
 		}
 		goto out;
 	}
@@ -426,8 +426,8 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 		if (!vtx->frame) {
 
 			err = vidframe_alloc(&vtx->frame,
-					     vtx->video->cfg.enc_fmt,
-					     &vtx->vsrc_size);
+					vtx->video->cfg.enc_fmt,
+					&vtx->vsrc_size);
 			if (err)
 				goto out;
 		}
@@ -458,7 +458,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
 
 	vtx->picup = false;
 
- out:
+	out:
 	mtx_unlock(vtx->lock_enc);
 }
 
@@ -473,7 +473,7 @@ static void encode_rtp_send(struct vtx *vtx, struct vidframe *frame,
  * @note This function has REAL-TIME properties
  */
 static void vidsrc_frame_handler(struct vidframe *frame, uint64_t timestamp,
-				 void *arg)
+		void *arg)
 {
 	struct vtx *vtx = arg;
 
@@ -573,7 +573,7 @@ static int vtx_thread(void *arg)
 		mbd = mbuf_dup(qent->mb);
 
 		stream_send(vtx->video->strm, qent->ext, qent->marker,
-			    qent->pt, qent->ts, qent->mb);
+				qent->pt, qent->ts, qent->mb);
 
 		mem_deref(qent->mb);
 
@@ -677,11 +677,11 @@ static void send_fir(struct stream *s, bool pli)
 	}
 	else
 		err = rtcp_send_fir(stream_rtp_sock(s),
-				    rtp_sess_ssrc(stream_rtp_sock(s)));
+				rtp_sess_ssrc(stream_rtp_sock(s)));
 
 	if (err) {
 		warning("video: failed to send RTCP %s: %m\n",
-			pli ? "PLI" : "FIR", err);
+				pli ? "PLI" : "FIR", err);
 	}
 }
 
@@ -712,21 +712,21 @@ static void update_rtp_timestamp(struct timestamp_recv *tsr, uint32_t rtp_ts)
 
 		switch (wrap) {
 
-		case -1:
-			info("video: rtp timestamp wraps backwards"
-			     " (delta = %d) -- discard\n",
-			     (int32_t)(tsr->last - rtp_ts));
-			return;
+			case -1:
+				info("video: rtp timestamp wraps backwards"
+					 " (delta = %d) -- discard\n",
+						(int32_t)(tsr->last - rtp_ts));
+				return;
 
-		case 0:
-			break;
+			case 0:
+				break;
 
-		case 1:
-			++tsr->num_wraps;
-			break;
+			case 1:
+				++tsr->num_wraps;
+				break;
 
-		default:
-			break;
+			default:
+				break;
 		}
 	}
 	else {
@@ -749,7 +749,7 @@ static void update_rtp_timestamp(struct timestamp_recv *tsr, uint32_t rtp_ts)
  * @return 0 if success, otherwise errorcode
  */
 static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
-			       struct mbuf *mb)
+		struct mbuf *mb)
 {
 	struct video *v = vrx->video;
 	struct vidframe *frame_filt = NULL;
@@ -774,17 +774,17 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	/* convert the RTP timestamp to VIDEO_TIMEBASE timestamp */
 	pkt.timestamp = video_calc_timebase_timestamp(
-			  timestamp_calc_extended(vrx->ts_recv.num_wraps,
-						  vrx->ts_recv.last));
+			timestamp_calc_extended(vrx->ts_recv.num_wraps,
+					vrx->ts_recv.last));
 
 	err = vrx->vc->dech(vrx->dec, frame, &pkt);
 	if (err) {
 
 		if (err != EPROTO) {
 			warning("video: %s decode error"
-				" (seq=%u, %zu bytes): %m\n",
-				vrx->vc->name, hdr->seq,
-				mbuf_get_left(mb), err);
+					" (seq=%u, %zu bytes): %m\n",
+					vrx->vc->name, hdr->seq,
+					mbuf_get_left(mb), err);
 		}
 
 		RE_TRACE_INSTANT("video", "decode_err");
@@ -804,9 +804,9 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	if (!vrx->size.w) {
 		info("video: receiving with resolution %u x %u"
-		     " and format '%s'\n",
-		     frame->size.w, frame->size.h,
-		     vidfmt_name(frame->fmt));
+			 " and format '%s'\n",
+				frame->size.w, frame->size.h,
+				vidfmt_name(frame->fmt));
 	}
 
 	vrx->size = frame->size;
@@ -836,7 +836,7 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	if (vrx->vd && vrx->vd->disph && vrx->vidisp)
 		err = vrx->vd->disph(vrx->vidisp, v->peer, frame,
-				     pkt.timestamp);
+				pkt.timestamp);
 
 	frame_filt = mem_deref(frame_filt);
 	if (err == ENODEV) {
@@ -855,7 +855,7 @@ static int video_stream_decode(struct vrx *vrx, const struct rtp_header *hdr,
 
 	++vrx->frames;
 
-out:
+	out:
 	mtx_unlock(&vrx->lock);
 
 	return err;
@@ -873,7 +873,7 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 
 	if (v->vrx.pt_rx != -1)
 		info("Video decoder changed payload %d -> %u\n",
-		     v->vrx.pt_rx, pt);
+				v->vrx.pt_rx, pt);
 
 	lc = sdp_media_lformat(stream_sdpmedia(v->strm), pt);
 	if (!lc)
@@ -886,11 +886,11 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 
 /* Handle incoming stream data from the network */
 static void stream_recv_handler(const struct rtp_header *hdr,
-				struct rtpext *extv, size_t extc,
-				struct mbuf *mb, unsigned lostc,
-				bool new_source,
-				bool *ignore,
-				void *arg)
+		struct rtpext *extv, size_t extc,
+		struct mbuf *mb, unsigned lostc,
+		bool new_source,
+		bool *ignore,
+		void *arg)
 {
 	struct video *v = arg;
 	(void)extv;
@@ -916,7 +916,7 @@ static void rtcp_nack_handler(struct vtx *vtx, struct rtcp_msg *msg)
 	struct le *le;
 
 	if (!msg || msg->hdr.count != RTCP_RTPFB_GNACK ||
-	    !msg->r.fb.fci.gnackv)
+			!msg->r.fb.fci.gnackv)
 		return;
 
 	nack_pid = msg->r.fb.fci.gnackv->pid;
@@ -948,7 +948,7 @@ static void rtcp_nack_handler(struct vtx *vtx, struct rtcp_msg *msg)
 
 		debug("NACK resend rtp seq: %u\n", pids[i]);
 		stream_resend(vtx->video->strm, qent->seq, qent->ext,
-			      qent->marker, qent->pt, qent->ts, qent->mb);
+				qent->marker, qent->pt, qent->ts, qent->mb);
 
 		/* sent only once */
 		mem_deref(qent);
@@ -968,32 +968,32 @@ static void rtcp_handler(struct stream *strm, struct rtcp_msg *msg, void *arg)
 
 	switch (msg->hdr.pt) {
 
-	case RTCP_FIR:
-		mtx_lock(vtx->lock_enc);
-		debug("video: recv Full Intra Request (FIR)\n");
-		vtx->picup = true;
-		mtx_unlock(vtx->lock_enc);
-		break;
-
-	case RTCP_PSFB:
-		if (msg->hdr.count == RTCP_PSFB_PLI ||
-		    msg->hdr.count == RTCP_PSFB_FIR) {
-			const char *s = msg->hdr.count == RTCP_PSFB_PLI ?
-				"Picture Loss Indication (PLI)" :
-				"Full Intra Request (FIR)";
-			debug("video: recv %s\n", s);
+		case RTCP_FIR:
 			mtx_lock(vtx->lock_enc);
+			debug("video: recv Full Intra Request (FIR)\n");
 			vtx->picup = true;
 			mtx_unlock(vtx->lock_enc);
-		}
-		break;
+			break;
 
-	case RTCP_RTPFB:
-		rtcp_nack_handler(vtx, msg);
-		break;
+		case RTCP_PSFB:
+			if (msg->hdr.count == RTCP_PSFB_PLI ||
+					msg->hdr.count == RTCP_PSFB_FIR) {
+				const char *s = msg->hdr.count == RTCP_PSFB_PLI ?
+						"Picture Loss Indication (PLI)" :
+						"Full Intra Request (FIR)";
+				debug("video: recv %s\n", s);
+				mtx_lock(vtx->lock_enc);
+				vtx->picup = true;
+				mtx_unlock(vtx->lock_enc);
+			}
+			break;
 
-	default:
-		break;
+		case RTCP_RTPFB:
+			rtcp_nack_handler(vtx, msg);
+			break;
+
+		default:
+			break;
 	}
 }
 
@@ -1010,7 +1010,7 @@ static int vtx_print_pipeline(struct re_printf *pf, const struct vtx *vtx)
 	vs = vtx->vs;
 
 	err = re_hprintf(pf, "video tx pipeline: %10s",
-			 vs ? vs->name : "(src)");
+			vs ? vs->name : "(src)");
 
 	for (le = list_head(&vtx->filtl); le; le = le->next) {
 		struct vidfilt_enc_st *st = le->data;
@@ -1020,7 +1020,7 @@ static int vtx_print_pipeline(struct re_printf *pf, const struct vtx *vtx)
 	}
 
 	err |= re_hprintf(pf, " ---> %s\n",
-			  vtx->vc ? vtx->vc->name : "(encoder)");
+			vtx->vc ? vtx->vc->name : "(encoder)");
 
 	return err;
 }
@@ -1038,7 +1038,7 @@ static int vrx_print_pipeline(struct re_printf *pf, const struct vrx *vrx)
 	vd = vrx->vd;
 
 	err = re_hprintf(pf, "video rx pipeline: %10s",
-			 vd ? vd->name : "(disp)");
+			vd ? vd->name : "(disp)");
 
 	for (le = list_head(&vrx->filtl); le; le = le->next) {
 		struct vidfilt_dec_st *st = le->data;
@@ -1048,7 +1048,7 @@ static int vrx_print_pipeline(struct re_printf *pf, const struct vrx *vrx)
 	}
 
 	err |= re_hprintf(pf, " <--- %s\n",
-			  vrx->vc ? vrx->vc->name : "(decoder)");
+			vrx->vc ? vrx->vc->name : "(decoder)");
 
 	return err;
 }
@@ -1110,22 +1110,22 @@ int video_alloc(struct video **vp, struct list *streaml,
 
 	if (acc && acc->vidsrc_mod) {
 		str_ncpy(v->vtx.module, acc->vidsrc_mod,
-			sizeof(v->vtx.module));
+				sizeof(v->vtx.module));
 		str_ncpy(v->vtx.device, acc->vidsrc_dev,
-			sizeof(v->vtx.device));
+				sizeof(v->vtx.device));
 
 		info("video: using account specific source: (%s,%s)\n",
-			acc->vidsrc_mod, acc->vidsrc_dev);
+				acc->vidsrc_mod, acc->vidsrc_dev);
 	}
 
 	if (acc && acc->viddisp_mod) {
 		str_ncpy(v->vrx.module, acc->viddisp_mod,
-			sizeof(v->vrx.module));
+				sizeof(v->vrx.module));
 		str_ncpy(v->vrx.device, acc->viddisp_dev,
-			sizeof(v->vrx.device));
+				sizeof(v->vrx.device));
 
 		info("video: using account specific display: (%s,%s)\n",
-			acc->viddisp_mod, acc->viddisp_dev);
+				acc->viddisp_mod, acc->viddisp_dev);
 	}
 
 	mem_destructor(v, video_destructor);
@@ -1133,10 +1133,10 @@ int video_alloc(struct video **vp, struct list *streaml,
 	tmr_init(&v->tmr);
 
 	err = stream_alloc(&v->strm, streaml, stream_prm,
-			   &cfg->avt, sdp_sess, MEDIA_VIDEO,
-			   mnat, mnat_sess, menc, menc_sess, offerer,
-			   stream_recv_handler, rtcp_handler,
-			   stream_pt_handler, v);
+			&cfg->avt, sdp_sess, MEDIA_VIDEO,
+			mnat, mnat_sess, menc, menc_sess, offerer,
+			stream_recv_handler, rtcp_handler,
+			stream_pt_handler, v);
 	if (err)
 		goto out;
 
@@ -1149,24 +1149,24 @@ int video_alloc(struct video **vp, struct list *streaml,
 		uint32_t bps = cfg->avt.rtp_bw.max - AUDIO_BANDWIDTH;
 
 		sdp_media_set_lbandwidth(stream_sdpmedia(v->strm),
-					 SDP_BANDWIDTH_AS, bps / 1000);
+				SDP_BANDWIDTH_AS, bps / 1000);
 	}
 
-	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
-				   "framerate", "%.2f", v->cfg.fps);
+//	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
+//				   "framerate", "%.2f", v->cfg.fps);
 
 	/* RFC 4585 */
 	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
-				   "rtcp-fb", "* nack");
+			"rtcp-fb", "* nack");
 
 	err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), false,
-				   "rtcp-fb", "* nack pli");
+			"rtcp-fb", "* nack pli");
 
 	/* RFC 4796 */
-	if (content) {
-		err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
-					   "content", "%s", content);
-	}
+//	if (content) {
+//		err |= sdp_media_set_lattr(stream_sdpmedia(v->strm), true,
+//					   "content", "%s", content);
+//	}
 
 	if (err)
 		goto out;
@@ -1178,9 +1178,9 @@ int video_alloc(struct video **vp, struct list *streaml,
 	for (le = list_head(vidcodecl); le; le = le->next) {
 		struct vidcodec *vc = le->data;
 		err |= sdp_format_add(NULL, stream_sdpmedia(v->strm), false,
-				      vc->pt, vc->name, 90000, 1,
-				      vc->fmtp_ench, vc->fmtp_cmph, vc, false,
-				      "%s", vc->fmtp);
+				vc->pt, vc->name, 90000, 1,
+				vc->fmtp_ench, vc->fmtp_cmph, vc, false,
+				"%s", vc->fmtp);
 	}
 
 	/* Video filters */
@@ -1203,12 +1203,12 @@ int video_alloc(struct video **vp, struct list *streaml,
 		err |= vidfilt_dec_append(&v->vrx.filtl, &ctx, vf, &prmdec, v);
 		if (err) {
 			warning("video: video-filter '%s' failed (%m)\n",
-				vf->name, err);
+					vf->name, err);
 			break;
 		}
 	}
 
- out:
+	out:
 	if (err)
 		mem_deref(v);
 	else
@@ -1241,12 +1241,12 @@ static int set_vidisp(struct vrx *vrx)
 	vrx->vidisp_prm.fullscreen = vrx->video->cfg.fullscreen;
 
 	vd = (struct vidisp *)vidisp_find(baresip_vidispl(),
-					  vrx->module);
+			vrx->module);
 	if (!vd)
 		return ENOENT;
 
 	err = vd->alloch(&vrx->vidisp, vd, &vrx->vidisp_prm, vrx->device,
-			 vidisp_resize_handler, vrx);
+			vidisp_resize_handler, vrx);
 	if (err)
 		return err;
 
@@ -1373,10 +1373,10 @@ int video_start_source(struct video *v)
 		struct vidsrc *vs;
 
 		vs = (struct vidsrc *)vidsrc_find(baresip_vidsrcl(),
-						  v->cfg.src_mod);
+				v->cfg.src_mod);
 		if (!vs) {
 			warning("video: source not found: %s\n",
-				v->cfg.src_mod);
+					v->cfg.src_mod);
 			return ENOENT;
 		}
 
@@ -1390,13 +1390,13 @@ int video_start_source(struct video *v)
 		vtx->vsrc = mem_deref(vtx->vsrc);
 
 		err = vs->alloch(&vtx->vsrc, vs, &vtx->vsrc_prm,
-				 &vtx->vsrc_size, NULL, v->vtx.device,
-				 vidsrc_frame_handler, vidsrc_packet_handler,
-				 vidsrc_error_handler, vtx);
+				&vtx->vsrc_size, NULL, v->vtx.device,
+				vidsrc_frame_handler, vidsrc_packet_handler,
+				vidsrc_error_handler, vtx);
 		if (err) {
 			warning("video: could not set source to"
-				" [%u x %u] %m\n",
-				size.w, size.h, err);
+					" [%u x %u] %m\n",
+					size.w, size.h, err);
 		}
 
 		vtx->vs = vs;
@@ -1453,7 +1453,7 @@ int video_start_display(struct video *v, const char *peer)
 		err = set_vidisp(&v->vrx);
 		if (err) {
 			warning("video: could not set vidisp '%s': %m\n",
-				v->vrx.device, err);
+					v->vrx.device, err);
 			return err;
 		}
 
@@ -1508,7 +1508,9 @@ void video_stop_display(struct video *v)
 
 	debug("video: stopping video display ..\n");
 
+	mtx_lock(&v->vrx.lock);
 	v->vrx.vidisp = mem_deref(v->vrx.vidisp);
+	mtx_unlock(&v->vrx.lock);
 }
 
 
@@ -1531,7 +1533,7 @@ static int vidisp_update(struct vrx *vrx)
 
 	if (vd->updateh) {
 		err = vd->updateh(vrx->vidisp, vrx->vidisp_prm.fullscreen,
-				  vrx->orient, NULL);
+				vrx->orient, NULL);
 	}
 
 	return err;
@@ -1577,7 +1579,7 @@ static void vidsrc_update(struct vtx *vtx, const char *dev)
  * @return 0 if success, otherwise errorcode
  */
 int video_encoder_set(struct video *v, struct vidcodec *vc,
-		      int pt_tx, const char *params)
+		int pt_tx, const char *params)
 {
 	struct vtx *vtx;
 	int err = 0;
@@ -1593,10 +1595,10 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 		struct list *vidcodecl = vc->le.list;
 
 		struct vidcodec *vcd = (struct vidcodec *)
-			vidcodec_find_encoder(vidcodecl, vc->name);
+				vidcodec_find_encoder(vidcodecl, vc->name);
 		if (!vcd) {
 			warning("video: could not find encoder (%s)\n",
-				vc->name);
+					vc->name);
 			return ENOENT;
 		}
 
@@ -1615,11 +1617,11 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 		prm.max_fs  = -1;
 
 		info("Set video encoder: %s %s (%u bit/s, %.2f fps)\n",
-		     vc->name, vc->variant, prm.bitrate, prm.fps);
+				vc->name, vc->variant, prm.bitrate, prm.fps);
 
 		vtx->enc = mem_deref(vtx->enc);
 		err = vc->encupdh(&vtx->enc, vc, &prm, params,
-				  packet_handler, v);
+				packet_handler, v);
 		if (err) {
 			warning("video: encoder alloc: %m\n", err);
 			goto out;
@@ -1630,7 +1632,7 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 
 	stream_update_encoder(v->strm, pt_tx);
 
- out:
+	out:
 	mtx_unlock(vtx->lock_enc);
 
 	return err;
@@ -1638,7 +1640,7 @@ int video_encoder_set(struct video *v, struct vidcodec *vc,
 
 
 int video_decoder_set(struct video *v, struct vidcodec *vc, int pt_rx,
-		      const char *fmtp)
+		const char *fmtp)
 {
 	struct vrx *vrx;
 	int err = 0;
@@ -1653,10 +1655,10 @@ int video_decoder_set(struct video *v, struct vidcodec *vc, int pt_rx,
 		info("video: vidcodec '%s' has no decoder\n", vc->name);
 
 		struct vidcodec *vcd = (struct vidcodec *)
-			vidcodec_find_decoder(vidcodecl, vc->name);
+				vidcodec_find_decoder(vidcodecl, vc->name);
 		if (!vcd) {
 			warning("video: could not find decoder (%s)\n",
-				vc->name);
+					vc->name);
 			return ENOENT;
 		}
 
@@ -1730,7 +1732,7 @@ void video_sdp_attr_decode(struct video *v)
 
 	/* RFC 4585 */
 	if (sdp_media_rattr_apply(stream_sdpmedia(v->strm), "rtcp-fb",
-				  nack_handler, 0))
+			nack_handler, 0))
 		v->nack_pli = true;
 }
 
@@ -1740,25 +1742,25 @@ static int vtx_debug(struct re_printf *pf, const struct vtx *vtx)
 	int err = 0;
 
 	err |= re_hprintf(pf, " tx: encode: %s %s\n",
-			  vtx->vc ? vtx->vc->name : "none",
-			  vidfmt_name(vtx->fmt));
+			vtx->vc ? vtx->vc->name : "none",
+			vidfmt_name(vtx->fmt));
 
 	mtx_lock(vtx->lock_enc);
 	err |= re_hprintf(pf, "     source: %s %u x %u, fps=%.2f"
-			  " frames=%llu\n",
-			  vtx->vs ? vtx->vs->name : "none",
-			  vtx->vsrc_size.w,
-			  vtx->vsrc_size.h, vtx->vsrc_prm.fps,
-			  vtx->stats.src_frames);
+						  " frames=%llu\n",
+			vtx->vs ? vtx->vs->name : "none",
+			vtx->vsrc_size.w,
+			vtx->vsrc_size.h, vtx->vsrc_prm.fps,
+			vtx->stats.src_frames);
 	mtx_unlock(vtx->lock_enc);
 
 	mtx_lock(vtx->lock_tx);
 	err |= re_hprintf(pf, "     skipc=%u sendq=%u\n",
-			  vtx->skipc, list_count(&vtx->sendq));
+			vtx->skipc, list_count(&vtx->sendq));
 
 	if (vtx->ts_base) {
 		err |= re_hprintf(pf, "     time = %.3f sec\n",
-			  video_calc_seconds(vtx->ts_last - vtx->ts_base));
+				video_calc_seconds(vtx->ts_last - vtx->ts_base));
 	}
 	else {
 		err |= re_hprintf(pf, "     time = (not started)\n");
@@ -1774,18 +1776,18 @@ static int vrx_debug(struct re_printf *pf, const struct vrx *vrx)
 	int err = 0;
 
 	err |= re_hprintf(pf, " rx: decode: %s %s\n",
-			  vrx->vc ? vrx->vc->name : "none",
-			  vidfmt_name(vrx->fmt));
+			vrx->vc ? vrx->vc->name : "none",
+			vidfmt_name(vrx->fmt));
 	err |= re_hprintf(pf, "     vidisp: %s %u x %u frames=%llu\n",
-			  vrx->vd ? vrx->vd->name : "none",
-			  vrx->size.w, vrx->size.h,
-			  vrx->stats.disp_frames);
+			vrx->vd ? vrx->vd->name : "none",
+			vrx->size.w, vrx->size.h,
+			vrx->stats.disp_frames);
 	err |= re_hprintf(pf, "     n_keyframes=%u, n_picup=%u\n",
-			  vrx->n_intra, vrx->n_picup);
+			vrx->n_intra, vrx->n_picup);
 
 	if (vrx->ts_recv.is_set) {
 		err |= re_hprintf(pf, "     time = %.3f sec\n",
-		  video_calc_seconds(timestamp_duration(&vrx->ts_recv)));
+				video_calc_seconds(timestamp_duration(&vrx->ts_recv)));
 	}
 	else {
 		err |= re_hprintf(pf, "     time = (not started)\n");
@@ -1817,9 +1819,9 @@ int video_debug(struct re_printf *pf, const struct video *v)
 
 	err = re_hprintf(pf, "\n--- Video stream ---\n");
 	err |= re_hprintf(pf, " source started: %s\n",
-		v->vtx.vsrc ? "yes" : "no");
+			v->vtx.vsrc ? "yes" : "no");
 	err |= re_hprintf(pf, " display started: %s\n",
-		v->vrx.vidisp ? "yes" : "no");
+			v->vrx.vidisp ? "yes" : "no");
 
 	err |= vtx_debug(pf, vtx);
 	err |= vrx_debug(pf, vrx);
@@ -1858,7 +1860,7 @@ int video_print(struct re_printf *pf, const struct video *v)
 int video_set_source(struct video *v, const char *name, const char *dev)
 {
 	struct vidsrc *vs = (struct vidsrc *)vidsrc_find(baresip_vidsrcl(),
-							 name);
+			name);
 	struct vtx *vtx;
 	int err;
 
@@ -1873,9 +1875,9 @@ int video_set_source(struct video *v, const char *name, const char *dev)
 	vtx->vsrc = mem_deref(vtx->vsrc);
 
 	err = vs->alloch(&vtx->vsrc, vs, &vtx->vsrc_prm,
-			 &vtx->vsrc_size, NULL, dev,
-			 vidsrc_frame_handler, vidsrc_packet_handler,
-			 vidsrc_error_handler, vtx);
+			&vtx->vsrc_size, NULL, dev,
+			vidsrc_frame_handler, vidsrc_packet_handler,
+			vidsrc_error_handler, vtx);
 	if (err)
 		return err;
 


### PR DESCRIPTION
Android: serialize AAudio stream open/close and harden media teardown paths

MR description

This MR addresses stability issues seen during Android AAudio stream teardown and restart, especially when player and recorder streams are closed and reopened from different threads.

Summary

The changes in this MR do two things:

Serialize critical AAudio stream lifecycle operations to reduce races between concurrent stream teardown and recreation.
Harden a few media teardown paths in the generic audio/video stack to avoid invalid access during shutdown.
AAudio changes
add a global recursive AAudio lock in aaudio/utils.c
serialize AAudioStreamBuilder_openStream()
serialize AAudioStream_close()
keep AAudioStream_requestStop() inside the serialized close path
restore stream state checks before closing
keep the existing player/recorder restart handling introduced in the previous changes

This is intended to reduce vendor/device-specific failures caused by overlapping stream close/open activity across threads.

Media teardown hardening
src/audio.c
make stop_tx() tolerate partially destroyed state
avoid returning early before TX thread shutdown and source cleanup
src/stream.c
add defensive checks in stream_enable_tx() for incomplete stream state
src/video.c
protect video_stop_display() with vrx.lock during display teardown