### PR TITLE
contact: intelligent matching for incoming calls

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -533,6 +533,8 @@ void contact_set_presence(struct contact *c, enum presence_status status);
 bool contact_block_access(const struct contacts *contacts, const char *uri);
 struct contact  *contact_find(const struct contacts *contacts,
 			      const char *uri);
+struct contact  *contact_find_call(const struct contacts *contacts,
+				   const struct call *call);
 struct sip_addr *contact_addr(const struct contact *c);
 struct list     *contact_list(const struct contacts *contacts);
 const char      *contact_str(const struct contact *c);

--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -711,12 +711,8 @@ static void process_module_event(struct call *call, const char *prm)
 
 static void apply_contact_mediadir(struct call *call)
 {
-	const char *peeruri = call_peeruri(call);
-	if (!peeruri)
-		return;
-
 	const struct contacts *contacts = baresip_contacts();
-	struct contact *con = contact_find(contacts, peeruri);
+	struct contact *con = contact_find_call(contacts, call);
 	if (!con)
 		return;
 

--- a/src/contact.c
+++ b/src/contact.c
@@ -511,7 +511,7 @@ struct contact *contact_find_call(const struct contacts *contacts,
 
 	/* replace the user */
 	aor.user = from_addr.uri.user;
-	char *uri;
+	char *uri = NULL;
 	err = re_sdprintf(&uri, "%H", uri_encode, &aor);
 	if (err)
 		return NULL;

--- a/src/contact.c
+++ b/src/contact.c
@@ -129,6 +129,7 @@ int contact_add(struct contacts *contacts,
 	c->status = PRESENCE_UNKNOWN;
 
 	list_append(&contacts->cl, &c->le, c);
+	debug("contact: adding <%r>\n", &c->addr.auri);
 	hash_append(contacts->cht, hash_joaat_pl(&c->addr.auri), &c->he, c);
 
 	if (contacts->handler)
@@ -437,6 +438,101 @@ struct contact *contact_find(const struct contacts *contacts, const char *uri)
 
 	return list_ledata(hash_lookup(contacts->cht, hash_joaat_str(uri),
 				       find_handler, (void *)uri));
+}
+
+
+static bool smart_find_handler(struct le *le, void *arg)
+{
+	struct contact *c = le->data;
+	struct sip_addr *addr = arg;
+	struct uri *uri = &addr->uri;
+	struct uri *curi = &c->addr.uri;
+
+	if (pl_cmp(&curi->host, &uri->host) != 0)
+		return false;
+
+	if (pl_isset(&uri->user) && pl_cmp(&curi->user, &uri->user) != 0)
+		return false;
+
+	if (uri->port && uri->port != 5060 && uri->port != curi->port)
+		return false;
+
+	struct pl val1, val2;
+	if (0 == msg_param_decode(&uri->params, "transport", &val1) &&
+	    0 == msg_param_decode(&curi->params, "transport", &val2) &&
+	    0 != pl_casecmp(&val1, &val2))
+		return false;
+
+	debug("contact: smart match for '%r' found <%r>\n", &addr->auri,
+	      &c->addr.auri);
+	return true;
+}
+
+
+static struct contact *contact_find_smart(const struct contacts *contacts,
+					 const char *uri)
+{
+	struct pl pl;
+	struct sip_addr addr;
+	int err;
+
+	pl_set_str(&pl, uri);
+	err = sip_addr_decode(&addr, &pl);
+	if (err)
+		return NULL;
+
+	return list_ledata(hash_apply(contacts->cht,
+				      smart_find_handler, &addr));
+}
+
+
+struct contact *contact_find_call(const struct contacts *contacts,
+				  const struct call *call)
+{
+	if (!call)
+		return NULL;
+
+	/* smart match of From header */
+	struct contact *c = contact_find_smart(contacts, call_peeruri(call));
+	if (c)
+		return c;
+
+	/* smart match of From-user at AOR */
+	struct account *acc = ua_account(call_get_ua(call));
+	struct pl pl;
+	struct uri aor = *account_luri(acc);
+	struct sip_addr from_addr;
+	int err;
+
+	pl_set_str(&pl, call_peeruri(call));
+	err = sip_addr_decode(&from_addr, &pl);
+	if (err)
+		return NULL;
+
+	/* replace the user */
+	aor.user = from_addr.uri.user;
+	char *uri;
+	err = re_sdprintf(&uri, "%H", uri_encode, &aor);
+	if (err)
+		return NULL;
+
+	c = contact_find_smart(contacts, uri);
+	mem_deref(uri);
+	if (c)
+		return c;
+
+	/* host only match for P2P calls */
+	if (ua_isregistered(call_get_ua(call)))
+		return NULL;
+
+	from_addr.uri.user = pl_null;
+	err = re_sdprintf(&uri, "%H", uri_encode, &from_addr.uri);
+	if (err)
+		return NULL;
+
+	c = contact_find_smart(contacts, uri);
+	mem_deref(uri);
+	return c;
 }
 
 

--- a/test/contact.c
+++ b/test/contact.c
@@ -7,6 +7,7 @@
 #include <re.h>
 #include <baresip.h>
 #include "test.h"
+#include "call.h"
 
 
 int test_contact(void)
@@ -52,6 +53,49 @@ int test_contact(void)
 
  out:
 	mem_deref(contacts);
+
+	return err;
+}
+
+
+int test_contact_find_call(void)
+{
+	struct contacts *contacts = NULL;
+	const char *cstr[] = {
+		"B <sip:b@127.0.0.1>",
+		"A <sip:a@127.0.0.1>"};
+	struct contact *c;
+	struct pl pl_addr;
+	struct fixture fix, *f = &fix;
+	int err;
+
+	fixture_init(f);
+
+	err = contact_init(&contacts);
+	TEST_ERR(err);
+
+	for (size_t i = 0; i < RE_ARRAY_SIZE(cstr); i++) {
+		pl_set_str(&pl_addr, cstr[i]);
+		err = contact_add(contacts, &c, &pl_addr);
+		TEST_ERR(err);
+	}
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_ON);
+	TEST_ERR(err);
+
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+
+	struct call *call = ua_call(f->b.ua);
+	struct contact *contact = contact_find_call(contacts, call);
+	ASSERT_TRUE(contact != NULL);
+	ASSERT_STREQ(cstr[1], contact_str(contact));
+
+	ua_hangup(f->a.ua, call, 0, 0);
+
+out:
+	mem_deref(contacts);
+	fixture_close(f);
 
 	return err;
 }

--- a/test/contact.c
+++ b/test/contact.c
@@ -74,6 +74,7 @@ int test_contact_find_call(void)
 	err = contact_init(&contacts);
 	TEST_ERR(err);
 
+	/* contact_find_smart() with peer_uri */
 	for (size_t i = 0; i < RE_ARRAY_SIZE(cstr); i++) {
 		pl_set_str(&pl_addr, cstr[i]);
 		err = contact_add(contacts, &c, &pl_addr);
@@ -90,6 +91,31 @@ int test_contact_find_call(void)
 	struct contact *contact = contact_find_call(contacts, call);
 	ASSERT_TRUE(contact != NULL);
 	ASSERT_STREQ(cstr[1], contact_str(contact));
+
+	ua_hangup(f->a.ua, call, 0, 0);
+
+	/* host only match */
+	contact_remove(contacts, contact);
+	ASSERT_EQ(1, list_count(contact_list(contacts)));
+
+	mem_deref(f->a.ua);
+	err = ua_alloc(&f->a.ua, "A <sip:a@localhost>;regint=0");
+	TEST_ERR(err);
+
+	pl_set_str(&pl_addr, "X <sip:x@localhost>");
+	contact_add(contacts, &c, &pl_addr);
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_ON);
+	TEST_ERR(err);
+
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+
+	call = ua_call(f->b.ua);
+	contact = contact_find_call(contacts, call);
+	ASSERT_TRUE(contact != NULL);
+	ASSERT_STREQ(contact_str(c), contact_str(contact));
+	ASSERT_STREQ("sip:x@localhost", contact_uri(contact));
 
 	ua_hangup(f->a.ua, call, 0, 0);
 

--- a/test/main.c
+++ b/test/main.c
@@ -67,6 +67,7 @@ static const struct test tests[] = {
 	TEST(test_cparam_call_decode),
 	TEST(test_cparam_ua_decode),
 	TEST(test_contact),
+	TEST(test_contact_find_call),
 	TEST(test_bevent_register),
 	TEST(test_jbuf),
 	TEST(test_jbuf_adaptive),

--- a/test/test.h
+++ b/test/test.h
@@ -240,6 +240,7 @@ int test_cmd_long(void);
 int test_cparam_call_decode(void);
 int test_cparam_ua_decode(void);
 int test_contact(void);
+int test_contact_find_call(void);
 int test_bevent_register(void);
 int test_jbuf(void);
 int test_jbuf_adaptive(void);


### PR DESCRIPTION
- **contact: intelligent matching for incoming calls**
- **menu: intelligent contact matching**

    
    Matching a contact with the From header of an incoming INVITE nearly always fails
    for registered User-Agents. This commit adds a new API function
    `contact_find_call()`.
    
    - first try the complete From header (like `contact_find()` does),
    - then try the AOR of the UA with the user-ID of the From header (for
      registered accountts),
    - as last fallback only for P2P calls try the From header without user-ID