### PR TITLE
menu: multiple call auto answer

### DIFF
--- a/modules/menu/menu.c
+++ b/modules/menu/menu.c
@@ -523,7 +523,8 @@ static void menu_invite(const char *prm)
 static int menu_autoanwser_call(struct call *call)
 {
 	struct call *outgoing;
-	if (menu_find_call(established_call_test, call))
+	bool single = conf_config()->call.hold_other_calls;
+	if (single && menu_find_call(established_call_test, call))
 		return EINVAL;
 
 	outgoing = menu_find_call(outgoing_call_test, call);


### PR DESCRIPTION
If `call_hold_other_calls=no` auto answer now is allowed for multiple
calls in parallel.

Related discussion: https://github.com/baresip/baresip/discussions/3709

Note, we see that the name of the setting seems to be not perfect for its purpose: We want a flag that tells if multiple established calls are allowed. If **not** as a consequence:
- other established calls are put on hold if the user accepts another incoming call, and
- auto-anwser only answers the first call.