### PR TITLE
misc/modules: fix redefinition once_flag errors

### DIFF
--- a/modules/avcodec/avcodec.c
+++ b/modules/avcodec/avcodec.c
@@ -3,11 +3,12 @@
  *
  * Copyright (C) 2010 - 2016 Alfred E. Heggestad
  */
+#include <libavutil/pixdesc.h>
+#include <libavcodec/avcodec.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <libavutil/pixdesc.h>
-#include <libavcodec/avcodec.h>
 #include "h26x.h"
 #include "avcodec.h"
 

--- a/modules/avcodec/decode.c
+++ b/modules/avcodec/decode.c
@@ -3,14 +3,15 @@
  *
  * Copyright (C) 2010 - 2013 Alfred E. Heggestad
  */
-#include <re.h>
-#include <re_h265.h>
-#include <rem.h>
-#include <baresip.h>
 #include <libavcodec/avcodec.h>
 #include <libavutil/avutil.h>
 #include <libavutil/mem.h>
 #include <libavutil/pixdesc.h>
+
+#include <re.h>
+#include <re_h265.h>
+#include <rem.h>
+#include <baresip.h>
 #include "h26x.h"
 #include "avcodec.h"
 

--- a/modules/avcodec/encode.c
+++ b/modules/avcodec/encode.c
@@ -6,14 +6,15 @@
  *     Media Magic Technologies <developer@mediamagictechnologies.com>
  *     and Divus GmbH <developer@divus.eu>
  */
-#include <re.h>
-#include <re_h265.h>
-#include <rem.h>
-#include <baresip.h>
 #include <libavcodec/avcodec.h>
 #include <libavutil/mem.h>
 #include <libavutil/opt.h>
 #include <libavutil/pixdesc.h>
+
+#include <re.h>
+#include <re_h265.h>
+#include <rem.h>
+#include <baresip.h>
 #include "h26x.h"
 #include "avcodec.h"
 

--- a/modules/avcodec/sdp.c
+++ b/modules/avcodec/sdp.c
@@ -7,9 +7,10 @@
  *     and Divus GmbH <developer@divus.eu>
  */
 
+#include <libavcodec/avcodec.h>
+
 #include <re.h>
 #include <baresip.h>
-#include <libavcodec/avcodec.h>
 #include "avcodec.h"
 
 

--- a/modules/avformat/audio.c
+++ b/modules/avformat/audio.c
@@ -3,15 +3,15 @@
  *
  * Copyright (C) 2010 - 2020 Alfred E. Heggestad
  */
+#include <libavutil/opt.h>
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libswresample/swresample.h>
 
 #include <re_atomic.h>
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <libavutil/opt.h>
-#include <libavformat/avformat.h>
-#include <libavcodec/avcodec.h>
-#include <libswresample/swresample.h>
 #include "mod_avformat.h"
 
 

--- a/modules/avformat/avformat.c
+++ b/modules/avformat/avformat.c
@@ -10,14 +10,15 @@
 #include <unistd.h>
 #endif
 #include <string.h>
-#include <re_atomic.h>
-#include <re.h>
-#include <rem.h>
-#include <baresip.h>
 #include <libavformat/avformat.h>
 #include <libavcodec/avcodec.h>
 #include <libavdevice/avdevice.h>
 #include <libavutil/hwcontext.h>
+
+#include <re_atomic.h>
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
 #include "mod_avformat.h"
 
 

--- a/modules/avformat/video.c
+++ b/modules/avformat/video.c
@@ -6,14 +6,14 @@
  *     Media Magic Technologies <developer@mediamagictechnologies.com>
  *     and Divus GmbH <developer@divus.eu>
  */
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/pixdesc.h>
 
 #include <re_atomic.h>
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <libavformat/avformat.h>
-#include <libavcodec/avcodec.h>
-#include <libavutil/pixdesc.h>
 #include "mod_avformat.h"
 
 

--- a/modules/gtk/call_window.c
+++ b/modules/gtk/call_window.c
@@ -3,12 +3,12 @@
  *
  * Copyright (C) 2015 Charles E. Lehner
  */
+#include <gtk/gtk.h>
+#include <string.h>
 
 #include <re.h>
 #include <baresip.h>
-#include <gtk/gtk.h>
 #include "gtk_mod.h"
-#include <string.h>
 
 struct call_window {
 	struct gtk_mod *mod;

--- a/modules/gtk/dial_dialog.c
+++ b/modules/gtk/dial_dialog.c
@@ -3,13 +3,13 @@
  *
  * Copyright (C) 2015 Charles E. Lehner
  */
+#include <stdlib.h>
+#include <gtk/gtk.h>
+#include <ctype.h>
 
 #include <re.h>
 #include <baresip.h>
-#include <stdlib.h>
-#include <gtk/gtk.h>
 #include "gtk_mod.h"
-#include <ctype.h>
 
 
 struct dial_dialog {

--- a/modules/gtk/gtk_mod.c
+++ b/modules/gtk/gtk_mod.c
@@ -4,13 +4,14 @@
  * Copyright (C) 2015 Charles E. Lehner
  * Copyright (C) 2010 - 2015 Alfred E. Heggestad
  */
-#include <re.h>
-#include <rem.h>
 #include <time.h>
-#include <baresip.h>
 #include <stdlib.h>
 #include <gtk/gtk.h>
 #include <gio/gio.h>
+
+#include <re.h>
+#include <rem.h>
+#include <baresip.h>
 #include "gtk_mod.h"
 
 #ifdef USE_LIBNOTIFY

--- a/modules/gtk/transfer_dialog.c
+++ b/modules/gtk/transfer_dialog.c
@@ -3,9 +3,10 @@
  *
  * Copyright (C) 2015 Charles E. Lehner
  */
+#include <gtk/gtk.h>
+
 #include <re.h>
 #include <baresip.h>
-#include <gtk/gtk.h>
 #include "gtk_mod.h"
 
 

--- a/modules/gtk/uri_entry.c
+++ b/modules/gtk/uri_entry.c
@@ -4,9 +4,10 @@
  * Copyright (C) 2015 Charles E. Lehner
  */
 
+#include <gtk/gtk.h>
+
 #include <re.h>
 #include <baresip.h>
-#include <gtk/gtk.h>
 #include "gtk_mod.h"
 
 

--- a/modules/pipewire/capture.c
+++ b/modules/pipewire/capture.c
@@ -6,11 +6,12 @@
 
 #include <string.h>
 #include <errno.h>
+#include <spa/param/audio/format-utils.h>
+#include <pipewire/pipewire.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <spa/param/audio/format-utils.h>
-#include <pipewire/pipewire.h>
 
 #include "pipewire.h"
 

--- a/modules/pipewire/pipewire.c
+++ b/modules/pipewire/pipewire.c
@@ -3,14 +3,13 @@
  *
  * Copyright (C) 2023 Commend.com - c.spielberger@commend.com
  */
-
-#include <string.h>
 #include <errno.h>
+#include <spa/param/audio/raw.h>
+#include <pipewire/pipewire.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <spa/param/audio/raw.h>
-#include <pipewire/pipewire.h>
 
 #include "pipewire.h"
 

--- a/modules/pipewire/playback.c
+++ b/modules/pipewire/playback.c
@@ -6,11 +6,12 @@
 
 #include <string.h>
 #include <errno.h>
+#include <spa/param/audio/format-utils.h>
+#include <pipewire/pipewire.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <spa/param/audio/format-utils.h>
-#include <pipewire/pipewire.h>
 
 #include "pipewire.h"
 

--- a/modules/swscale/swscale.c
+++ b/modules/swscale/swscale.c
@@ -3,10 +3,11 @@
  *
  * Copyright (C) 2010 - 2016 Alfred E. Heggestad
  */
+#include <libswscale/swscale.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <libswscale/swscale.h>
 
 
 struct swscale_enc {


### PR DESCRIPTION
Keep include order to prevent errors:

1. System/Third party headers
2. libre/baresip headers
3. Local/Custom headers

https://github.com/baresip/re/wiki/Development-(re-usage)#include-headers

Example (compiled with `-DHAVE_THREADS=`):
```c
In file included from baresip/modules/swscale/swscale.c:9:
In file included from /usr/include/libswscale/swscale.h:33:
In file included from /usr/include/libavutil/avutil.h:300:
In file included from /usr/include/libavutil/common.h:39:
In file included from /usr/include/stdlib.h:1191:
/usr/include/bits/types/once_flag.h:24:21: error: typedef redefinition with different types ('__once_flag' vs 'pthread_once_t' (aka 'int'))
   24 | typedef __once_flag once_flag;
      |                     ^
re/include/re_thread.h:47:24: note: previous definition is here
   47 | typedef pthread_once_t once_flag;
      |                        ^
1 error generated.
```