### PR TITLE
call: Use CRLF in REFER NOTIFY sipfrag body

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -2876,7 +2876,7 @@ int call_notify_sipfrag(struct call *call, uint16_t scode,
 		return ENOMEM;
 
 	va_start(ap, reason);
-	(void)mbuf_printf(mb, "SIP/2.0 %u %v\n", scode, reason, &ap);
+	(void)mbuf_printf(mb, "SIP/2.0 %u %v\r\n", scode, reason, &ap);
 	va_end(ap);
 
 	mb->pos = 0;


### PR DESCRIPTION
This PR fixes the REFER NOTIFY `message/sipfrag` body line ending.
It was created following the bug here: baresip/baresip#3723.

Currently, `call_notify_sipfrag()` generates the SIP status line using LF only:

SIP/2.0 100 Trying\n

This produces:

Content-Length: 19

However, a SIP status line is expected to be terminated with CRLF. For this specific sipfrag body, the payload should be:

SIP/2.0 100 Trying\r\n

which produces:

Content-Length: 20.

Using LF only caused interoperability issues with strict SIP UAs, which rejected the REFER NOTIFY with `400 Bad Request`.

After this change, the NOTIFY is accepted correctly with `200 OK`.