### PR TITLE
ua: avoid fallback 500 after unsupported address family

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -803,6 +803,11 @@ int ua_accept(struct ua *ua, const struct sip_msg *msg)
 	err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, to_uri, true);
 	if (err) {
 		warning("ua: call_alloc: %m\n", err);
+		if (err == EAFNOSUPPORT) {
+			mem_deref(to_uri);
+			return err;
+		}
+
 		goto error;
 	}
 
@@ -915,7 +920,7 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 				net_af2name(af));
 		(void)sip_treply(NULL, uag_sip(), msg, 488,
 				 "Not Acceptable Here");
-		return EINVAL;
+		return EAFNOSUPPORT;
 	}
 
 	memset(&cprm, 0, sizeof(cprm));
@@ -985,8 +990,11 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 		err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, NULL,
 				    false);
 		if (err) {
-			(void)sip_treply(NULL, uag_sip(), msg,
-					 500, "Call Error");
+			if (err != EAFNOSUPPORT) {
+				(void)sip_treply(NULL, uag_sip(), msg,
+						500, "Call Error");
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
## Summary
This PR fixes the existing `488 Not Acceptable Here` path in `ua_call_alloc()`.

When the address family from the incoming SIP message is not supported, `ua_call_alloc()` already sends:
```c
sip_treply(..., 488, "Not Acceptable Here");
```

However, it returned `EINVAL`, so callers treated the failure as a generic allocation error and could send the fallback:
```c
sip_treply(..., 500, "Call Error");
```

This could result in a second final response being attempted after `488 Not Acceptable Here` had already been sent.

## What i've changed
The unsupported address family path now returns `EAFNOSUPPORT` instead of `EINVAL`
The callers check for `EAFNOSUPPORT` and avoid sending the generic `500 Call Error` fallback when the 488 response has already been sent.

It only prevents the later fallback `500 Call Error` from being sent for the same request after the `488 path` has already handled it.