### PR TITLE
ua: stop processing INVITE after 421 response

### DIFF
--- a/src/ua.c
+++ b/src/ua.c
@@ -764,6 +764,7 @@ void sipsess_conn_handler(const struct sip_msg *msg, void *arg)
 				  421, "Extension required",
 				  "Require: 100rel\r\n"
 				  "Content-Length: 0\r\n\r\n");
+		return;
 	}
 
 	if (config->call.accept)

--- a/src/ua.c
+++ b/src/ua.c
@@ -803,6 +803,11 @@ int ua_accept(struct ua *ua, const struct sip_msg *msg)
 	err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, to_uri, true);
 	if (err) {
 		warning("ua: call_alloc: %m\n", err);
+		if (err == EAFNOSUPPORT) {
+			mem_deref(to_uri);
+			return err;
+		}
+
 		goto error;
 	}
 
@@ -915,7 +920,7 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 				net_af2name(af));
 		(void)sip_treply(NULL, uag_sip(), msg, 488,
 				 "Not Acceptable Here");
-		return EINVAL;
+		return EAFNOSUPPORT;
 	}
 
 	memset(&cprm, 0, sizeof(cprm));
@@ -985,8 +990,11 @@ void ua_handle_options(struct ua *ua, const struct sip_msg *msg)
 		err = ua_call_alloc(&call, ua, VIDMODE_ON, msg, NULL, NULL,
 				    false);
 		if (err) {
-			(void)sip_treply(NULL, uag_sip(), msg,
-					 500, "Call Error");
+			if (err != EAFNOSUPPORT) {
+				(void)sip_treply(NULL, uag_sip(), msg,
+						500, "Call Error");
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes the `421 Extension required` path in `sipsess_conn_handler()`.

When `rel100_mode` is set to `REL100_REQUIRED`, but the incoming `INVITE` does not advertise `100rel` through either `Supported` or `Require`, Baresip sends:

```c
sip_treplyf(..., 421, "Extension required", ...);
```
However, after sending the final `421` response, the function could continue and reach the normal incoming call handling path.
Since `421` should be a final response, the rejected INVITE must not continue toward ua_accept() after the response has been sent.

## What is changed
The `421 Extension required`path now returns immediately after sending the final response.