### PR TITLE
ci: bump actions scripts to fix Node.js warning

### DIFF
--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -95,7 +95,7 @@ jobs:
           'spandsp-devel' \
           '/usr/bin/gdbus-codegen'
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: re-fedora
         path: re/placeholder-0-build

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -45,7 +45,7 @@ jobs:
       with:
         path: baresip-win32/baresip
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: openssl
       with:
         path: baresip-win32/openssl
@@ -62,7 +62,7 @@ jobs:
     - name: "build"
       run: make -j$(nproc) -C baresip-win32 baresip
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: selftest-exe
         path: baresip-win32/baresip/build/test/selftest.exe
@@ -73,7 +73,7 @@ jobs:
     needs: MinGW-w64-build
 
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
     - uses: actions/checkout@v5
       with:
         path: baresip

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -73,7 +73,7 @@ jobs:
     needs: MinGW-w64-build
 
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@v4
     - uses: actions/checkout@v5
       with:
         path: baresip


### PR DESCRIPTION
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. ...