### PR TITLE
uag: check registration state of fallback UA

### DIFF
--- a/src/uag.c
+++ b/src/uag.c
@@ -947,7 +947,7 @@ struct ua *uag_find_msg(const struct sip_msg *msg)
 			return ua;
 		}
 
-		if (!uaf && ua_catchall(ua))
+		if (!uaf && ua_catchall(ua) && ua_isregistered(ua))
 			uaf = ua;
 	}
 


### PR DESCRIPTION
A catchall account which should register at a SIP registrar needs to be
registered in order to be chosen as fallback UA.
