### PR TITLE
test: fix a ruff warning in ccheck

### DIFF
--- a/test/ccheck.py
+++ b/test/ccheck.py
@@ -235,7 +235,7 @@ class ccheck:
                 return
             return
 
-        if 'LIST_FOREACH' in line and not 'LIST_FOREACH_SAFE' in line:
+        if 'LIST_FOREACH' in line and 'LIST_FOREACH_SAFE' not in line:
             self.listfor_depth = 1
             return
 


### PR DESCRIPTION
$ ruff check test/ccheck.py
E713 [*] Test for membership should be `not in`
   --> test/ccheck.py:238:43
    |
236 |             return
237 |
238 |         if 'LIST_FOREACH' in line and not 'LIST_FOREACH_SAFE' in line:
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
239 |             self.listfor_depth = 1
240 |             return
    |
help: Convert to `not in`