### PR TITLE
call: add SIP INFO handling

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -500,6 +500,17 @@ int config_print(struct re_printf *pf, const struct config *cfg);
 int config_write_template(const char *file, const struct config *cfg);
 struct config *conf_config(void);
 
+/** Sip Info Configuration*/
+typedef bool (call_sip_info_h)(
+    struct call *call,
+    const char *content_type,
+    const uint8_t *body,
+    size_t body_len,
+    const struct sip_msg *msg,
+    void *arg
+);
+void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
+
 
 /*
  * Contact

--- a/src/call.c
+++ b/src/call.c
@@ -90,7 +90,8 @@ struct call {
 
 static int send_invite(struct call *call);
 static int send_dtmf_info(struct call *call, char key);
-
+static call_sip_info_h *sip_info_handler = NULL;
+static void *sip_info_arg = NULL;
 
 static const char *state_name(enum call_state st)
 {
@@ -974,6 +975,11 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	return err;
 }
 
+void call_set_sip_info_handler(call_sip_info_h *handler, void *arg)
+{
+    sip_info_handler = handler;
+    sip_info_arg = arg;
+}
 
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
 {
@@ -2010,6 +2016,48 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 	return minwait + rand_u16() % (maxwait - minwait);
 }
 
+static bool call_emit_sip_info(struct call *call, const struct sip_msg *msg)
+{
+    struct pl body;
+    char content_type[256] = "";
+
+    if (!call || !msg || !sip_info_handler) {
+        return false;
+    }
+
+    if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
+        if (pl_isset(&msg->ctyp.params)) {
+            re_snprintf(
+                content_type,
+                sizeof(content_type),
+                "%r/%r;%r",
+                &msg->ctyp.type,
+                &msg->ctyp.subtype,
+                &msg->ctyp.params
+            );
+        }
+        else {
+            re_snprintf(
+                content_type,
+                sizeof(content_type),
+                "%r/%r",
+                &msg->ctyp.type,
+                &msg->ctyp.subtype
+            );
+        }
+    }
+
+    pl_set_mbuf(&body, msg->mb);
+
+    return sip_info_handler(
+        call,
+        content_type[0] ? content_type : NULL,
+        (const uint8_t *)body.p,
+        body.l,
+        msg,
+        sip_info_arg
+    );
+}
 
 static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 {
@@ -2081,6 +2129,7 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 				 void *arg)
 {
 	struct call *call = arg;
+    bool app_handled = call_emit_sip_info(call, msg);
 
 	if (msg_ctype_cmp(&msg->ctyp, "application", "dtmf-relay")) {
 


### PR DESCRIPTION
## Summary

This PR adds a call-level callback for incoming SIP INFO requests.

The callback allows applications embedding Baresip to inspect and handle SIP INFO messages directly, including:

- the related struct call
- the SIP INFO Content-Type
- the raw body payload
- the body length
- the original struct sip_msg
- custom SIP headers through the original SIP message reference

This is useful for SDK integrations that need to receive application-specific SIP INFO messages, not only standard DTMF-related INFO handling.

## Changes

Added a new SIP INFO handler type:

```c
typedef bool (call_sip_info_h)(
      struct call *call,
      const char *content_type,
      const uint8_t *body,
      size_t body_len,
      const struct sip_msg *msg,
      void *arg
);
```

Added a public registration API:
```c
void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
```

Added internal SIP INFO event emission:
```c
bool app_handled = call_emit_sip_info(call, msg);
```

The new `call_emit_sip_info()` helper extracts the SIP INFO content type, including optional content-type parameters, maps the message body from the SIP message buffer, and invokes the registered application handler.

## Motivation
Some applications use SIP INFO for custom in-call signaling, not only for DTMF-related use cases.

For example, SDK integrations may need to receive application-specific commands, metadata, or custom headers carried inside SIP INFO requests.

Before this change, there was no clean call-level API to expose incoming SIP INFO messages to the application layer while preserving access to the raw body and original SIP headers.