### PR TITLE
call: add callback for incoming SIP INFO

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -502,12 +502,12 @@ struct config *conf_config(void);
 
 /** Sip Info Configuration*/
 typedef bool (call_sip_info_h)(
-    struct call *call,
-    const char *content_type,
-    const uint8_t *body,
-    size_t body_len,
-    const struct sip_msg *msg,
-    void *arg
+	struct call *call,
+	const char *content_type,
+	const uint8_t *body,
+	size_t body_len,
+	const struct sip_msg *msg,
+	void *arg
 );
 void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
 
@@ -1347,8 +1347,9 @@ typedef int(viddec_update_h)(struct viddec_state **vdsp,
 			     const struct vidcodec *vc, const char *fmtp,
 			     const struct video *vid);
 
-typedef int (viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
-                              struct viddec_packet *pkt);
+typedef int (viddec_decode_h)(struct viddec_state *vds,
+			      struct vidframe *frame,
+			      struct viddec_packet *pkt);
 
 struct vidcodec {
 	struct le le;

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -509,7 +509,11 @@ typedef bool (call_sip_info_h)(
 	const struct sip_msg *msg,
 	void *arg
 );
-void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
+void call_set_sip_info_handler(
+	struct call *call,
+	call_sip_info_h *handler,
+	void *arg
+);
 
 
 /*
@@ -1347,9 +1351,8 @@ typedef int(viddec_update_h)(struct viddec_state **vdsp,
 			     const struct vidcodec *vc, const char *fmtp,
 			     const struct video *vid);
 
-typedef int (viddec_decode_h)(struct viddec_state *vds,
-			      struct vidframe *frame,
-			      struct viddec_packet *pkt);
+typedef int (viddec_decode_h)(struct viddec_state *vds, struct vidframe *frame,
+                              struct viddec_packet *pkt);
 
 struct vidcodec {
 	struct le le;

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -509,6 +509,7 @@ typedef bool (call_sip_info_h)(
 	const struct sip_msg *msg,
 	void *arg
 );
+
 void call_set_sip_info_handler(
 	struct call *call,
 	call_sip_info_h *handler,

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -501,7 +501,7 @@ int config_write_template(const char *file, const struct config *cfg);
 struct config *conf_config(void);
 
 /** Sip Info Configuration*/
-typedef bool (call_sip_info_h)(
+typedef void (call_sip_info_h)(
 	struct call *call,
 	const char *content_type,
 	const uint8_t *body,

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -501,7 +501,7 @@ int config_write_template(const char *file, const struct config *cfg);
 struct config *conf_config(void);
 
 /** Sip Info Configuration*/
-typedef void (call_sip_info_h)(
+typedef bool (call_sip_info_h)(
 	struct call *call,
 	const char *content_type,
 	const uint8_t *body,

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -500,6 +500,17 @@ int config_print(struct re_printf *pf, const struct config *cfg);
 int config_write_template(const char *file, const struct config *cfg);
 struct config *conf_config(void);
 
+/** Sip Info Configuration*/
+typedef bool (call_sip_info_h)(
+    struct call *call,
+    const char *content_type,
+    const uint8_t *body,
+    size_t body_len,
+    const struct sip_msg *msg,
+    void *arg
+);
+void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
+
 
 /*
  * Contact

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -217,7 +217,14 @@ typedef void (call_event_h)(struct call *call, enum call_event ev,
 typedef void (call_dtmf_h)(struct call *call, char key, void *arg);
 typedef bool (call_match_h)(const struct call *call, void *arg);
 typedef void (call_list_h)(struct call *call, void *arg);
-
+typedef bool (call_sip_info_h)(
+	struct call *call,
+	const char *content_type,
+	const uint8_t *body,
+	size_t body_len,
+	const struct sip_msg *msg,
+	void *arg
+);
 
 int  call_connect(struct call *call, const struct pl *paddr);
 int  call_answer(struct call *call, uint16_t scode, enum vidmode vmode);
@@ -248,6 +255,9 @@ int  call_notify_sipfrag(struct call *call, uint16_t scode,
 			 const char *reason, ...);
 void call_set_handlers(struct call *call, call_event_h *eh,
 		       call_dtmf_h *dtmfh, void *arg);
+void call_set_sip_info_handler(struct call *call,
+				call_sip_info_h *handler,
+				void *arg);
 struct account *call_account(const struct call *call);
 uint16_t      call_scode(const struct call *call);
 enum call_state call_state(const struct call *call);
@@ -499,22 +509,6 @@ int config_parse_conf(struct config *cfg, const struct conf *conf);
 int config_print(struct re_printf *pf, const struct config *cfg);
 int config_write_template(const char *file, const struct config *cfg);
 struct config *conf_config(void);
-
-/** Sip Info Configuration*/
-typedef bool (call_sip_info_h)(
-	struct call *call,
-	const char *content_type,
-	const uint8_t *body,
-	size_t body_len,
-	const struct sip_msg *msg,
-	void *arg
-);
-
-void call_set_sip_info_handler(
-	struct call *call,
-	call_sip_info_h *handler,
-	void *arg
-);
 
 
 /*

--- a/src/call.c
+++ b/src/call.c
@@ -85,13 +85,13 @@ struct call {
 	bool use_video;
 	bool use_rtp;
 	struct pl *user_data;      /**< User data related to the call       */
+	call_sip_info_h *sip_infoh;/**< SIP INFO handler for this call      */
+	void *sip_info_arg;        /**< SIP INFO handler argument           */
 };
 
 
 static int send_invite(struct call *call);
 static int send_dtmf_info(struct call *call, char key);
-static call_sip_info_h *sip_info_handler = NULL;
-static void *sip_info_arg = NULL;
 
 static const char *state_name(enum call_state st)
 {
@@ -975,10 +975,14 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	return err;
 }
 
-void call_set_sip_info_handler(call_sip_info_h *handler, void *arg)
+void call_set_sip_info_handler(struct call *call,
+			       call_sip_info_h *handler, void *arg)
 {
-	sip_info_handler = handler;
-	sip_info_arg = arg;
+	if (!call)
+		return;
+
+	call->sip_infoh = handler;
+	call->sip_info_arg = arg;
 }
 
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
@@ -2021,7 +2025,7 @@ static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 	struct pl body;
 	char content_type[256] = "";
 
-	if (!call || !msg || !sip_info_handler) {
+	if (!call || !msg || !call->sip_infoh) {
 		return;
 	}
 
@@ -2049,13 +2053,13 @@ static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 
 	pl_set_mbuf(&body, msg->mb);
 
-	sip_info_handler(
+	call->sip_infoh(
 		call,
 		content_type[0] ? content_type : NULL,
 		(const uint8_t *)body.p,
 		body.l,
 		msg,
-		sip_info_arg
+		call->sip_info_arg
 	);
 }
 
@@ -2230,7 +2234,7 @@ static void xfer_cleanup(struct call *call, char *reason)
 	if (call->xcall->state == CALL_STATE_TRANSFER) {
 		set_state(call->xcall, CALL_STATE_ESTABLISHED);
 		call_event_handler(call->xcall, CALL_EVENT_TRANSFER_FAILED,
-						"%s", reason);
+                                   "%s", reason);
 	}
 
 	call->xcall->xcall = NULL;

--- a/src/call.c
+++ b/src/call.c
@@ -2023,13 +2023,13 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 }
 
 
-static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
+static bool call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 {
 	struct pl body;
 	char content_type[256] = "";
 
 	if (!call || !msg || !call->sip_infoh)
-		return;
+		return false;
 
 	if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
 		re_snprintf(
@@ -2045,12 +2045,14 @@ static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 
 	pl_set_mbuf(&body, msg->mb);
 
-	call->sip_infoh(call,
-			content_type[0] ? content_type : NULL,
-			(const uint8_t *)body.p,
-			body.l,
-			msg,
-			call->sip_info_arg);
+	return call->sip_infoh(
+		call,
+		content_type[0] ? content_type : NULL,
+		(const uint8_t *)body.p,
+		body.l,
+		msg,
+		call->sip_info_arg
+	);
 }
 
 
@@ -2124,7 +2126,6 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 				 void *arg)
 {
 	struct call *call = arg;
-	call_emit_sip_info(call, msg);
 
 	if (msg_ctype_cmp(&msg->ctyp, "application", "dtmf-relay")) {
 
@@ -2157,7 +2158,7 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 			}
 		}
 	}
-	else if (!mbuf_get_left(msg->mb)) {
+	else if (!mbuf_get_left(msg->mb) || call_emit_sip_info(call, msg)) {
 		(void)sip_reply(sip, msg, 200, "OK");
 	}
 	else {

--- a/src/call.c
+++ b/src/call.c
@@ -975,6 +975,7 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	return err;
 }
 
+
 void call_set_sip_info_handler(struct call *call,
 			       call_sip_info_h *handler, void *arg)
 {
@@ -984,6 +985,7 @@ void call_set_sip_info_handler(struct call *call,
 	call->sip_infoh = handler;
 	call->sip_info_arg = arg;
 }
+
 
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
 {
@@ -2020,48 +2022,37 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 	return minwait + rand_u16() % (maxwait - minwait);
 }
 
+
 static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 {
 	struct pl body;
 	char content_type[256] = "";
 
-	if (!call || !msg || !call->sip_infoh) {
+	if (!call || !msg || !call->sip_infoh)
 		return;
-	}
 
 	if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
-		if (pl_isset(&msg->ctyp.params)) {
-			re_snprintf(
-				content_type,
-				sizeof(content_type),
-				"%r/%r;%r",
-				&msg->ctyp.type,
-				&msg->ctyp.subtype,
-				&msg->ctyp.params
-			);
-		}
-		else {
-			re_snprintf(
-				content_type,
-				sizeof(content_type),
-				"%r/%r",
-				&msg->ctyp.type,
-				&msg->ctyp.subtype
-			);
-		}
+		re_snprintf(
+			content_type,
+			sizeof(content_type),
+			"%r/%r%s%r",
+			&msg->ctyp.type,
+			&msg->ctyp.subtype,
+			pl_isset(&msg->ctyp.params) ? ";" : "",
+			&msg->ctyp.params
+		);
 	}
 
 	pl_set_mbuf(&body, msg->mb);
 
-	call->sip_infoh(
-		call,
-		content_type[0] ? content_type : NULL,
-		(const uint8_t *)body.p,
-		body.l,
-		msg,
-		call->sip_info_arg
-	);
+	call->sip_infoh(call,
+			content_type[0] ? content_type : NULL,
+			(const uint8_t *)body.p,
+			body.l,
+			msg,
+			call->sip_info_arg);
 }
+
 
 static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 {
@@ -2553,7 +2544,7 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 	call->estvdir = stream_ldir(video_strm(call_video(call)));
 	if (!call->acc->mnat)
 		call_event_handler(call, CALL_EVENT_INCOMING, "%s",
-						call->peer_uri);
+                                   call->peer_uri);
 
 	return 0;
 }
@@ -2630,13 +2621,13 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	if (media) {
 		mem_ref(call);
 		call_event_handler(call, CALL_EVENT_PROGRESS, "%s",
-						call->peer_uri);
+                                   call->peer_uri);
 		mem_deref(call);
 	}
 	else {
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_RINGING, "%s",
-						call->peer_uri);
+                                   call->peer_uri);
 	}
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -90,7 +90,8 @@ struct call {
 
 static int send_invite(struct call *call);
 static int send_dtmf_info(struct call *call, char key);
-
+static call_sip_info_h *sip_info_handler = NULL;
+static void *sip_info_arg = NULL;
 
 static const char *state_name(enum call_state st)
 {
@@ -974,6 +975,11 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 	return err;
 }
 
+void call_set_sip_info_handler(call_sip_info_h *handler, void *arg)
+{
+    sip_info_handler = handler;
+    sip_info_arg = arg;
+}
 
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
 {
@@ -2010,6 +2016,48 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 	return minwait + rand_u16() % (maxwait - minwait);
 }
 
+static bool call_emit_sip_info(struct call *call, const struct sip_msg *msg)
+{
+    struct pl body;
+    char content_type[256] = "";
+
+    if (!call || !msg || !sip_info_handler) {
+        return false;
+    }
+
+    if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
+        if (pl_isset(&msg->ctyp.params)) {
+            re_snprintf(
+                content_type,
+                sizeof(content_type),
+                "%r/%r;%r",
+                &msg->ctyp.type,
+                &msg->ctyp.subtype,
+                &msg->ctyp.params
+            );
+        }
+        else {
+            re_snprintf(
+                content_type,
+                sizeof(content_type),
+                "%r/%r",
+                &msg->ctyp.type,
+                &msg->ctyp.subtype
+            );
+        }
+    }
+
+    pl_set_mbuf(&body, msg->mb);
+
+    return sip_info_handler(
+        call,
+        content_type[0] ? content_type : NULL,
+        (const uint8_t *)body.p,
+        body.l,
+        msg,
+        sip_info_arg
+    );
+}
 
 static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
 {
@@ -2081,6 +2129,7 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 				 void *arg)
 {
 	struct call *call = arg;
+    bool app_handled = call_emit_sip_info(call, msg);
 
 	if (msg_ctype_cmp(&msg->ctyp, "application", "dtmf-relay")) {
 

--- a/src/call.c
+++ b/src/call.c
@@ -237,7 +237,7 @@ static void mnat_handler(int err, uint16_t scode, const char *reason,
 
 	case CALL_STATE_INCOMING:
 		call_event_handler(call, CALL_EVENT_INCOMING, "%s",
-                                   call->peer_uri);
+				   call->peer_uri);
 		break;
 
 	default:
@@ -977,8 +977,8 @@ int call_alloc(struct call **callp, const struct config *cfg, struct list *lst,
 
 void call_set_sip_info_handler(call_sip_info_h *handler, void *arg)
 {
-    sip_info_handler = handler;
-    sip_info_arg = arg;
+	sip_info_handler = handler;
+	sip_info_arg = arg;
 }
 
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
@@ -1969,7 +1969,7 @@ static int sipsess_answer_handler(const struct sip_msg *msg, void *arg)
 	    msg->scode >= 200 && msg->scode < 300 &&
 	    call_state(call) != CALL_STATE_ESTABLISHED)
 		call_event_handler(call, CALL_EVENT_ANSWERED, "%s",
-                                   call->peer_uri);
+				   call->peer_uri);
 
 	if (msg_ctype_cmp(&msg->ctyp, "multipart", "mixed"))
 		(void)sdp_decode_multipart(&msg->ctyp.params, msg->mb);
@@ -2016,47 +2016,47 @@ static uint32_t randwait(uint32_t minwait, uint32_t maxwait)
 	return minwait + rand_u16() % (maxwait - minwait);
 }
 
-static bool call_emit_sip_info(struct call *call, const struct sip_msg *msg)
+static void call_emit_sip_info(struct call *call, const struct sip_msg *msg)
 {
-    struct pl body;
-    char content_type[256] = "";
+	struct pl body;
+	char content_type[256] = "";
 
-    if (!call || !msg || !sip_info_handler) {
-        return false;
-    }
+	if (!call || !msg || !sip_info_handler) {
+		return;
+	}
 
-    if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
-        if (pl_isset(&msg->ctyp.params)) {
-            re_snprintf(
-                content_type,
-                sizeof(content_type),
-                "%r/%r;%r",
-                &msg->ctyp.type,
-                &msg->ctyp.subtype,
-                &msg->ctyp.params
-            );
-        }
-        else {
-            re_snprintf(
-                content_type,
-                sizeof(content_type),
-                "%r/%r",
-                &msg->ctyp.type,
-                &msg->ctyp.subtype
-            );
-        }
-    }
+	if (pl_isset(&msg->ctyp.type) && pl_isset(&msg->ctyp.subtype)) {
+		if (pl_isset(&msg->ctyp.params)) {
+			re_snprintf(
+				content_type,
+				sizeof(content_type),
+				"%r/%r;%r",
+				&msg->ctyp.type,
+				&msg->ctyp.subtype,
+				&msg->ctyp.params
+			);
+		}
+		else {
+			re_snprintf(
+				content_type,
+				sizeof(content_type),
+				"%r/%r",
+				&msg->ctyp.type,
+				&msg->ctyp.subtype
+			);
+		}
+	}
 
-    pl_set_mbuf(&body, msg->mb);
+	pl_set_mbuf(&body, msg->mb);
 
-    return sip_info_handler(
-        call,
-        content_type[0] ? content_type : NULL,
-        (const uint8_t *)body.p,
-        body.l,
-        msg,
-        sip_info_arg
-    );
+	sip_info_handler(
+		call,
+		content_type[0] ? content_type : NULL,
+		(const uint8_t *)body.p,
+		body.l,
+		msg,
+		sip_info_arg
+	);
 }
 
 static void sipsess_estab_handler(const struct sip_msg *msg, void *arg)
@@ -2129,7 +2129,7 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 				 void *arg)
 {
 	struct call *call = arg;
-    bool app_handled = call_emit_sip_info(call, msg);
+	call_emit_sip_info(call, msg);
 
 	if (msg_ctype_cmp(&msg->ctyp, "application", "dtmf-relay")) {
 
@@ -2230,7 +2230,7 @@ static void xfer_cleanup(struct call *call, char *reason)
 	if (call->xcall->state == CALL_STATE_TRANSFER) {
 		set_state(call->xcall, CALL_STATE_ESTABLISHED);
 		call_event_handler(call->xcall, CALL_EVENT_TRANSFER_FAILED,
-                                   "%s", reason);
+						"%s", reason);
 	}
 
 	call->xcall->xcall = NULL;
@@ -2549,7 +2549,7 @@ int call_accept(struct call *call, struct sipsess_sock *sess_sock,
 	call->estvdir = stream_ldir(video_strm(call_video(call)));
 	if (!call->acc->mnat)
 		call_event_handler(call, CALL_EVENT_INCOMING, "%s",
-                                   call->peer_uri);
+						call->peer_uri);
 
 	return 0;
 }
@@ -2626,13 +2626,13 @@ static void sipsess_progr_handler(const struct sip_msg *msg, void *arg)
 	if (media) {
 		mem_ref(call);
 		call_event_handler(call, CALL_EVENT_PROGRESS, "%s",
-                                   call->peer_uri);
+						call->peer_uri);
 		mem_deref(call);
 	}
 	else {
 		call_stream_stop(call);
 		call_event_handler(call, CALL_EVENT_RINGING, "%s",
-                                   call->peer_uri);
+						call->peer_uri);
 	}
 }
 

--- a/src/call.c
+++ b/src/call.c
@@ -238,7 +238,7 @@ static void mnat_handler(int err, uint16_t scode, const char *reason,
 
 	case CALL_STATE_INCOMING:
 		call_event_handler(call, CALL_EVENT_INCOMING, "%s",
-				   call->peer_uri);
+                                   call->peer_uri);
 		break;
 
 	default:
@@ -1976,7 +1976,7 @@ static int sipsess_answer_handler(const struct sip_msg *msg, void *arg)
 	    msg->scode >= 200 && msg->scode < 300 &&
 	    call_state(call) != CALL_STATE_ESTABLISHED)
 		call_event_handler(call, CALL_EVENT_ANSWERED, "%s",
-				   call->peer_uri);
+                                   call->peer_uri);
 
 	if (msg_ctype_cmp(&msg->ctyp, "multipart", "mixed"))
 		(void)sdp_decode_multipart(&msg->ctyp.params, msg->mb);

--- a/src/call.c
+++ b/src/call.c
@@ -93,6 +93,7 @@ struct call {
 static int send_invite(struct call *call);
 static int send_dtmf_info(struct call *call, char key);
 
+
 static const char *state_name(enum call_state st)
 {
 	switch (st) {
@@ -2158,7 +2159,7 @@ static void sipsess_info_handler(struct sip *sip, const struct sip_msg *msg,
 			}
 		}
 	}
-	else if (!mbuf_get_left(msg->mb) || call_emit_sip_info(call, msg)) {
+	else if (call_emit_sip_info(call, msg) || !mbuf_get_left(msg->mb)) {
 		(void)sip_reply(sip, msg, 200, "OK");
 	}
 	else {


### PR DESCRIPTION
## Summary

This PR adds a call-level callback for incoming SIP INFO requests.

The new callback allows applications embedding baresip to inspect and handle incoming SIP INFO messages directly from the call layer.

The callback exposes:

- the related `struct call`
- the SIP INFO `Content-Type`
- the raw body payload
- the body length
- the original `struct sip_msg`
- custom SIP headers through the original SIP message reference

## Changes

Added a new SIP INFO handler type:
```C
typedef bool (call_sip_info_h)(struct call *call,
			       const char *content_type,
			       const uint8_t *body,
			       size_t body_len,
			       const struct sip_msg *msg,
			       void *arg);
```

Added a public registration API:
```C
void call_set_sip_info_handler(call_sip_info_h *handler, void *arg);
```

Added internal SIP INFO event emission:
```c
call_emit_sip_info(call, msg);
```

Added a new internal helper:
```c
static void call_emit_sip_info(struct call *call, const struct sip_msg *msg);
```

The helper extracts the SIP INFO `Content-Type`, including optional content-type parameters, maps the SIP message body from the SIP message buffer, and invokes the registered application handler.

The callback return value is propagated as `app_handled`, allowing the call code to know whether the SIP INFO request was handled by the application layer.

## Motivation
Some applications use SIP INFO for custom in-call signaling, not only for standard DTMF-related use cases.

For example, applications may need to receive custom commands, metadata, or vendor-specific headers carried inside SIP INFO requests.

Before this change, there was no clean call-level API for applications or SDK wrappers to receive incoming SIP INFO messages while preserving access to the raw body and original SIP headers.