### PR TITLE
rtprecv: fix use after free on ENODEV errors

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -622,7 +622,7 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 /**
  * Stream receive handler for audio is called from RX thread if enabled
  */
-static void stream_recv_handler(const struct rtp_header *hdr,
+static int stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc,
 				bool new_source,
@@ -633,12 +633,12 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	MAGIC_CHECK(a);
 
 	if (!a->aur)
-		return;
+		return EINVAL;
 
 	if (new_source)
 		aurecv_reset(a->aur);
 
-	aurecv_receive(a->aur, hdr, extv, extc, mb, lostc);
+	return aurecv_receive(a->aur, hdr, extv, extc, mb, lostc);
 }
 
 

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -274,22 +274,23 @@ void aurecv_reset(struct audio_recv *ar)
 	mtx_unlock(ar->mtx);
 }
 
-/* Handle incoming stream data from the network */
-void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+
+int  aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		    struct rtpext *extv, size_t extc,
 		    struct mbuf *mb, unsigned lostc)
 {
 	bool discard = false;
 	int wrap;
+	int err = 0;
 	(void) lostc;
 
 	if (!mb)
-		return;
+		return EINVAL;
 
 	mtx_lock(ar->mtx);
 	if (hdr->pt != ar->pt) {
 		mtx_unlock(ar->mtx);
-		return;
+		return EAGAIN;
 	}
 
 
@@ -341,10 +342,11 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 /*        if (lostc)*/
 /*                (void)aurecv_stream_decode(ar, hdr, mb, lostc, drop);*/
 
-	(void)aurecv_stream_decode(ar, hdr, mb, 0);
+	err = aurecv_stream_decode(ar, hdr, mb, 0);
 
 out:
 	mtx_unlock(ar->mtx);
+	return err;
 }
 
 

--- a/src/core.h
+++ b/src/core.h
@@ -128,7 +128,7 @@ void aurecv_flush(struct audio_recv *ar);
 void aurecv_set_extmap(struct audio_recv *ar, uint8_t aulevel);
 int  aurecv_set_module(struct audio_recv *ar, const char *module);
 int  aurecv_set_device(struct audio_recv *ar, const char *device);
-void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
+int  aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		    struct rtpext *extv, size_t extc,
 		    struct mbuf *mb, unsigned lostc);
 void aurecv_reset(struct audio_recv *ar);
@@ -302,7 +302,7 @@ struct rtp_header;
 
 enum {STREAM_PRESZ = 4+12}; /* same as RTP_HEADER_SIZE */
 
-typedef void (stream_rtp_h)(const struct rtp_header *hdr,
+typedef int (stream_rtp_h)(const struct rtp_header *hdr,
 			    struct rtpext *extv, size_t extc,
 			    struct mbuf *mb, unsigned lostc, bool new_source,
 			    void *arg);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -260,7 +260,7 @@ static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
 }
 
 
-static void handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
+static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 		      struct mbuf *mb, unsigned lostc)
 {
 	struct rtpext extv[8];
@@ -286,7 +286,7 @@ static void handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 			warning("rtp_receiver: corrupt rtp packet,"
 				" not enough space for rtpext of %zu bytes\n",
 				ext_len);
-			return;
+			return EPROTO;
 		}
 
 		mb->pos = mb->pos - ext_len;
@@ -298,7 +298,7 @@ static void handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 			if (err) {
 				warning("rtp_receiver: rtpext_decode failed "
 					"(%m)\n", err);
-				return;
+				return err;
 			}
 		}
 
@@ -313,9 +313,7 @@ handler:
 
 	bool new_source = rtprecv_consume_ssrc_change(rx, NULL);
 
-	rx->rtph(hdr, extv, extc, mb, lostc, new_source, rx->arg);
-
-	return;
+	return rx->rtph(hdr, extv, extc, mb, lostc, new_source, rx->arg);
 }
 
 
@@ -374,8 +372,10 @@ static void decode_frames(struct rtp_receiver *rx)
 
 		lostc = lostcalc(rx, hdr.seq);
 
-		handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0);
+		err = handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0);
 		mem_deref(mb);
+		if (err == ENODEV)
+			return;
 	} while (--n);
 
 	delay = jbuf_next_play(rx->jbuf);

--- a/src/video.c
+++ b/src/video.c
@@ -885,7 +885,7 @@ static int stream_pt_handler(uint8_t pt, struct mbuf *mb, void *arg)
 
 
 /* Handle incoming stream data from the network */
-static void stream_recv_handler(const struct rtp_header *hdr,
+static int stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc,
 				bool new_source,
@@ -902,7 +902,7 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	if (lostc)
 		request_picture_update(&v->vrx);
 
-	(void)video_stream_decode(&v->vrx, hdr, mb);
+	return video_stream_decode(&v->vrx, hdr, mb);
 }
 
 


### PR DESCRIPTION
There was a use after free in the decode_frames() loop if CALL_CLOSED was emitted from
video_error_handler().

The wanted behavior is to hangup the call if there is no video display or in any other case where a CALL_CLOSED event is emitted. After emitting CALL_CLOSED it is not allowed to access any data that belongs to the call object.

This PR adds an early exit to the `decode_frames()` loop in `rtprecv.c`

```
Thread 1 "baresip" received signal SIGSEGV, Segmentation fault.
0x00007ffff7f7f528 in jbuf_get (jb=0xb5b5b5b5b5b5b5b5, hdr=0x7fffffffd788, mem=0x7fffffffd780) at /home/cspiel/src/baresip/src/jbuf.c:683
683		mtx_lock(jb->lock);
(gdb) bt
#0  0x00007ffff7f7f528 in jbuf_get (jb=0xb5b5b5b5b5b5b5b5, hdr=0x7fffffffd788, mem=0x7fffffffd780) at /home/cspiel/src/baresip/src/jbuf.c:683
#1  0x00007ffff7f8aa3b in decode_frames (rx=0x555555710720) at /home/cspiel/src/baresip/src/rtprecv.c:372
#2  0x00007ffff7f893dd in decode_tmr (arg=0x555555710720) at /home/cspiel/src/baresip/src/rtprecv.c:330
#3  0x00007ffff7ed6b88 in tmr_poll (tmrl=0x55555555b8e0) at /home/cspiel/src/re/src/tmr/tmr.c:166
#4  0x00007ffff7eb4961 in re_main (signalh=0x555555556c60 <signal_handler>) at /home/cspiel/src/re/src/main/main.c:1085
#5  0x0000555555556b16 in main (argc=1, argv=0x7fffffffdbd8) at /home/cspiel/src/baresip/src/main.c:329
```