### PR TITLE
aaudio: support device selection via config

### DIFF
--- a/modules/aaudio/player.c
+++ b/modules/aaudio/player.c
@@ -5,6 +5,9 @@
  * Copyright (C) 2024 Sebastian Reimers
  */
 
+#include <stdlib.h>
+#include <stdint.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
@@ -18,6 +21,7 @@ struct auplay_st {
 	void *arg;
 	struct auplay_prm play_prm;
 	size_t sampsz;
+	int32_t device_id;
 };
 
 
@@ -103,7 +107,10 @@ static int open_player_stream(struct auplay_st *st) {
 
 	AAudioStreamBuilder *builder;
 	aaudio_result_t result;
+	int32_t device_id = st->device_id;
+	bool fallback = false;
 
+ retry:
 	result = AAudio_createStreamBuilder(&builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: player: failed to create stream builder: "
@@ -122,15 +129,30 @@ static int open_player_stream(struct auplay_st *st) {
 		AAUDIO_USAGE_VOICE_COMMUNICATION);
 	AAudioStreamBuilder_setPerformanceMode(builder,
 		AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
+	if (device_id >= 0)
+		AAudioStreamBuilder_setDeviceId(builder, device_id);
 	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, st);
 	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, st);
 
 	result = AAudioStreamBuilder_openStream(builder, &st->playerStream);
 	if (result != AAUDIO_OK) {
+		AAudioStreamBuilder_delete(builder);
+
+		if (device_id >= 0 && !fallback) {
+			warning("aaudio: player: device %d unavailable, "
+				"falling back to default\n", device_id);
+			device_id = -1;
+			fallback = true;
+			goto retry;
+		}
+
 		warning("aaudio: player: failed to open stream: error %s\n",
 			AAudio_convertResultToText(result));
 		return result;
 	}
+
+	if (fallback)
+		info("aaudio: player: fell back to default device\n");
 
 	info("aaudio: player: opened stream with direction %d, "
 	     "sharing mode %d, sample rate %d, format %d, sessionId %d, "
@@ -161,7 +183,7 @@ int aaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 	if (!stp || !ap || !prm || !wh)
 		return EINVAL;
 
-	info ("aadio: opening player (%u Hz, %d channels, device %s, "
+	info ("aaudio: opening player (%u Hz, %d channels, device %s, "
 		"ptime %u)\n", prm->srate, prm->ch, dev, prm->ptime);
 
 	if (prm->fmt != AUFMT_S16LE) {
@@ -181,6 +203,30 @@ int aaudio_player_alloc(struct auplay_st **stp, const struct auplay *ap,
 		return ENOMEM;
 
 	st->play_prm = *prm;
+
+	/*
+	 * Parse device id from the <device> field of audio_player config
+	 * (e.g. "audio_player aaudio,5").  "default" or empty means -1
+	 * (let AAudio pick the default device).
+	 */
+	if (str_isset(dev) && str_casecmp(dev, "default") != 0) {
+		char *endptr;
+		long val = strtol(dev, &endptr, 10);
+		if (endptr == dev || *endptr != '\0' || val < 0 ||
+		    val > INT32_MAX) {
+			warning("aaudio: player: invalid device id "
+				"'%s', using default\n", dev);
+			st->device_id = -1;
+		}
+		else {
+			st->device_id = (int32_t)val;
+		}
+	}
+	else {
+		st->device_id = -1;
+	}
+
+	info("aaudio: player: using device id %d\n", st->device_id);
 
 	st->wh  = wh;
 	st->arg = arg;

--- a/modules/aaudio/recorder.c
+++ b/modules/aaudio/recorder.c
@@ -5,10 +5,13 @@
  * Copyright (C) 2024 Sebastian Reimers
  */
 
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
 #include <re.h>
 #include <rem.h>
 #include <baresip.h>
-#include <string.h>
 
 #include "aaudio.h"
 
@@ -23,6 +26,7 @@ struct ausrc_st {
 	size_t  sampsz;
 	size_t  sampc;
 	uint64_t samps;
+	int32_t device_id;
 };
 
 
@@ -130,7 +134,10 @@ static int open_recorder_stream(struct ausrc_st *st) {
 
 	AAudioStreamBuilder *builder;
 	aaudio_result_t result;
+	int32_t device_id = st->device_id;
+	bool fallback = false;
 
+ retry:
 	result = AAudio_createStreamBuilder(&builder);
 	if (result != AAUDIO_OK) {
 		warning("aaudio: recorder: failed to create stream builder: "
@@ -151,15 +158,30 @@ static int open_recorder_stream(struct ausrc_st *st) {
 		AAUDIO_PERFORMANCE_MODE_LOW_LATENCY);
 	AAudioStreamBuilder_setInputPreset(builder,
 		AAUDIO_INPUT_PRESET_VOICE_COMMUNICATION);
+	if (device_id >= 0)
+		AAudioStreamBuilder_setDeviceId(builder, device_id);
 	AAudioStreamBuilder_setDataCallback(builder, &dataCallback, st);
 	AAudioStreamBuilder_setErrorCallback(builder, &errorCallback, st);
 
 	result = AAudioStreamBuilder_openStream(builder, &st->recorderStream);
 	if (result != AAUDIO_OK) {
+		AAudioStreamBuilder_delete(builder);
+
+		if (device_id >= 0 && !fallback) {
+			warning("aaudio: recorder: device %d unavailable, "
+				"falling back to default\n", device_id);
+			device_id = -1;
+			fallback = true;
+			goto retry;
+		}
+
 		warning("aaudio: recorder: failed to open stream: error %s\n",
 			AAudio_convertResultToText(result));
 		return result;
 	}
+
+	if (fallback)
+		info("aaudio: recorder: fell back to default device\n");
 
 	info("aaudio: recorder: opened stream with direction %d, "
 	     "sharing mode %d, sample rate %d, format %d, sessionId %d, "
@@ -218,6 +240,30 @@ int aaudio_recorder_alloc(struct ausrc_st **stp, const struct ausrc *as,
 		return ENOMEM;
 
 	st->src_prm = *prm;
+
+	/*
+	 * Parse device id from the <device> field of audio_source config
+	 * (e.g. "audio_source aaudio,7").  "default" or empty means -1
+	 * (let AAudio pick the default device).
+	 */
+	if (str_isset(dev) && str_casecmp(dev, "default") != 0) {
+		char *endptr;
+		long val = strtol(dev, &endptr, 10);
+		if (endptr == dev || *endptr != '\0' || val < 0 ||
+		    val > INT32_MAX) {
+			warning("aaudio: recorder: invalid device id "
+				"'%s', using default\n", dev);
+			st->device_id = -1;
+		}
+		else {
+			st->device_id = (int32_t)val;
+		}
+	}
+	else {
+		st->device_id = -1;
+	}
+
+	info("aaudio: recorder: using device id %d\n", st->device_id);
 
 	st->sampsz = aufmt_sample_size(prm->fmt);
 	st->sampc  = prm->ptime * prm->ch * prm->srate / 1000;


### PR DESCRIPTION
## Summary

Add device selection support to the Android AAudio module by parsing the `<device>` field from the standard `audio_player` / `audio_source` baresip config. The device ID is passed as an integer to `AAudioStreamBuilder_setDeviceId`. Runtime switching uses the existing `/auplay` and `/ausrc` menu commands — no custom command is registered.

## Changes

- `modules/aaudio/player.c`: Parse the `dev` parameter as an AAudio device id via `strtol` with strict validation (rejects negative values, trailing garbage, and overflow). Store the id per-stream so error-callback restarts reuse it. `"default"` or empty means -1 (let AAudio pick). Fall back to the system default if the requested device is unavailable.
- `modules/aaudio/recorder.c`: Same as above for the input device.
- `modules/aaudio/aaudio.c`: No changes to module init/close (registers auplay + ausrc only, no custom command).
- `modules/aaudio/aaudio.h`: No global variables added.
- `modules/aaudio/player.c` (typo): Fix pre-existing `aadio` → `aaudio` in a log message.

## Usage

### Config file

```text
audio_player    aaudio,5     # output device id 5
audio_source    aaudio,7     # input device id 7
```

The `<device>` field is parsed via `strtol` — negative values, trailing garbage (e.g. `"123abc"`), and overflow (`> INT32_MAX`) are rejected with a warning and fall back to default. `"default"` or empty means -1 (let AAudio auto-select).

### Runtime switching (during a call)

```text
/auplay aaudio,5         # switch output device
/ausrc  aaudio,7         # switch input device
/auplay aaudio,default   # reset to auto-selection
/ausrc  aaudio,default   # reset to auto-selection
```

These are standard menu commands that update the config and immediately re-allocate the audio device on all active calls — no need to hang up and redial.

## Notes

- `-1` means "use system default" (original behavior).
- Device id is stored per-stream; error-callback restarts reuse the same value.
- If the selected device becomes unavailable, the stream falls back to the default device without changing the config.
- AAudio C API does not provide device enumeration, so `mediadev` is not used (same as alsa). The `/auplay` and `/ausrc` commands skip device validation when `dev_list` is empty, passing the string directly to the module for parsing.