### PR TITLE
core: cleanup stream_rtp_h ignore handling

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -626,7 +626,6 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc,
 				bool new_source,
-				bool *ignore,
 				void *arg)
 {
 	struct audio *a = arg;
@@ -639,7 +638,7 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 	if (new_source)
 		aurecv_reset(a->aur);
 
-	aurecv_receive(a->aur, hdr, extv, extc, mb, lostc, ignore);
+	aurecv_receive(a->aur, hdr, extv, extc, mb, lostc);
 }
 
 

--- a/src/aureceiver.c
+++ b/src/aureceiver.c
@@ -213,7 +213,7 @@ static int aurecv_push_aubuf(struct audio_recv *ar, const struct auframe *af)
 
 static int aurecv_stream_decode(struct audio_recv *ar,
 				const struct rtp_header *hdr,
-				struct mbuf *mb, unsigned lostc, bool drop)
+				struct mbuf *mb, unsigned lostc)
 {
 	struct auframe af;
 	size_t sampc = ar->sampvsz / aufmt_sample_size(ar->fmt);
@@ -256,11 +256,6 @@ static int aurecv_stream_decode(struct audio_recv *ar,
 	auframe_init(&af, ar->fmt, ar->sampv, sampc, ac->srate, ac->ch);
 	af.timestamp = ((uint64_t) hdr->ts) * AUDIO_TIMEBASE / ac->crate;
 
-	if (drop) {
-		aubuf_drop_auframe(ar->aubuf, &af);
-		goto out;
-	}
-
 	err = aurecv_process_decfilt(ar, &af);
 	if (err)
 		goto out;
@@ -286,10 +281,9 @@ void aurecv_reset(struct audio_recv *ar)
 /* Handle incoming stream data from the network */
 void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		    struct rtpext *extv, size_t extc,
-		    struct mbuf *mb, unsigned lostc, bool *ignore)
+		    struct mbuf *mb, unsigned lostc)
 {
 	bool discard = false;
-	bool drop = *ignore;
 	int wrap;
 	(void) lostc;
 
@@ -299,11 +293,9 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 	mtx_lock(ar->mtx);
 	if (hdr->pt != ar->pt) {
 		mtx_unlock(ar->mtx);
-		*ignore = true;
 		return;
 	}
 
-	*ignore = false;
 
 	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
 	const struct rtpext *ext = rtpext_find(extv, extc, ar->extmap_aulevel);
@@ -353,7 +345,7 @@ void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 /*        if (lostc)*/
 /*                (void)aurecv_stream_decode(ar, hdr, mb, lostc, drop);*/
 
-	(void)aurecv_stream_decode(ar, hdr, mb, 0, drop);
+	(void)aurecv_stream_decode(ar, hdr, mb, 0);
 
 out:
 	mtx_unlock(ar->mtx);

--- a/src/core.h
+++ b/src/core.h
@@ -130,7 +130,7 @@ int  aurecv_set_module(struct audio_recv *ar, const char *module);
 int  aurecv_set_device(struct audio_recv *ar, const char *device);
 void aurecv_receive(struct audio_recv *ar, const struct rtp_header *hdr,
 		    struct rtpext *extv, size_t extc,
-		    struct mbuf *mb, unsigned lostc, bool *ignore);
+		    struct mbuf *mb, unsigned lostc);
 void aurecv_reset(struct audio_recv *ar);
 int  aurecv_start_player(struct audio_recv *ar, struct list *auplayl);
 bool aurecv_player_started(const struct audio_recv *ar);
@@ -305,7 +305,6 @@ enum {STREAM_PRESZ = 4+12}; /* same as RTP_HEADER_SIZE */
 typedef void (stream_rtp_h)(const struct rtp_header *hdr,
 			    struct rtpext *extv, size_t extc,
 			    struct mbuf *mb, unsigned lostc, bool new_source,
-			    bool *ignore,
 			    void *arg);
 typedef int (stream_pt_h)(uint8_t pt, struct mbuf *mb, void *arg);
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -260,7 +260,7 @@ static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
 }
 
 
-static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
+static void handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 		      struct mbuf *mb, unsigned lostc)
 {
 	struct rtpext extv[8];
@@ -286,7 +286,7 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 			warning("rtp_receiver: corrupt rtp packet,"
 				" not enough space for rtpext of %zu bytes\n",
 				ext_len);
-			return 0;
+			return;
 		}
 
 		mb->pos = mb->pos - ext_len;
@@ -298,7 +298,7 @@ static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
 			if (err) {
 				warning("rtp_receiver: rtpext_decode failed "
 					"(%m)\n", err);
-				return 0;
+				return;
 			}
 		}
 
@@ -315,7 +315,7 @@ handler:
 
 	rx->rtph(hdr, extv, extc, mb, lostc, new_source, rx->arg);
 
-	return 0;
+	return;
 }
 
 
@@ -363,7 +363,7 @@ static void decode_frames(struct rtp_receiver *rx)
 	if (!rx || !rx->jbuf)
 		return;
 
-	uint32_t n = jbuf_packets(rx->jbuf);
+	uint32_t n = 1;
 
 	do {
 		err = jbuf_get(rx->jbuf, &hdr, &mb);
@@ -374,12 +374,9 @@ static void decode_frames(struct rtp_receiver *rx)
 
 		lostc = lostcalc(rx, hdr.seq);
 
-		err = handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0);
+		handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0);
 		mem_deref(mb);
-
-		if (err)
-			break;
-	} while (n--);
+	} while (--n);
 
 	delay = jbuf_next_play(rx->jbuf);
 	if (delay < 0)

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -261,11 +261,10 @@ static int lostcalc(struct rtp_receiver *rx, uint16_t seq)
 
 
 static int handle_rtp(struct rtp_receiver *rx, const struct rtp_header *hdr,
-		      struct mbuf *mb, unsigned lostc, bool drop)
+		      struct mbuf *mb, unsigned lostc)
 {
 	struct rtpext extv[8];
 	size_t extc = 0;
-	bool ignore = drop;
 
 	/* RFC 5285 -- A General Mechanism for RTP Header Extensions */
 	if (hdr->ext && hdr->x.len && mb) {
@@ -314,9 +313,7 @@ handler:
 
 	bool new_source = rtprecv_consume_ssrc_change(rx, NULL);
 
-	rx->rtph(hdr, extv, extc, mb, lostc, new_source, &ignore, rx->arg);
-	if (ignore)
-		return EAGAIN;
+	rx->rtph(hdr, extv, extc, mb, lostc, new_source, rx->arg);
 
 	return 0;
 }
@@ -370,16 +367,17 @@ static void decode_frames(struct rtp_receiver *rx)
 
 	do {
 		err = jbuf_get(rx->jbuf, &hdr, &mb);
-		if (err && err != EAGAIN)
+		if (err == EAGAIN)
+			++n;
+		else if (err)
 			break;
 
 		lostc = lostcalc(rx, hdr.seq);
 
-		err = handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0,
-				 err == EAGAIN);
+		err = handle_rtp(rx, &hdr, mb, lostc > 0 ? lostc : 0);
 		mem_deref(mb);
 
-		if (err && err != EAGAIN)
+		if (err)
 			break;
 	} while (n--);
 
@@ -492,7 +490,7 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 		}
 	}
 	else {
-		(void)handle_rtp(rx, hdr, mb, 0, false);
+		(void)handle_rtp(rx, hdr, mb, 0);
 	}
 }
 

--- a/src/video.c
+++ b/src/video.c
@@ -889,14 +889,12 @@ static void stream_recv_handler(const struct rtp_header *hdr,
 				struct rtpext *extv, size_t extc,
 				struct mbuf *mb, unsigned lostc,
 				bool new_source,
-				bool *ignore,
 				void *arg)
 {
 	struct video *v = arg;
 	(void)extv;
 	(void)extc;
 	(void)new_source;
-	(void)ignore;
 
 	MAGIC_CHECK(v);
 


### PR DESCRIPTION
Since the new jbuf is already aware of clock timing, there should no need for dropping a packet anymore. A jbuf_get EAGAIN should always be decoded.