### PR TITLE
rtprecv: avoid processing of telev events

### DIFF
--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -344,7 +344,7 @@ static void rtprecv_resync(struct rtp_receiver *rx,
 	rx->pseq = (uint16_t)(hdr->seq - 1);
 	rx->pseq_set = true;
 	rx->pt = -1;
-	rx->pt_tel = 0;
+	rx->pt_tel = -1;
 	rx->ssrc_changed = true;
 	mtx_unlock(rx->mtx);
 }
@@ -397,7 +397,7 @@ static bool rtprecv_filter_pt(struct rtp_receiver *rx,
 	bool handle;
 
 	handle = hdr->pt != rx->pt;
-	if (rx->pt_tel)
+	if (rx->pt_tel != -1)
 		handle |= hdr->pt == rx->pt_tel;
 
 	if (!handle)
@@ -772,6 +772,7 @@ int rtprecv_alloc(struct rtp_receiver **rxp,
 	rx->arg    = arg;
 	rx->pseq   = -1;
 	rx->pt     = -1;
+	rx->pt_tel = -1;
 
 	err  = str_dup(&rx->name, name);
 	err |= mutex_alloc(&rx->mtx);

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -478,6 +478,9 @@ void rtprecv_decode(const struct sa *src, const struct rtp_header *hdr,
 		err = pass_pt_work(rx, hdr->pt, mb);
 		if (err)
 			return;
+
+		if (hdr->pt == rx->pt_tel)
+			return;
 	}
 
 	if (rx->jbuf) {


### PR DESCRIPTION
In case of `rtp_rxmode thread` telev events had been forwarded to the
decoder pipeline. This commit adds an early exit for telev events
