### PR TITLE
test: call - increase timeout for mediaenc

### DIFF
--- a/test/call.c
+++ b/test/call.c
@@ -1480,7 +1480,7 @@ static int test_call_mediaenc_param(const char *name, bool rtcp_mux)
 	TEST_ERR(err);
 
 	/* run main-loop with timeout, wait for events */
-	err = re_main_timeout(5000);
+	err = re_main_timeout(10000);
 	TEST_ERR(err);
 	TEST_ERR(fix.err);
 


### PR DESCRIPTION
There was a timeout once in the valgrind test

```
[ RUN      ] test_call_mediaenc (rx thread)
selftest: re_main() loop timed out -- test hung..
TEST_ERR: /home/runner/work/baresip/baresip/test/call.c:1484: (Connection timed out [110])
TEST_ERR: /home/runner/work/baresip/baresip/test/call.c:1519: (Connection timed out [110])
test_call_mediaenc (rx thread): test failed (Connection timed out [110])
test failed (Connection timed out [110])
```

I am not sure. @alfredh @sreimers please decide if this makes sense!
