### PR TITLE
audio: increase RTP timestamp also for underruns

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -894,6 +894,9 @@ static int tx_thread(void *arg)
 		}
 		else {
 			++tx->stats.aubuf_underrun;
+			mtx_lock(tx->mtx);
+			tx->ts_ext += (tx->ptime * tx->ac->crate / 1000);
+			mtx_unlock(tx->mtx);
 
 			debug("audio: thread: tx aubuf underrun"
 			      " (total %llu)\n", tx->stats.aubuf_underrun);


### PR DESCRIPTION
If the audio source misses to deliver a frame in time the tx thread
looses one RTP packet slot and has to increase the time stamp. This
avoids a jump in the skew value.

Note: We observed jumps of the skew value in the TX stream of our devices, if pulseaudio missed to send a frame. One to three audio frames are absent if the pulseaudio stream is moved from one device to another. This is finally not so dramatic if the timestamps fit to the following packets. With this fix the skew keeps low and at the receiver it will be not more than a short crack.