### PR TITLE
call: avoid call progress if media is inactive

### DIFF
--- a/src/call.c
+++ b/src/call.c
@@ -1273,6 +1273,17 @@ int call_progress_dir(struct call *call, enum sdp_dir adir, enum sdp_dir vdir)
 	if (!call)
 		return EINVAL;
 
+	enum sdp_dir ardir = sdp_media_rdir(stream_sdpmedia(audio_strm(
+				call_audio(call))));
+	enum sdp_dir vrdir = sdp_media_rdir(stream_sdpmedia(video_strm(
+				call_video(call))));
+	if ((adir & ardir) == SDP_INACTIVE &&
+	    (vdir & vrdir) == SDP_INACTIVE) {
+		debug("call: progress: both audio and video would become "
+		      "inactive\n");
+		return EINVAL;
+	}
+
 	tmr_cancel(&call->tmr_inv);
 
 	if (adir != call->estadir || vdir != call->estvdir)


### PR DESCRIPTION
A 183 Session Progress with SDP answer audio=inactive and video=inactive
makes no sense. This can happen if call_set_media_direction() is used to
switch off video receive direction before call_progress() is called.

Note, that the call_event_handler() in ua.c calls call_progress() if the
account has early media enabled!
