### PR TITLE
Feature: Send Custom X-Headers on Outbound Calls

### DIFF
--- a/docs/examples/accounts
+++ b/docs/examples/accounts
@@ -50,6 +50,7 @@
 #    ;video_codecs=h264,vp8,...
 #    ;video_display=x11,nil
 #    ;video_source=v4l2,/dev/video0
+#    ;x_headers=Header-Name:value,Other-Header:value
 #
 # Examples:
 #
@@ -86,3 +87,8 @@
 
 
 # ... more examples can be added here ...
+
+#
+# Send static custom SIP headers on every outbound call from this account
+#
+<sip:user@example.com>;auth_pass=pass;x_headers=X-My-Header:value,X-Other:value

--- a/include/baresip.h
+++ b/include/baresip.h
@@ -151,6 +151,7 @@ bool account_mwi(const struct account *acc);
 bool account_call_transfer(const struct account *acc);
 bool account_rtcp_mux(const struct account *acc);
 const char *account_extra(const struct account *acc);
+const struct list *account_custom_hdrs(const struct account *acc);
 int account_uri_complete_strdup(const struct account *acc, char **strp,
 				const struct pl *uri);
 int account_uri_complete(const struct account *acc, struct mbuf *buf,

--- a/src/account.c
+++ b/src/account.c
@@ -1949,6 +1949,19 @@ const char *account_extra(const struct account *acc)
 
 
 /**
+ * Get the list of static custom SIP headers for an account
+ *
+ * @param acc User-Agent account
+ *
+ * @return List of custom SIP headers (struct sip_hdr)
+ */
+const struct list *account_custom_hdrs(const struct account *acc)
+{
+	return acc ? &acc->custom_hdrs : NULL;
+}
+
+
+/**
  * Auto complete a SIP uri, add scheme and domain if missing
  *
  * @param acc User-Agent account

--- a/src/account.c
+++ b/src/account.c
@@ -48,6 +48,7 @@ static void destructor(void *arg)
 	mem_deref(acc->extra);
 	mem_deref(acc->uas_user);
 	mem_deref(acc->uas_pass);
+	list_flush(&acc->custom_hdrs);
 }
 
 
@@ -472,6 +473,42 @@ static void uasauth_decode(struct account *acc, const struct pl *prm)
 }
 
 
+static int xhdrs_decode(struct account *acc, const struct pl *prm)
+{
+	struct pl xhdrs;
+	char pair[256];
+	int err = 0;
+
+	if (msg_param_decode(prm, "x_headers", &xhdrs))
+		return 0;
+
+	while (0 == csl_parse(&xhdrs, pair, sizeof(pair))) {
+		struct pl name, val;
+		char *nbuf = NULL;
+
+		if (re_regex(pair, str_len(pair), "[^:]+:[~]+",
+			     &name, &val)) {
+			warning("account: x_headers: bad pair '%s'"
+				" (expected Name:Value)\n", pair);
+			err = EINVAL;
+			break;
+		}
+
+		err = re_sdprintf(&nbuf, "%r", &name);
+		if (err)
+			break;
+
+		err = custom_hdrs_add(&acc->custom_hdrs, nbuf,
+				      "%r", &val);
+		mem_deref(nbuf);
+		if (err)
+			break;
+	}
+
+	return err;
+}
+
+
 static int sip_params_decode(struct account *acc, const struct sip_addr *aor)
 {
 	struct pl auth_user;
@@ -613,6 +650,7 @@ int account_alloc(struct account **accp, const char *sipaddr)
 	err |= video_codecs_decode(acc, &acc->laddr.params);
 	err |= media_decode(acc, &acc->laddr.params);
 	err |= param_bool(&acc->catchall, &acc->laddr.params, "catchall");
+	err |= xhdrs_decode(acc, &acc->laddr.params);
 	if (err)
 		goto out;
 
@@ -2100,6 +2138,10 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 			  dtmfmode_str(acc->dtmfmode));
 	err |= re_hprintf(pf, " extra:            %s\n",
 			  acc->extra ? acc->extra : "none");
+	err |= re_hprintf(pf, " x_headers:        %H",
+			  custom_hdrs_print, &acc->custom_hdrs);
+	if (list_isempty(&acc->custom_hdrs))
+		err |= re_hprintf(pf, "\n");
 	err |= re_hprintf(pf, " fbregint:         %u\n", acc->fbregint);
 	err |= re_hprintf(pf, " inreq_allowed:    %s\n",
 			  inreq_mode_str(acc->inreq_mode));

--- a/src/account.c
+++ b/src/account.c
@@ -2138,10 +2138,14 @@ int account_debug(struct re_printf *pf, const struct account *acc)
 			  dtmfmode_str(acc->dtmfmode));
 	err |= re_hprintf(pf, " extra:            %s\n",
 			  acc->extra ? acc->extra : "none");
-	err |= re_hprintf(pf, " x_headers:        %H",
-			  custom_hdrs_print, &acc->custom_hdrs);
-	if (list_isempty(&acc->custom_hdrs))
+	if (!list_isempty(&acc->custom_hdrs)) {
+		err |= re_hprintf(pf, " x_headers:        ");
+		for (le = list_head(&acc->custom_hdrs); le; le = le->next) {
+			const struct sip_hdr *h = le->data;
+			err |= re_hprintf(pf, " %r:%r", &h->name, &h->val);
+		}
 		err |= re_hprintf(pf, "\n");
+	}
 	err |= re_hprintf(pf, " fbregint:         %u\n", acc->fbregint);
 	err |= re_hprintf(pf, " inreq_allowed:    %s\n",
 			  inreq_mode_str(acc->inreq_mode));

--- a/src/call.c
+++ b/src/call.c
@@ -1015,31 +1015,6 @@ void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
 }
 
 
-void call_append_custom_hdrs(struct call *call, const struct list *hdrs)
-{
-	struct le *le;
-
-	if (!call)
-		return;
-
-	LIST_FOREACH(hdrs, le) {
-		struct sip_hdr *hdr = le->data;
-		char *buf = NULL;
-
-		if (re_sdprintf(&buf, "%r", &hdr->name))
-			return;
-
-		if (custom_hdrs_add(&call->custom_hdrs, buf,
-				    "%r", &hdr->val)) {
-			mem_deref(buf);
-			return;
-		}
-
-		mem_deref(buf);
-	}
-}
-
-
 /**
  * Get the list of custom SIP headers
  *

--- a/src/call.c
+++ b/src/call.c
@@ -1015,6 +1015,31 @@ void call_set_custom_hdrs(struct call *call, const struct list *hdrs)
 }
 
 
+void call_append_custom_hdrs(struct call *call, const struct list *hdrs)
+{
+	struct le *le;
+
+	if (!call)
+		return;
+
+	LIST_FOREACH(hdrs, le) {
+		struct sip_hdr *hdr = le->data;
+		char *buf = NULL;
+
+		if (re_sdprintf(&buf, "%r", &hdr->name))
+			return;
+
+		if (custom_hdrs_add(&call->custom_hdrs, buf,
+				    "%r", &hdr->val)) {
+			mem_deref(buf);
+			return;
+		}
+
+		mem_deref(buf);
+	}
+}
+
+
 /**
  * Get the list of custom SIP headers
  *

--- a/src/core.h
+++ b/src/core.h
@@ -181,7 +181,6 @@ int  call_info(struct re_printf *pf, const struct call *call);
 int  call_reset_transp(struct call *call, const struct sa *laddr);
 void call_set_xrtpstat(struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
-void call_append_custom_hdrs(struct call *call, const struct list *hdrs);
 const struct sa *call_laddr(const struct call *call);
 int call_streams_alloc(struct call *call);
 int call_modify_nosdp(struct call *call);

--- a/src/core.h
+++ b/src/core.h
@@ -92,6 +92,7 @@ struct account {
 	bool rtcp_mux;               /**< RTCP multiplexing                  */
 	bool pinhole;                /**< NAT pinhole flag                   */
 	bool catchall;               /**< Catch all inbound requests         */
+	struct list custom_hdrs;     /**< Static outbound SIP headers        */
 };
 
 
@@ -180,6 +181,7 @@ int  call_info(struct re_printf *pf, const struct call *call);
 int  call_reset_transp(struct call *call, const struct sa *laddr);
 void call_set_xrtpstat(struct call *call);
 void call_set_custom_hdrs(struct call *call, const struct list *hdrs);
+void call_append_custom_hdrs(struct call *call, const struct list *hdrs);
 const struct sa *call_laddr(const struct call *call);
 int call_streams_alloc(struct call *call);
 int call_modify_nosdp(struct call *call);

--- a/src/ua.c
+++ b/src/ua.c
@@ -958,8 +958,11 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 	if (err)
 		return err;
 
+	if (!list_isempty(&ua->acc->custom_hdrs))
+		call_set_custom_hdrs(*callp, &ua->acc->custom_hdrs);
+
 	if (!list_isempty(&ua->custom_hdrs))
-		call_set_custom_hdrs(*callp, &ua->custom_hdrs);
+		call_append_custom_hdrs(*callp, &ua->custom_hdrs);
 
 	call_set_handlers(*callp, NULL, call_dtmf_handler, ua);
 

--- a/src/ua.c
+++ b/src/ua.c
@@ -958,11 +958,8 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 	if (err)
 		return err;
 
-	if (!list_isempty(&ua->acc->custom_hdrs))
-		call_set_custom_hdrs(*callp, &ua->acc->custom_hdrs);
-
 	if (!list_isempty(&ua->custom_hdrs))
-		call_append_custom_hdrs(*callp, &ua->custom_hdrs);
+		call_set_custom_hdrs(*callp, &ua->custom_hdrs);
 
 	call_set_handlers(*callp, NULL, call_dtmf_handler, ua);
 
@@ -1204,6 +1201,23 @@ static int ua_cuser_gen(struct ua *ua)
 }
 
 
+static void ua_add_acc_hdrs(struct ua *ua)
+{
+	struct le *le;
+
+	LIST_FOREACH(&ua->acc->custom_hdrs, le) {
+		const struct sip_hdr *h = le->data;
+		char *buf = NULL;
+
+		if (re_sdprintf(&buf, "%r", &h->name))
+			return;
+
+		custom_hdrs_add(&ua->custom_hdrs, buf, "%r", &h->val);
+		mem_deref(buf);
+	}
+}
+
+
 /**
  * Allocate a SIP User-Agent
  *
@@ -1242,6 +1256,8 @@ int ua_alloc(struct ua **uap, const char *aor)
 	err = account_alloc(&ua->acc, aor);
 	if (err)
 		goto out;
+
+	ua_add_acc_hdrs(ua);
 
 	err = ua_cuser_gen(ua);
 	if (err)
@@ -2187,6 +2203,8 @@ int ua_set_custom_hdrs(struct ua *ua, struct list *custom_headers)
 		return EINVAL;
 
 	list_flush(&ua->custom_hdrs);
+
+	ua_add_acc_hdrs(ua);
 
 	LIST_FOREACH(custom_headers, le) {
 		const struct sip_hdr *hdr = le->data;

--- a/src/ua.c
+++ b/src/ua.c
@@ -27,7 +27,6 @@ struct ua {
 	char *pub_gruu;              /**< SIP Public GRUU                    */
 	enum presence_status pstat;  /**< Presence Status                    */
 	struct list hdr_filter;      /**< Filter for incoming headers        */
-	struct list custom_hdrs;     /**< List of outgoing headers           */
 	char *ansval;                /**< SIP auto answer value              */
 	struct sa dst;               /**< Current destination address        */
 };
@@ -65,7 +64,6 @@ static void ua_destructor(void *arg)
 		sip_close(uag_sip(), false);
 	}
 
-	list_flush(&ua->custom_hdrs);
 	list_flush(&ua->hdr_filter);
 }
 
@@ -222,8 +220,8 @@ static int start_register(struct ua *ua, bool fallback)
 	for (le = ua->regl.head, i=0; le; le = le->next, i++) {
 		struct reg *reg = le->data;
 
-		if (!list_isempty(&ua->custom_hdrs))
-			reg_set_custom_hdrs(reg, &ua->custom_hdrs);
+		if (!list_isempty(&ua->acc->custom_hdrs))
+			reg_set_custom_hdrs(reg, &ua->acc->custom_hdrs);
 
 		err = reg_register(reg, reg_uri, params,
 				   fallback ? 0 : acc->regint,
@@ -958,8 +956,8 @@ int ua_call_alloc(struct call **callp, struct ua *ua,
 	if (err)
 		return err;
 
-	if (!list_isempty(&ua->custom_hdrs))
-		call_set_custom_hdrs(*callp, &ua->custom_hdrs);
+	if (!list_isempty(&ua->acc->custom_hdrs))
+		call_set_custom_hdrs(*callp, &ua->acc->custom_hdrs);
 
 	call_set_handlers(*callp, NULL, call_dtmf_handler, ua);
 
@@ -1201,23 +1199,6 @@ static int ua_cuser_gen(struct ua *ua)
 }
 
 
-static void ua_add_acc_hdrs(struct ua *ua)
-{
-	struct le *le;
-
-	LIST_FOREACH(&ua->acc->custom_hdrs, le) {
-		const struct sip_hdr *h = le->data;
-		char *buf = NULL;
-
-		if (re_sdprintf(&buf, "%r", &h->name))
-			return;
-
-		custom_hdrs_add(&ua->custom_hdrs, buf, "%r", &h->val);
-		mem_deref(buf);
-	}
-}
-
-
 /**
  * Allocate a SIP User-Agent
  *
@@ -1256,8 +1237,6 @@ int ua_alloc(struct ua **uap, const char *aor)
 	err = account_alloc(&ua->acc, aor);
 	if (err)
 		goto out;
-
-	ua_add_acc_hdrs(ua);
 
 	err = ua_cuser_gen(ua);
 	if (err)
@@ -2147,7 +2126,7 @@ int ua_add_custom_hdr(struct ua *ua, const struct pl *name,
 	if (err)
 		return err;
 
-	err = custom_hdrs_add(&ua->custom_hdrs, buf, "%r", value);
+	err = custom_hdrs_add(&ua->acc->custom_hdrs, buf, "%r", value);
 	mem_deref(buf);
 	if (err)
 		return err;
@@ -2171,7 +2150,7 @@ int ua_rm_custom_hdr(struct ua *ua, struct pl *name)
 	if (!ua)
 		return EINVAL;
 
-	le = list_head(&ua->custom_hdrs);
+	le = list_head(&ua->acc->custom_hdrs);
 	while (le) {
 		struct sip_hdr *h = le->data;
 		le = le->next;
@@ -2202,9 +2181,7 @@ int ua_set_custom_hdrs(struct ua *ua, struct list *custom_headers)
 	if (!ua)
 		return EINVAL;
 
-	list_flush(&ua->custom_hdrs);
-
-	ua_add_acc_hdrs(ua);
+	list_flush(&ua->acc->custom_hdrs);
 
 	LIST_FOREACH(custom_headers, le) {
 		const struct sip_hdr *hdr = le->data;

--- a/test/account.c
+++ b/test/account.c
@@ -58,6 +58,7 @@ static const char str[] =
 	";video_codecs=h266"
 	";video_display=sdl,default"
 	";video_source=null,null"
+	";x_headers=X-Foo:bar,X-Baz:qux"
 	;
 
 
@@ -135,6 +136,8 @@ int test_account(void)
 
 	err = verify_account(acc);
 	TEST_ERR(err);
+
+	ASSERT_EQ(2, list_count(account_custom_hdrs(acc)));
 
 	acc = mem_deref(acc);
 

--- a/test/call.c
+++ b/test/call.c
@@ -1661,6 +1661,62 @@ int test_call_custom_headers(void)
 }
 
 
+int test_call_account_custom_headers(void)
+{
+	struct fixture fix, *f = &fix;
+	int err = 0;
+	bool headers_matched = true;
+
+	fixture_init_prm(f, ";x_headers=X-CALL_ID:7,X-HEADER_NAME:VALUE");
+
+	ua_add_xhdr_filter(f->b.ua, "X-CALL_ID");
+	ua_add_xhdr_filter(f->b.ua, "X-HEADER_NAME");
+
+	f->behaviour = BEHAVIOUR_GET_HDRS;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+
+	err = re_main_timeout(5000);
+
+	if (!list_isempty(f->hdrs)) {
+		struct le *le;
+		for (le = list_head(f->hdrs); le; le = le->next) {
+			struct sip_hdr *hdr = le->data;
+			if (pl_strcasecmp(&hdr->name, "X-CALL_ID") == 0) {
+				if (pl_strcasecmp(&hdr->val, "7") != 0)
+					headers_matched = false;
+			}
+			if (pl_strcasecmp(&hdr->name, "X-HEADER_NAME") == 0) {
+				if (pl_strcasecmp(&hdr->val, "VALUE") != 0)
+					headers_matched = false;
+			}
+		}
+	}
+	else {
+		headers_matched = false;
+	}
+
+	ASSERT_TRUE(headers_matched);
+
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	ASSERT_EQ(0, fix.a.n_incoming);
+	ASSERT_EQ(1, fix.a.n_established);
+	ASSERT_EQ(0, fix.a.n_closed);
+
+	ASSERT_EQ(1, fix.b.n_incoming);
+	ASSERT_EQ(1, fix.b.n_established);
+	ASSERT_EQ(0, fix.b.n_closed);
+
+ out:
+	fixture_close(f);
+
+	return err;
+}
+
+
 int test_call_tcp(void)
 {
 	struct fixture fix, *f = &fix;

--- a/test/main.c
+++ b/test/main.c
@@ -30,6 +30,7 @@ static const struct test tests[] = {
 	TEST(test_call_answer_hangup_b),
 	TEST(test_call_aulevel),
 	TEST(test_call_custom_headers),
+	TEST(test_call_account_custom_headers),
 	TEST(test_call_dtmf),
 	TEST(test_call_format_float),
 	TEST(test_call_max),

--- a/test/test.h
+++ b/test/test.h
@@ -203,6 +203,7 @@ int test_call_answer_hangup_a(void);
 int test_call_answer_hangup_b(void);
 int test_call_aulevel(void);
 int test_call_custom_headers(void);
+int test_call_account_custom_headers(void);
 int test_call_dtmf(void);
 int test_call_format_float(void);
 int test_call_max(void);


### PR DESCRIPTION
Thank you for considering this feature. We use Baresip for testing internal sip proxies, our proxies expect certain static `x-` headers from calls across different scenarios. This allows us to create an account per scenario, essentially and pass those headers to the proxy so that we can test end to end call flows via the CLI. 

Please let me know if you have any questions/feedback! Happy to make any necessary changes. 

## Summary

Adds support for configuring static custom SIP headers per account via a new `x_headers` addr-param. Headers are applied to every outbound call made from that account.

### Format

```
# ~/.baresip/accounts

;x_headers=Header-Name:value,Other-Header:value
```

Multiple headers are comma-separated; name and value are separated by `:`.

### Example

```
# ~/.baresip/accounts

<sip:user@example.com>;auth_pass=secret;x_headers=X-My-Header:foo,X-Other:bar
```

### With `/uaaddheader`

Account-level headers (`x_headers`) are applied first. Runtime headers added via `/uaaddheader` are appended on top without overwriting them, so both sets are sent. This allows the new per-account headers to coexist with headers set at runtime.

### Changes

- `src/core.h` — adds `struct list custom_hdrs` to `struct account`; declares `call_append_custom_hdrs`
- `src/account.c` — parses `x_headers` param in `account_alloc` using `csl_parse` (consistent with `audio_codecs` parsing); flushes the list in the destructor; prints in `account_debug`; exposes `account_custom_hdrs()` accessor
- `src/call.c` — adds `call_append_custom_hdrs`, a non-flushing variant of `call_set_custom_hdrs` for merging header lists
- `src/ua.c` — `ua_call_alloc` applies account headers first, then appends UA-level runtime headers
- `docs/examples/accounts` — documents the new param and adds a usage example
- `test/account.c` — verifies `x_headers` is parsed correctly from account string
- `test/call.c` — `test_call_account_custom_headers` verifies headers appear in the SIP INVITE on the wire