### PR TITLE
feat: audio codec ptime cap

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1282,7 +1282,7 @@ struct aucodec {
 	uint32_t crate;             /* RTP Clock rate   */
 	uint8_t ch;
 	uint8_t pch;                /* RTP packet channels */
-	uint32_t ptime;             /* Packet time in [ms] (optional) */
+	uint32_t ptime;             /* Max packet time in [ms], 0 = no cap */
 	const char *fmtp;
 	auenc_update_h *encupdh;
 	auenc_encode_h *ench;

--- a/src/audio.c
+++ b/src/audio.c
@@ -91,6 +91,7 @@ struct autx {
 	char *device;                 /**< Audio source device name        */
 	void *sampv;                  /**< Sample buffer                   */
 	uint32_t ptime;               /**< Packet time for sending         */
+	uint32_t ptime_req;           /**< Requested packet time           */
 	uint64_t ts_ext;              /**< Ext. Timestamp for outgoing RTP */
 	uint32_t ts_base;             /**< First timestamp sent            */
 	uint32_t ts_tel;              /**< Timestamp for Telephony Events  */
@@ -796,7 +797,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 			goto out;
 	}
 
-	tx->ptime  = ptime;
+	tx->ptime = tx->ptime_req = ptime;
 	tx->ts_ext = tx->ts_base = rand_u16();
 	tx->marker = true;
 
@@ -858,7 +859,9 @@ static int tx_thread(void *arg)
 
 	mtx_lock(tx->mtx);
 	while (re_atomic_rlx(&tx->thr.run)) {
+		uint32_t ptime;
 		uint64_t now;
+		size_t psize;
 
 		mtx_unlock(tx->mtx);
 		sys_msleep(4);
@@ -872,6 +875,9 @@ static int tx_thread(void *arg)
 		if (!re_atomic_rlx(&tx->thr.run))
 			break;
 
+		psize = tx->psize;
+		ptime = tx->ptime;
+
 		mtx_unlock(tx->mtx);
 
 		now = tmr_jiffies();
@@ -883,7 +889,7 @@ static int tx_thread(void *arg)
 
 		/* Now is the time to send */
 
-		if (aubuf_cur_size(tx->aubuf) >= tx->psize) {
+		if (aubuf_cur_size(tx->aubuf) >= psize) {
 
 			poll_aubuf_tx(a);
 		}
@@ -897,7 +903,7 @@ static int tx_thread(void *arg)
 			      " (total %llu)\n", tx->stats.aubuf_underrun);
 		}
 
-		ts += tx->ptime;
+		ts += ptime;
 
 		/* Exact timing: send Telephony-Events from here.
 		 * Be aware check_telev sets tx->mtx, so it must released!
@@ -1362,13 +1368,18 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 
 	mtx_lock(a->tx.mtx);
 	stream_update_encoder(a->strm, pt_tx);
+
+	/* a codec ptime is an upper bound on the requested one */
+	tx->ptime = ac->ptime ? min(tx->ptime_req, ac->ptime) : tx->ptime_req;
+	if (tx->ausrc) {
+		tx->psize = aufmt_sample_size(tx->src_fmt) *
+			au_calc_nsamp(tx->ausrc_prm.srate,
+				      tx->ausrc_prm.ch, tx->ptime);
+		tx->ausrc_prm.ptime = tx->ptime;
+	}
 	mtx_unlock(a->tx.mtx);
 
 	telev_set_srate(a->telev, ac->crate);
-
-	/* use a codec-specific ptime */
-	if (ac->ptime)
-		tx->ptime = ac->ptime;
 
 	return err;
 }
@@ -1562,27 +1573,22 @@ void audio_sdp_attr_decode(struct audio *a)
 	if (attr) {
 		struct autx *tx = &a->tx;
 		uint32_t ptime_tx = atoi(attr);
+		int err;
 
-		if (ptime_tx && ptime_tx != a->tx.ptime
+		if (ptime_tx && ptime_tx != a->tx.ptime_req
 		    && ptime_tx <= MAX_PTIME) {
 
 			info("audio: peer changed ptime_tx %ums -> %ums\n",
-			     a->tx.ptime, ptime_tx);
+			     a->tx.ptime_req, ptime_tx);
 
-			tx->ptime = ptime_tx;
+			tx->ptime_req = ptime_tx;
 
-			if (tx->ac) {
-				size_t sz;
-
-				sz = aufmt_sample_size(tx->src_fmt);
-
-				tx->psize = sz * au_calc_nsamp(tx->ac->srate,
-							    tx->ac->ch,
-							    ptime_tx);
-			}
-
-			sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					    "ptime", "%u", ptime_tx);
+			err = sdp_media_set_lattr(stream_sdpmedia(a->strm),
+						  true, "ptime", "%u",
+						  ptime_tx);
+			if (err)
+				warning("audio: mirror peer ptime (%m)\n",
+					err);
 		}
 	}
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1061,13 +1061,15 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			.fmt        = tx->src_fmt
 		};
 
-		tx->ausrc_prm = prm;
-
 		sz = aufmt_sample_size(tx->src_fmt);
 
 		psize_alloc = sz * au_calc_nsamp(prm.srate, prm.ch, prm.ptime);
+
+		mtx_lock(tx->mtx);
+		tx->ausrc_prm = prm;
 		tx->psize = psize_alloc;
 		tx->aubuf_maxsz = tx->psize * 30;
+		mtx_unlock(tx->mtx);
 
 		if (!tx->aubuf) {
 			err = aubuf_alloc(&tx->aubuf, tx->psize,
@@ -1309,6 +1311,7 @@ bool audio_started(const struct audio *a)
 int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 		      int pt_tx, const char *params)
 {
+	struct auenc_state *enc;
 	struct autx *tx;
 	int err = 0;
 
@@ -1328,8 +1331,13 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 			aubuf_flush(tx->aubuf);
 		}
 
-		tx->enc = mem_deref(tx->enc);
+		/* deref outside: a codec destructor may take tx->mtx */
+		mtx_lock(tx->mtx);
+		enc = tx->enc;
+		tx->enc = NULL;
 		tx->ac = ac;
+		mtx_unlock(tx->mtx);
+		mem_deref(enc);
 
 		if (!list_isempty(baresip_aufiltl())) {
 			err = aufilt_setup(a, baresip_aufiltl());

--- a/test/call.c
+++ b/test/call.c
@@ -1186,6 +1186,231 @@ int test_call_aulevel(void)
 }
 
 
+static void rx_metric_snapshot(const struct stream *strm,
+			       uint32_t *packets, uint32_t *bytes)
+{
+	do {
+		*packets = stream_metric_get_rx_n_packets(strm);
+		*bytes = stream_metric_get_rx_n_bytes(strm);
+	}
+	while (*packets != stream_metric_get_rx_n_packets(strm));
+}
+
+
+static int wait_for_audio_frames(struct fixture *f, unsigned n)
+{
+	struct cancel_rule *cr;
+	int err = 0;
+
+	cancel_rule_new(BEVENT_CUSTOM, f->a.ua, 0, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = f->a.n_auframe + n;
+	cancel_rule_and(BEVENT_CUSTOM, f->b.ua, 1, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = f->b.n_auframe + n;
+
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	if (!err)
+		err = f->err;
+	TEST_ERR(err);
+
+ out:
+	return err;
+}
+
+
+static int reinvite_from_b_expect_payload(struct fixture *f, uint32_t psize)
+{
+	struct agent *agents[] = {&f->a, &f->b};
+	struct stream *strmv[RE_ARRAY_SIZE(agents)];
+	struct cancel_rule *cr;
+	uint32_t packetv[2], bytesv[2];
+	size_t i;
+	int err = 0;
+
+	cancel_rule_new(BEVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 1);
+	cr->prm = "offer";
+	cancel_rule_and(BEVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
+	cr->prm = "answer";
+
+	err = call_modify(ua_call(f->b.ua));
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	TEST_ERR(err);
+	TEST_ERR(f->err);
+
+	err = agent_wait_for_ack(&f->a, 0, 0, 1);
+	TEST_ERR(err);
+
+	/* drain packets that were already in flight during renegotiation */
+	err = wait_for_audio_frames(f, 10);
+	TEST_ERR(err);
+	for (i=0; i<RE_ARRAY_SIZE(agents); i++) {
+		strmv[i] = audio_strm(call_audio(ua_call(agents[i]->ua)));
+		rx_metric_snapshot(strmv[i], &packetv[i], &bytesv[i]);
+	}
+
+	err = wait_for_audio_frames(f, 10);
+	TEST_ERR(err);
+
+	for (i=0; i<RE_ARRAY_SIZE(agents); i++) {
+		uint32_t bytes, packets;
+
+		rx_metric_snapshot(strmv[i], &packets, &bytes);
+		ASSERT_TRUE(packets > packetv[i]);
+		ASSERT_EQ((packets - packetv[i]) * psize, bytes - bytesv[i]);
+	}
+
+ out:
+	return err;
+}
+
+
+static int test_call_ptime_cap_base(uint32_t aptime, uint32_t wire_ptime)
+{
+	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
+	struct stream *strm;
+	const char *attr;
+	uint32_t bytes, n;
+	size_t psize;
+	char prm[64];
+	int err;
+
+	re_snprintf(prm, sizeof(prm),
+		    ";ptime=%u;audio_codecs=aucmock/48000/2", aptime);
+	fixture_init_prm(f, prm);
+
+	psize = 4 * (48000 * wire_ptime / 1000);
+
+	cancel_rule_new(BEVENT_CALL_RTPESTAB, f->b.ua, 1, 0, 1);
+	cancel_rule_and(BEVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	f->estab_action = ACTION_NOTHING;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	strm = audio_strm(call_audio(ua_call(f->a.ua)));
+
+	/* the answer mirrors the raw request, not the effective cap */
+	attr = sdp_media_rattr(stream_sdpmedia(strm), "ptime");
+	ASSERT_TRUE(attr != NULL);
+	ASSERT_EQ(aptime, (uint32_t)atoi(attr));
+
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * psize, bytes);
+
+	strm = audio_strm(call_audio(ua_call(f->b.ua)));
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * psize, bytes);
+
+ out:
+	fixture_close(f);
+	return err;
+}
+
+
+static int test_call_ptime_cap_reinvite(void)
+{
+	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
+	struct auplay *auplay = NULL;
+	struct sdp_format *pcmu;
+	struct sdp_media *m;
+	int err = 0;
+
+	fixture_init_prm(f, ";audio_codecs=aucmock/48000/2,PCMU/8000/1"
+			 ";audio_player=mock-auplay,a");
+	f->b.ua = mem_deref(f->b.ua);
+	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>;regint=0"
+		       ";audio_codecs=aucmock/48000/2,PCMU/8000/1"
+		       ";audio_player=mock-auplay,b");
+	TEST_ERR(err);
+
+	err = mock_auplay_register(&auplay, baresip_auplayl(),
+				   auframe_handler, f);
+	TEST_ERR(err);
+
+	cancel_rule_new(BEVENT_CALL_RTPESTAB, f->b.ua, 1, 0, 1);
+	cancel_rule_and(BEVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	f->estab_action = ACTION_NOTHING;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
+
+	/* a smaller peer request must resize active packetization */
+	err = sdp_media_set_lattr(m, true, "ptime", "%u", 5);
+	TEST_ERR(err);
+	err = reinvite_from_b_expect_payload(f, 960);
+	TEST_ERR(err);
+
+	/* restoring the raw request leaves the codec cap in force */
+	err = sdp_media_set_lattr(m, true, "ptime", "%u", 20);
+	TEST_ERR(err);
+	err = reinvite_from_b_expect_payload(f, 1920);
+	TEST_ERR(err);
+
+	/* switching codecs alone must release the previous cap */
+	pcmu = sdp_media_format(m, true, NULL, -1, "PCMU", 8000, 1);
+	ASSERT_TRUE(pcmu != NULL);
+	list_unlink(&pcmu->le);
+	list_prepend((struct list *)sdp_media_format_lst(m, true),
+		     &pcmu->le, pcmu);
+
+	err = reinvite_from_b_expect_payload(f, 160);
+	TEST_ERR(err);
+
+	ASSERT_STREQ("PCMU",
+		     audio_codec(call_audio(ua_call(f->a.ua)), true)->name);
+
+ out:
+	fixture_close(f);
+	mem_deref(auplay);
+	return err;
+}
+
+
+int test_call_ptime_cap(void)
+{
+	int err;
+
+	mock_aucodec_register();
+
+	err = module_load(".", "ausine");
+	TEST_ERR(err);
+
+	err = test_call_ptime_cap_base(60, 10);
+	TEST_ERR(err);
+	err = test_call_ptime_cap_base(5, 5);
+	TEST_ERR(err);
+
+	err = test_call_ptime_cap_reinvite();
+	TEST_ERR(err);
+
+ out:
+	module_unload("ausine");
+	mock_aucodec_unregister();
+	return err;
+}
+
+
 static int test_100rel_audio_base(void)
 {
 	struct fixture fix, *f = &fix;

--- a/test/main.c
+++ b/test/main.c
@@ -29,6 +29,7 @@ static const struct test tests[] = {
 	TEST(test_call_answer_hangup_a),
 	TEST(test_call_answer_hangup_b),
 	TEST(test_call_aulevel),
+	TEST(test_call_ptime_cap),
 	TEST(test_call_custom_headers),
 	TEST(test_call_dtmf),
 	TEST(test_call_format_float),

--- a/test/mock/mock_aucodec.c
+++ b/test/mock/mock_aucodec.c
@@ -76,6 +76,7 @@ static struct aucodec aucmock = {
 	.crate = 48000,
 	.ch    = 2,
 	.pch   = 2,
+	.ptime = 10,		/* cap exercised by test_call_ptime_cap */
 	.ench  = encode,
 	.dech  = decode,
 };

--- a/test/test.h
+++ b/test/test.h
@@ -202,6 +202,7 @@ int test_call_answer(void);
 int test_call_answer_hangup_a(void);
 int test_call_answer_hangup_b(void);
 int test_call_aulevel(void);
+int test_call_ptime_cap(void);
 int test_call_custom_headers(void);
 int test_call_dtmf(void);
 int test_call_format_float(void);


### PR DESCRIPTION
Previously, if a codec specified a ptime in its struct aucodec definition, baresip treated it as a rigid, fixed value that unconditionally overrode account configurations (account.ptime) and SDP negotiation.                                                                         
                                                                                                                                               
This PR changes the packetization model so that a codec's ptime is treated as an upper-bound cap rather than a mandatory fixed value:        
                                                                                                                                               
  1. Configured account packet times and peer SDP requests (ptime_req) are preserved and negotiated normally.                                  
  2. The effective transmit packet time is derived upon encoder selection as min(ptime_req, ac->ptime) (or ptime_req if the codec has no cap). 
  3. L16 codec table entries now derive their caps dynamically from a Ethernet MTU payload budget (L16_PTIME(srate, ch)), preventing packet fragmentation while allowing flexible packetization for lower rates.