### PR TITLE
Feat/l16 ptime budget

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1282,7 +1282,7 @@ struct aucodec {
 	uint32_t crate;             /* RTP Clock rate   */
 	uint8_t ch;
 	uint8_t pch;                /* RTP packet channels */
-	uint32_t ptime;             /* Packet time in [ms] (optional) */
+	uint32_t ptime;             /* Max packet time in [ms], 0 = no cap */
 	const char *fmtp;
 	auenc_update_h *encupdh;
 	auenc_encode_h *ench;

--- a/modules/l16/l16.c
+++ b/modules/l16/l16.c
@@ -69,18 +69,22 @@ static int decode(struct audec_state *st, int fmt, void *sampv, size_t *sampc,
 }
 
 
+/* ptime cap: keep the payload within 1400 bytes (1500 MTU - hdrs) */
+#define L16_FMT(srate, ch) srate, srate, ch, ch, 1400*1000/((srate)*(ch)*2)
+
+
 /* See RFC 3551 */
 static struct aucodec l16v[] = {
-{LE_INIT,    0, "L16", 48000, 48000, 2, 2,  4, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT, "10", "L16", 44100, 44100, 2, 2,  4, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16", 32000, 32000, 2, 2, 10, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16", 16000, 16000, 2, 2, 20, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16",  8000,  8000, 2, 2, 20, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16", 48000, 48000, 1, 1, 10, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT, "11", "L16", 44100, 44100, 1, 1, 10, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16", 32000, 32000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16", 16000, 16000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
-{LE_INIT,    0, "L16",  8000,  8000, 1, 1, 20, 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(48000, 2), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT, "10", "L16", L16_FMT(44100, 2), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(32000, 2), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(16000, 2), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT( 8000, 2), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(48000, 1), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT, "11", "L16", L16_FMT(44100, 1), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(32000, 1), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT(16000, 1), 0, 0, encode, 0, decode, 0,0,0},
+{LE_INIT,    0, "L16", L16_FMT( 8000, 1), 0, 0, encode, 0, decode, 0,0,0},
 };
 
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -91,6 +91,7 @@ struct autx {
 	char *device;                 /**< Audio source device name        */
 	void *sampv;                  /**< Sample buffer                   */
 	uint32_t ptime;               /**< Packet time for sending         */
+	uint32_t ptime_req;           /**< Requested packet time           */
 	uint64_t ts_ext;              /**< Ext. Timestamp for outgoing RTP */
 	uint32_t ts_base;             /**< First timestamp sent            */
 	uint32_t ts_tel;              /**< Timestamp for Telephony Events  */
@@ -798,7 +799,7 @@ int audio_alloc(struct audio **ap, struct list *streaml,
 			goto out;
 	}
 
-	tx->ptime  = ptime;
+	tx->ptime = tx->ptime_req = ptime;
 	tx->ts_ext = tx->ts_base = rand_u16();
 	tx->marker = true;
 
@@ -1364,9 +1365,8 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 	mtx_lock(a->tx.mtx);
 	stream_update_encoder(a->strm, pt_tx);
 
-	/* use a codec-specific ptime */
-	if (ac->ptime)
-		tx->ptime = ac->ptime;
+	/* a codec ptime is an upper bound on the requested one */
+	tx->ptime = ac->ptime ? min(tx->ptime_req, ac->ptime) : tx->ptime_req;
 
 	/* re-packetize a running source for the current ptime */
 	if (tx->ausrc) {
@@ -1572,16 +1572,14 @@ void audio_sdp_attr_decode(struct audio *a)
 		struct autx *tx = &a->tx;
 		uint32_t ptime_tx = atoi(attr);
 
-		if (ptime_tx && ptime_tx != a->tx.ptime
+		if (ptime_tx && ptime_tx != a->tx.ptime_req
 		    && ptime_tx <= MAX_PTIME) {
 			int err;
 
 			info("audio: peer changed ptime_tx %ums -> %ums\n",
-			     a->tx.ptime, ptime_tx);
+			     a->tx.ptime_req, ptime_tx);
 
-			mtx_lock(tx->mtx);
-			tx->ptime = ptime_tx;
-			mtx_unlock(tx->mtx);
+			tx->ptime_req = ptime_tx;
 
 			err = sdp_media_set_lattr(stream_sdpmedia(a->strm),
 						  true, "ptime", "%u",

--- a/src/audio.c
+++ b/src/audio.c
@@ -1363,13 +1363,21 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 
 	mtx_lock(a->tx.mtx);
 	stream_update_encoder(a->strm, pt_tx);
-	mtx_unlock(a->tx.mtx);
-
-	telev_set_srate(a->telev, ac->crate);
 
 	/* use a codec-specific ptime */
 	if (ac->ptime)
 		tx->ptime = ac->ptime;
+
+	/* re-packetize a running source for the current ptime */
+	if (tx->ausrc) {
+		tx->psize = aufmt_sample_size(tx->src_fmt) *
+			au_calc_nsamp(tx->ausrc_prm.srate,
+				      tx->ausrc_prm.ch, tx->ptime);
+		tx->ausrc_prm.ptime = tx->ptime;
+	}
+	mtx_unlock(a->tx.mtx);
+
+	telev_set_srate(a->telev, ac->crate);
 
 	return err;
 }
@@ -1566,24 +1574,21 @@ void audio_sdp_attr_decode(struct audio *a)
 
 		if (ptime_tx && ptime_tx != a->tx.ptime
 		    && ptime_tx <= MAX_PTIME) {
+			int err;
 
 			info("audio: peer changed ptime_tx %ums -> %ums\n",
 			     a->tx.ptime, ptime_tx);
 
+			mtx_lock(tx->mtx);
 			tx->ptime = ptime_tx;
+			mtx_unlock(tx->mtx);
 
-			if (tx->ac) {
-				size_t sz;
-
-				sz = aufmt_sample_size(tx->src_fmt);
-
-				tx->psize = sz * au_calc_nsamp(tx->ac->srate,
-							    tx->ac->ch,
-							    ptime_tx);
-			}
-
-			sdp_media_set_lattr(stream_sdpmedia(a->strm), true,
-					    "ptime", "%u", ptime_tx);
+			err = sdp_media_set_lattr(stream_sdpmedia(a->strm),
+						  true, "ptime", "%u",
+						  ptime_tx);
+			if (err)
+				warning("audio: mirror peer ptime (%m)\n",
+					err);
 		}
 	}
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -1066,13 +1066,15 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			.fmt        = tx->src_fmt
 		};
 
-		tx->ausrc_prm = prm;
-
 		sz = aufmt_sample_size(tx->src_fmt);
 
 		psize_alloc = sz * au_calc_nsamp(prm.srate, prm.ch, prm.ptime);
+
+		mtx_lock(tx->mtx);
+		tx->ausrc_prm = prm;
 		tx->psize = psize_alloc;
 		tx->aubuf_maxsz = tx->psize * 30;
+		mtx_unlock(tx->mtx);
 
 		if (!tx->aubuf) {
 			err = aubuf_alloc(&tx->aubuf, tx->psize,
@@ -1334,7 +1336,9 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 		}
 
 		tx->enc = mem_deref(tx->enc);
+		mtx_lock(tx->mtx);
 		tx->ac = ac;
+		mtx_unlock(tx->mtx);
 
 		if (!list_isempty(baresip_aufiltl())) {
 			err = aufilt_setup(a, baresip_aufiltl());

--- a/test/call.c
+++ b/test/call.c
@@ -1411,6 +1411,52 @@ int test_call_ptime_cap(void)
 }
 
 
+int test_call_l16_ptime(void)
+{
+	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
+	struct stream *strm;
+	uint32_t bytes, n;
+	int err;
+
+	err = module_load(".", "l16");
+	TEST_ERR(err);
+	err = module_load(".", "ausine");
+	TEST_ERR(err);
+
+	fixture_init_prm(f, ";audio_codecs=L16/48000/2");
+
+	cancel_rule_new(BEVENT_CALL_RTPESTAB, f->b.ua, 1, 0, 1);
+	cancel_rule_and(BEVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	f->estab_action = ACTION_NOTHING;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	/* 48kHz stereo caps the 20ms default at 7ms, i.e. 1344 bytes */
+	strm = audio_strm(call_audio(ua_call(f->a.ua)));
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * 1344, bytes);
+
+	strm = audio_strm(call_audio(ua_call(f->b.ua)));
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * 1344, bytes);
+
+ out:
+	fixture_close(f);
+	module_unload("ausine");
+	module_unload("l16");
+	return err;
+}
+
+
 static int test_100rel_audio_base(void)
 {
 	struct fixture fix, *f = &fix;

--- a/test/call.c
+++ b/test/call.c
@@ -1186,6 +1186,231 @@ int test_call_aulevel(void)
 }
 
 
+static void rx_metric_snapshot(const struct stream *strm,
+			       uint32_t *packets, uint32_t *bytes)
+{
+	do {
+		*packets = stream_metric_get_rx_n_packets(strm);
+		*bytes = stream_metric_get_rx_n_bytes(strm);
+	}
+	while (*packets != stream_metric_get_rx_n_packets(strm));
+}
+
+
+static int wait_for_audio_frames(struct fixture *f, unsigned n)
+{
+	struct cancel_rule *cr;
+	int err = 0;
+
+	cancel_rule_new(BEVENT_CUSTOM, f->a.ua, 0, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = f->a.n_auframe + n;
+	cancel_rule_and(BEVENT_CUSTOM, f->b.ua, 1, 0, 1);
+	cr->prm = "auframe";
+	cr->n_auframe = f->b.n_auframe + n;
+
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	if (!err)
+		err = f->err;
+	TEST_ERR(err);
+
+ out:
+	return err;
+}
+
+
+static int reinvite_from_b_expect_payload(struct fixture *f, uint32_t psize)
+{
+	struct agent *agents[] = {&f->a, &f->b};
+	struct stream *strmv[RE_ARRAY_SIZE(agents)];
+	struct cancel_rule *cr;
+	uint32_t packetv[2], bytesv[2];
+	size_t i;
+	int err = 0;
+
+	cancel_rule_new(BEVENT_CALL_REMOTE_SDP, f->a.ua, 0, 0, 1);
+	cr->prm = "offer";
+	cancel_rule_and(BEVENT_CALL_REMOTE_SDP, f->b.ua, 1, 0, 1);
+	cr->prm = "answer";
+
+	err = call_modify(ua_call(f->b.ua));
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	TEST_ERR(err);
+	TEST_ERR(f->err);
+
+	err = agent_wait_for_ack(&f->a, 0, 0, 1);
+	TEST_ERR(err);
+
+	/* drain packets that were already in flight during renegotiation */
+	err = wait_for_audio_frames(f, 10);
+	TEST_ERR(err);
+	for (i=0; i<RE_ARRAY_SIZE(agents); i++) {
+		strmv[i] = audio_strm(call_audio(ua_call(agents[i]->ua)));
+		rx_metric_snapshot(strmv[i], &packetv[i], &bytesv[i]);
+	}
+
+	err = wait_for_audio_frames(f, 10);
+	TEST_ERR(err);
+
+	for (i=0; i<RE_ARRAY_SIZE(agents); i++) {
+		uint32_t bytes, packets;
+
+		rx_metric_snapshot(strmv[i], &packets, &bytes);
+		ASSERT_TRUE(packets > packetv[i]);
+		ASSERT_EQ((packets - packetv[i]) * psize, bytes - bytesv[i]);
+	}
+
+ out:
+	return err;
+}
+
+
+static int test_call_ptime_cap_base(uint32_t aptime, uint32_t wire_ptime)
+{
+	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
+	struct stream *strm;
+	const char *attr;
+	uint32_t bytes, n;
+	size_t psize;
+	char prm[64];
+	int err;
+
+	re_snprintf(prm, sizeof(prm),
+		    ";ptime=%u;audio_codecs=aucmock/48000/2", aptime);
+	fixture_init_prm(f, prm);
+
+	psize = 4 * (48000 * wire_ptime / 1000);
+
+	cancel_rule_new(BEVENT_CALL_RTPESTAB, f->b.ua, 1, 0, 1);
+	cancel_rule_and(BEVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	f->estab_action = ACTION_NOTHING;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	strm = audio_strm(call_audio(ua_call(f->a.ua)));
+
+	/* the answer mirrors the raw request, not the effective cap */
+	attr = sdp_media_rattr(stream_sdpmedia(strm), "ptime");
+	ASSERT_TRUE(attr != NULL);
+	ASSERT_EQ(aptime, (uint32_t)atoi(attr));
+
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * psize, bytes);
+
+	strm = audio_strm(call_audio(ua_call(f->b.ua)));
+	rx_metric_snapshot(strm, &n, &bytes);
+	ASSERT_TRUE(n > 0);
+	ASSERT_EQ(n * psize, bytes);
+
+ out:
+	fixture_close(f);
+	return err;
+}
+
+
+static int test_call_ptime_cap_reinvite(void)
+{
+	struct fixture fix, *f = &fix;
+	struct cancel_rule *cr;
+	struct auplay *auplay = NULL;
+	struct sdp_format *pcmu;
+	struct sdp_media *m;
+	int err = 0;
+
+	fixture_init_prm(f, ";audio_codecs=aucmock/48000/2,PCMU/8000/1"
+			 ";audio_player=mock-auplay,a");
+	f->b.ua = mem_deref(f->b.ua);
+	err = ua_alloc(&f->b.ua, "B <sip:b@127.0.0.1>;regint=0"
+		       ";audio_codecs=aucmock/48000/2,PCMU/8000/1"
+		       ";audio_player=mock-auplay,b");
+	TEST_ERR(err);
+
+	err = mock_auplay_register(&auplay, baresip_auplayl(),
+				   auframe_handler, f);
+	TEST_ERR(err);
+
+	cancel_rule_new(BEVENT_CALL_RTPESTAB, f->b.ua, 1, 0, 1);
+	cancel_rule_and(BEVENT_CALL_RTPESTAB, f->a.ua, 0, 0, 1);
+
+	f->behaviour = BEHAVIOUR_ANSWER;
+	f->estab_action = ACTION_NOTHING;
+
+	err = ua_connect(f->a.ua, 0, NULL, f->buri, VIDMODE_OFF);
+	TEST_ERR(err);
+	err = re_main_timeout(5000);
+	cancel_rule_pop();
+	TEST_ERR(err);
+	TEST_ERR(fix.err);
+
+	m = stream_sdpmedia(audio_strm(call_audio(ua_call(f->b.ua))));
+
+	/* a smaller peer request must resize active packetization */
+	err = sdp_media_set_lattr(m, true, "ptime", "%u", 5);
+	TEST_ERR(err);
+	err = reinvite_from_b_expect_payload(f, 960);
+	TEST_ERR(err);
+
+	/* restoring the raw request leaves the codec cap in force */
+	err = sdp_media_set_lattr(m, true, "ptime", "%u", 20);
+	TEST_ERR(err);
+	err = reinvite_from_b_expect_payload(f, 1920);
+	TEST_ERR(err);
+
+	/* switching codecs alone must release the previous cap */
+	pcmu = sdp_media_format(m, true, NULL, -1, "PCMU", 8000, 1);
+	ASSERT_TRUE(pcmu != NULL);
+	list_unlink(&pcmu->le);
+	list_prepend((struct list *)sdp_media_format_lst(m, true),
+		     &pcmu->le, pcmu);
+
+	err = reinvite_from_b_expect_payload(f, 160);
+	TEST_ERR(err);
+
+	ASSERT_STREQ("PCMU",
+		     audio_codec(call_audio(ua_call(f->a.ua)), true)->name);
+
+ out:
+	fixture_close(f);
+	mem_deref(auplay);
+	return err;
+}
+
+
+int test_call_ptime_cap(void)
+{
+	int err;
+
+	mock_aucodec_register();
+
+	err = module_load(".", "ausine");
+	TEST_ERR(err);
+
+	err = test_call_ptime_cap_base(60, 10);
+	TEST_ERR(err);
+	err = test_call_ptime_cap_base(5, 5);
+	TEST_ERR(err);
+
+	err = test_call_ptime_cap_reinvite();
+	TEST_ERR(err);
+
+ out:
+	module_unload("ausine");
+	mock_aucodec_unregister();
+	return err;
+}
+
+
 static int test_100rel_audio_base(void)
 {
 	struct fixture fix, *f = &fix;

--- a/test/main.c
+++ b/test/main.c
@@ -30,6 +30,7 @@ static const struct test tests[] = {
 	TEST(test_call_answer_hangup_b),
 	TEST(test_call_aulevel),
 	TEST(test_call_ptime_cap),
+	TEST(test_call_l16_ptime),
 	TEST(test_call_custom_headers),
 	TEST(test_call_account_custom_headers),
 	TEST(test_call_dtmf),

--- a/test/main.c
+++ b/test/main.c
@@ -29,6 +29,7 @@ static const struct test tests[] = {
 	TEST(test_call_answer_hangup_a),
 	TEST(test_call_answer_hangup_b),
 	TEST(test_call_aulevel),
+	TEST(test_call_ptime_cap),
 	TEST(test_call_custom_headers),
 	TEST(test_call_account_custom_headers),
 	TEST(test_call_dtmf),

--- a/test/mock/mock_aucodec.c
+++ b/test/mock/mock_aucodec.c
@@ -76,6 +76,7 @@ static struct aucodec aucmock = {
 	.crate = 48000,
 	.ch    = 2,
 	.pch   = 2,
+	.ptime = 10,		/* cap exercised by test_call_ptime_cap */
 	.ench  = encode,
 	.dech  = decode,
 };

--- a/test/test.h
+++ b/test/test.h
@@ -202,6 +202,7 @@ int test_call_answer(void);
 int test_call_answer_hangup_a(void);
 int test_call_answer_hangup_b(void);
 int test_call_aulevel(void);
+int test_call_ptime_cap(void);
 int test_call_custom_headers(void);
 int test_call_account_custom_headers(void);
 int test_call_dtmf(void);

--- a/test/test.h
+++ b/test/test.h
@@ -203,6 +203,7 @@ int test_call_answer_hangup_a(void);
 int test_call_answer_hangup_b(void);
 int test_call_aulevel(void);
 int test_call_ptime_cap(void);
+int test_call_l16_ptime(void);
 int test_call_custom_headers(void);
 int test_call_account_custom_headers(void);
 int test_call_dtmf(void);


### PR DESCRIPTION
Based on the existing behavior change for core audio's pTime behavior to be cap.

This updates the codec table for L16 configuration to take advantage of the new behavior. 