### PR TITLE
jbuf: safer jbuf_set_id

### DIFF
--- a/include/baresip.h
+++ b/include/baresip.h
@@ -1612,7 +1612,7 @@ struct jbuf_stat {
 int jbuf_alloc(struct jbuf **jbp, uint32_t mind, uint32_t maxd,
 	       uint32_t maxsz);
 void jbuf_set_srate(struct jbuf *jb, uint32_t srate);
-void jbuf_set_id(struct jbuf *jb, struct pl *id);
+int  jbuf_set_id(struct jbuf *jb, const char *id);
 int  jbuf_set_type(struct jbuf *jb, enum jbuf_type jbtype);
 void jbuf_set_gnack(struct jbuf *jb, struct rtp_sock *rtp);
 int  jbuf_put(struct jbuf *jb, const struct rtp_header *hdr, void *mem);

--- a/src/jbuf.c
+++ b/src/jbuf.c
@@ -60,7 +60,7 @@ struct packet {
  * sequence number.
  */
 struct jbuf {
-	struct pl *id;       /**< Jitter buffer Identifier                   */
+	char *id;            /**< Jitter buffer Identifier                   */
 	struct rtp_sock *gnack_rtp; /**< Generic NACK RTP Socket             */
 	struct list pooll;   /**< List of free packets in pool               */
 	struct list packetl; /**< List of buffered packets                   */
@@ -266,14 +266,16 @@ void jbuf_set_srate(struct jbuf *jb, uint32_t srate)
  * @param jb  The jitter buffer.
  * @param id  Identifier.
  */
-void jbuf_set_id(struct jbuf *jb, struct pl *id)
+int jbuf_set_id(struct jbuf *jb, const char *id)
 {
 	if (!jb)
-		return;
+		return EINVAL;
 
+	int err;
 	mtx_lock(jb->lock);
-	jb->id = mem_ref(id);
+	err = str_dup(&jb->id, id);
 	mtx_unlock(jb->lock);
+	return err;
 }
 
 

--- a/src/jbuf.c
+++ b/src/jbuf.c
@@ -60,7 +60,7 @@ struct packet {
  * sequence number.
  */
 struct jbuf {
-	char *id;            /**< Jitter buffer Identifier                   */
+	struct pl *id;       /**< Jitter buffer Identifier                   */
 	struct rtp_sock *gnack_rtp; /**< Generic NACK RTP Socket             */
 	struct list pooll;   /**< List of free packets in pool               */
 	struct list packetl; /**< List of buffered packets                   */
@@ -271,11 +271,10 @@ int jbuf_set_id(struct jbuf *jb, const char *id)
 	if (!jb)
 		return EINVAL;
 
-	int err;
 	mtx_lock(jb->lock);
-	err = str_dup(&jb->id, id);
+	jb->id = pl_alloc_str(id);
 	mtx_unlock(jb->lock);
-	return err;
+	return jb->id ? 0 : ENOMEM;
 }
 
 

--- a/src/rtprecv.c
+++ b/src/rtprecv.c
@@ -802,12 +802,9 @@ int rtprecv_alloc(struct rtp_receiver **rxp,
 			goto out;
 	}
 
-	struct pl *id = pl_alloc_str(name);
-	if (!id)
+	err = jbuf_set_id(rx->jbuf, name);
+	if (err)
 		goto out;
-
-	jbuf_set_id(rx->jbuf, id);
-	mem_deref(id);
 
 	rx->metric = metric_alloc();
 	if (!rx->metric)


### PR DESCRIPTION
Increasing the reference counter of a struct pl that lies on the stack lead
to an illegal memory access.

```c
	char id[32];
	re_snprintf(id, sizeof(id), "mcreceiver-%d", prio);
	struct pl pl_id = PL_INIT;
	pl_set_str(&pl_id, id);
	jbuf_set_id(mcreceiver->jbuf, &pl_id);
```

Now the setter accepts a const char string
which is safer and simplifies also the application code

```c
	char id[32];
	re_snprintf(id, sizeof(id), "mcreceiver-%d", prio);
	err = jbuf_set_id(mcreceiver->jbuf, id);
	if (err)
		goto out;
```
