### PR TITLE
audio: serialize encoder configuration in audio_encoder_set

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -1314,13 +1314,12 @@ bool audio_started(const struct audio *a)
 int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 		      int pt_tx, const char *params)
 {
-	struct autx *tx;
 	int err = 0;
 
 	if (!a || !ac)
 		return EINVAL;
 
-	tx = &a->tx;
+	struct autx *tx = &a->tx;
 
 	if (ac != tx->ac) {
 		info("audio: Set audio encoder: %s %uHz %dch\n",
@@ -1333,8 +1332,19 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 			aubuf_flush(tx->aubuf);
 		}
 
+		mtx_lock(tx->mtx);
 		tx->enc = mem_deref(tx->enc);
 		tx->ac = ac;
+		if (ac->encupdh) {
+			struct auenc_param prm = { .bitrate = 0 };
+
+			err = ac->encupdh(&tx->enc, ac, &prm, params);
+		}
+		mtx_unlock(tx->mtx);
+		if (err) {
+			warning("audio: alloc encoder: %m\n", err);
+			return err;
+		}
 
 		if (!list_isempty(baresip_aufiltl())) {
 			err = aufilt_setup(a, baresip_aufiltl());
@@ -1342,13 +1352,12 @@ int audio_encoder_set(struct audio *a, const struct aucodec *ac,
 				return err;
 		}
 	}
+	else if (ac->encupdh) {
+		struct auenc_param prm = { .bitrate = 0 };
 
-	if (ac->encupdh) {
-		struct auenc_param prm;
-
-		prm.bitrate = 0;        /* auto */
-
+		mtx_lock(tx->mtx);
 		err = ac->encupdh(&tx->enc, ac, &prm, params);
+		mtx_unlock(tx->mtx);
 		if (err) {
 			warning("audio: alloc encoder: %m\n", err);
 			return err;


### PR DESCRIPTION
This code deals with a race that gets triggered by a mid-call codec switch.
After a mid-call codec switch, the TX thread keeps running while the main thread rewrites the fields it reads. The locks ensure this switch is safe.

During this codec switch, the following audio_start then re-enters the source-allocation block and writes psize, ausrc_prm, and aubuf_maxsz

Meanwhile tx_thread reads psize under the lock at src/audio.c:877, and poll_aubuf_tx reads psize and ausrc_prm under the lock at src/audio.c:427. 

Note: buils on this PR https://github.com/baresip/baresip/pull/3810 
