### PR TITLE
audio: thread-safe TX source parameters and aubuf_maxsz

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -530,6 +530,7 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 	enum aufmt fmt = tx->src_fmt;
 	bool muted = tx->muted;
 	size_t psize = tx->psize;
+	size_t aubuf_maxsz = tx->aubuf_maxsz;
 	mtx_unlock(tx->mtx);
 
 	if (fmt != af->fmt) {
@@ -543,7 +544,7 @@ static void ausrc_read_handler(struct auframe *af, void *arg)
 	if (muted)
 		auframe_mute(af);
 
-	if (aubuf_cur_size(tx->aubuf) >= tx->aubuf_maxsz) {
+	if (aubuf_cur_size(tx->aubuf) >= aubuf_maxsz) {
 
 		mtx_lock(tx->mtx);
 		uint64_t aubuf_overrun = ++tx->stats.aubuf_overrun;
@@ -1066,13 +1067,15 @@ static int start_source(struct autx *tx, struct audio *a, struct list *ausrcl)
 			.fmt        = tx->src_fmt
 		};
 
-		tx->ausrc_prm = prm;
-
 		sz = aufmt_sample_size(tx->src_fmt);
 
 		psize_alloc = sz * au_calc_nsamp(prm.srate, prm.ch, prm.ptime);
+
+		mtx_lock(tx->mtx);
+		tx->ausrc_prm = prm;
 		tx->psize = psize_alloc;
 		tx->aubuf_maxsz = tx->psize * 30;
+		mtx_unlock(tx->mtx);
 
 		if (!tx->aubuf) {
 			err = aubuf_alloc(&tx->aubuf, tx->psize,


### PR DESCRIPTION
Split from https://github.com/baresip/baresip/pull/3813

Adds concurrency guards to another set of parameters for later ptime calculations. 

tx->ausrc_prm, tx->psize, and tx->aubuf_maxsz with tx->mtx in start_source(), and snapshot tx->aubuf_maxsz under tx->mtx in ausrc_read_handler() to prevent data races and inconsistent buffer limits.